### PR TITLE
workflows: add `do not merge` workflow

### DIFF
--- a/.github/workflows/dnm.yml
+++ b/.github/workflows/dnm.yml
@@ -1,0 +1,21 @@
+name: Do Not Merge
+
+on:
+  workflow_run:
+    workflows: ["Compliance"]
+    types:
+      - completed
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
+    name: Manual Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'DNM'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
Adds a workflow that prevents a PR from being merged if the DNM label is set.