### PR TITLE
lite: remove .gitlint_local

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -81,12 +81,6 @@ jobs:
         if [[ $? -ne 0 ]]; then
           echo "$?" >&2
         fi
-        # Gitlint for repository specific rules
-        exec 2> gitlint_local_errors.txt
-        gitlint_output=$(gitlint --commits origin/${BASE_REF}.. --config .gitlint_local)
-        if [[ $? -ne 0 ]]; then
-          echo "$gitlint_output" >&2
-        fi
 
     - name: upload-results
       uses: actions/upload-artifact@v4
@@ -108,7 +102,7 @@ jobs:
     - name: check-warns
       working-directory: nrf-lite
       run: |
-        for file in Codeowners.txt Devicetree.txt Gitlint.txt Identity.txt Nits.txt pylint.txt gitlint_local_errors.txt
+        for file in Codeowners.txt Devicetree.txt Gitlint.txt Identity.txt Nits.txt pylint.txt
         do
           if [[ -s $file ]]; then
             errors=$(cat $file)

--- a/.gitlint_local
+++ b/.gitlint_local
@@ -1,6 +1,0 @@
-[body-match-regex]
-# Regex that the commit-msg body should contain. It points to the issue that prompted
-# the commit. The format of this inclusion should be "Ref: <project>-xxxx". This is
-# used to track changes to the codebase and have a reference to the origins of the
-# proposed changes. A workaround can be used by specifying "Ref: NONE".
-regex=(R|r)ef:( {0,4})((([A-Z0-9]*)(-?)(NONE|((N|n)one)))|(([A-Z0-9]+)-([0-9]+)))


### PR DESCRIPTION
Not all commits have a JIRA reference.
Rather than adding a special keyword to those that don't, simply add a reference where that's applicable.