### PR TITLE
west: blocklist modules that are not needed

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -20,7 +20,21 @@ manifest:
       remote: lemrey
       path: nrf
       revision: baremetal
-      import: true
+      import:
+        name-allowlist:
+          - cmsis
+          - dragoon
+          - hal_nordic
+          - lz4
+          - mbedtls
+          - mcuboot
+          - nrfxlib
+          - picolibc
+          - oberon-psa-crypto
+          - qcbor
+          - segger
+          - tinycrypt
+          - zephyr
 
   self:
     path: nrf-lite


### PR DESCRIPTION
The SDK-lite project requires only subset of libraries from the parent nRF Connect SDK. Removing not required libraries from the manifest allows for much faster initialization and updates of the repository.