### PR TITLE
GATT Queue Library porting

### DIFF
--- a/include/ble_gq.h
+++ b/include/ble_gq.h
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2018-2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *
+ * @defgroup ble_gq GATT Queue
+ * @{
+ * @brief  Queue for the BLE GATT requests.
+ *
+ * @details The BLE GATT Queue (BGQ) module can be used to queue BLE GATT requests if the
+ *          SoftDevice is not able to handle them at the moment. In this case, processing of
+ *          the queued request is postponed. Later on, when the corresponding BLE event indicates
+ *          that the SoftDevice may be free, the request is retried.
+ */
+
+#ifndef BLE_GQ_H__
+#define BLE_GQ_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <nrf_sdh_ble.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Macro for defining a BLE GATT queue instance with default parameters from Kconfig.
+ *
+ * @param _name Name of the instance.
+ */
+#define BLE_GQ_DEF(_name)                                                                          \
+	BLE_GQ_CUSTOM_DEF(_name, CONFIG_BLE_GQ_MAX_CONNECTIONS, CONFIG_BLE_GQ_HEAP_SIZE,           \
+			  (CONFIG_BLE_GQ_MAX_CONNECTIONS * CONFIG_BLE_GQ_QUEUE_SIZE))
+
+/**
+ * @brief Macro for defining a BLE GATT queue instance.
+ *
+ * @param _name            Name of the instance.
+ * @param _max_conns       Maximum number of connection handles that can be registered.
+ * @param _heap_size       Size of heap used for storing additional data for
+ *                         write, notify and indicate operations.
+ * @param _max_req_blocks  Maximum number of requests that can be held at any point in time.
+ */
+#define BLE_GQ_CUSTOM_DEF(_name, _max_conns, _heap_size, _max_req_blocks)                          \
+	static uint16_t CONCAT(_name, _conn_handles_arr)[] = {                                     \
+		LISTIFY(_max_conns, BLE_GQ_CONN_HANDLE_INIT, (,)),                                 \
+	};                                                                                         \
+	BUILD_ASSERT(ARRAY_SIZE(CONCAT(_name, _conn_handles_arr)) == (_max_conns));                \
+	static uint16_t CONCAT(_name, _purge_arr)[] = {                                            \
+		LISTIFY(_max_conns, BLE_GQ_PURGE_ARRAY_INIT, (,), (_max_conns)),                   \
+	};                                                                                         \
+	BUILD_ASSERT(ARRAY_SIZE(CONCAT(_name, _purge_arr)) == (_max_conns));                       \
+	static sys_slist_t CONCAT(_name, _req_queues)[] = {                                        \
+		LISTIFY(_max_conns, BLE_GQ_REQ_QUEUE_INIT, (,), _name),                            \
+	};                                                                                         \
+	BUILD_ASSERT(ARRAY_SIZE(CONCAT(_name, _req_queues)) == (_max_conns));                      \
+	K_MEM_SLAB_DEFINE_STATIC(_name##_req_blocks, sizeof(struct ble_gq_req), (_max_req_blocks), \
+				 sizeof(void *));                                                  \
+	static K_HEAP_DEFINE(_name##_heap, (_heap_size));                                          \
+	static const struct ble_gq _name = {                                                       \
+		.max_conns = (_max_conns),                                                         \
+		.conn_handles = CONCAT(_name, _conn_handles_arr),                                  \
+		.purge_list = CONCAT(_name, _purge_arr),                                           \
+		.req_queue = (sys_slist_t *)&CONCAT(_name, _req_queues),                           \
+		.req_blocks = &CONCAT(_name, _req_blocks),                                         \
+		.data_pool = &CONCAT(_name, _heap),                                                \
+	};                                                                                         \
+	NRF_SDH_BLE_OBSERVER(CONCAT(_name, _obs), ble_gq_on_ble_evt, (void *)&_name,               \
+			     CONFIG_BLE_GQ_OBSERVER_PRIO)
+
+/**
+ * @brief Helper macro for initializing connection handle array. Used in @ref BLE_GQ_CUSTOM_DEF.
+ */
+#define BLE_GQ_CONN_HANDLE_INIT(i, _) BLE_CONN_HANDLE_INVALID
+
+/**
+ * @brief Helper macro for initializing purge array. Used in @ref BLE_GQ_CUSTOM_DEF.
+ */
+#define BLE_GQ_PURGE_ARRAY_INIT(i, _max_conns) (_max_conns)
+
+/**
+ * @brief Helper macro for initializing request queues. Used in @ref BLE_GQ_CUSTOM_DEF.
+ */
+#define BLE_GQ_REQ_QUEUE_INIT(i, _name) SYS_SLIST_STATIC_INIT(&((_name)[i]))
+
+/**
+ * @brief BLE GATT request types.
+ */
+enum ble_gq_req_type {
+	/**
+	 * @brief GATTC Read Request. See @ref sd_ble_gattc_read.
+	 */
+	BLE_GQ_REQ_GATTC_READ,
+	/**
+	 * @brief GATTC Write Request. See @ref sd_ble_gattc_write.
+	 */
+	BLE_GQ_REQ_GATTC_WRITE,
+	/**
+	 * @brief GATTC Service Discovery Request. See @ref sd_ble_gattc_primary_services_discover.
+	 */
+	BLE_GQ_REQ_SRV_DISCOVERY,
+	/**
+	 * @brief GATTC Characteristic Discovery Request.
+	 *        See @ref sd_ble_gattc_characteristics_discover.
+	 */
+	BLE_GQ_REQ_CHAR_DISCOVERY,
+	/**
+	 * @brief GATTC Characteristic Descriptor Discovery Request.
+	 *        See @ref sd_ble_gattc_descriptors_discover.
+	 */
+	BLE_GQ_REQ_DESC_DISCOVERY,
+	/**
+	 * @brief GATTS Handle Value Notification or Indication. See @ref ble_gatts_hvx_params_t.
+	 */
+	BLE_GQ_REQ_GATTS_HVX,
+	/**
+	 * @brief Total number of different GATT Request types.
+	 */
+	BLE_GQ_REQ_NUM,
+};
+
+/**
+ * @brief Error handler type.
+ */
+typedef void (*ble_gq_req_error_cb_t)(uint16_t conn_handle, uint32_t nrf_error, void *context);
+
+/**
+ * @brief Structure used to handle SoftDevice error.
+ */
+struct ble_gq_req_error_handler {
+	/**
+	 * @brief Error handler to be called in case of an error from SoftDevice.
+	 */
+	ble_gq_req_error_cb_t cb;
+	/**
+	 * @brief Parameter passed to the error handler;
+	 */
+	void *ctx;
+};
+
+/**
+ * @brief Structure to hold a BLE GATT request.
+ */
+struct ble_gq_req {
+	/**
+	 * @brief Data for storing the request in a singly-linked list.
+	 */
+	sys_snode_t node;
+	/**
+	 * @brief Type of request.
+	 */
+	enum ble_gq_req_type type;
+	/**
+	 * @brief Extra payload data that cannot be contained in the request queue.
+	 *
+	 * Used internally by the GATT queue to manage additional memory allocations.
+	 */
+	uint8_t *data;
+	/**
+	 * @brief Error handler structure.
+	 */
+	struct ble_gq_req_error_handler error_handler;
+	/**
+	 * @brief Request type specific parameters.
+	 */
+	union {
+		/**
+		 * @brief GATTC read parameters.
+		 *        Type @ref BLE_GQ_REQ_GATTC_READ.
+		 */
+		struct {
+			uint16_t handle;
+			uint16_t offset;
+		} gattc_read;
+		/**
+		 * @brief GATTC write parameters.
+		 *        Type @ref BLE_GQ_REQ_GATTC_WRITE.
+		 */
+		ble_gattc_write_params_t gattc_write;
+		/**
+		 * @brief GATTC service discovery parameters.
+		 *        Type @ref BLE_GQ_REQ_SRV_DISCOVERY.
+		 */
+		struct {
+			uint16_t start_handle;
+			ble_uuid_t srvc_uuid;
+		} gattc_srv_disc;
+		/**
+		 * @brief GATTC characteristic discovery parameters.
+		 *        Type @ref NRF_BLE_GQ_REQ_CHAR_DISCOVERY.
+		 */
+		ble_gattc_handle_range_t gattc_char_disc;
+		/**
+		 * @brief GATTC characteristic descriptor discovery parameters.
+		 *        Type @ref NRF_BLE_GQ_REQ_DESC_DISCOVERY.
+		 */
+		ble_gattc_handle_range_t gattc_desc_disc;
+		/**
+		 * @brief GATTS handle value notification or indication parameters.
+		 *        Type @ref NRF_BLE_GQ_REQ_GATTS_HVX.
+		 */
+		ble_gatts_hvx_params_t gatts_hvx;
+	};
+};
+
+/**
+ * @brief BLE GATT Queue.
+ */
+struct ble_gq {
+	/**
+	 * @brief Maximum number of connection handles that can be registered.
+	 */
+	const uint16_t max_conns;
+	/**
+	 * @brief Pointer to array with registered connection handles.
+	 */
+	uint16_t *const conn_handles;
+	/**
+	 * @brief Pointer to array used to hold indices of request queues to purge.
+	 */
+	uint16_t *const purge_list;
+	/**
+	 * @brief Pointer to array of lists used to hold pending requests.
+	 */
+	sys_slist_t *const req_queue;
+	/**
+	 * @brief Pointer to memory slabs used to hold GATT requests.
+	 */
+	struct k_mem_slab *const req_blocks;
+	/**
+	 * @brief Heap for allocating memory for write, notification, and indication request values.
+	 */
+	struct k_heap *const data_pool;
+};
+
+/**
+ * @brief Add a GATT request to the GATT queue instance.
+ *
+ * @details This function adds a request to the BGQ instance and allocates necessary memory
+ *          for data that can be held within the request descriptor. If the SoftDevice is free,
+ *          this request will be processed immediately. Otherwise, the request remains in the
+ *          queue and is processed later.
+ *
+ * @param[in] gatt_queue   Pointer to the @ref ble_gq instance.
+ * @param[in] req          Pointer to the request.
+ * @param[in] conn_handle  Connection handle associated with the request.
+ *
+ * @retval 0        Request was added successfully.
+ * @retval -EFAULT  Any parameter was NULL.
+ * @retval -EINVAL  If @p conn_handle is not registered or type of request @p req is not valid.
+ * @retval -ENOMEM  There was no room in the queue or in the data pool.
+ */
+int ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req, uint16_t conn_handle);
+
+/**
+ * @brief Register connection handle in the GATT queue instance.
+ *
+ * @details This function is used for registering connection handle in the BGQ instance.
+ *          From this point, the BGQ instance can handle GATT requests associated with the
+ *          handle until connection is no longer valid (disconnect event occurs).
+ *
+ * @param[in] gatt_queue   Pointer to the @ref ble_gq instance.
+ * @param[in] conn_handle  Connection handle.
+ *
+ * @retval 0        Connection handle was successful registered.
+ * @retval -EFAULT  If @p gatt_queue was NULL.
+ * @retval -ENOMEM  No space for another connection handle.
+ */
+int ble_gq_conn_handle_register(const struct ble_gq *gatt_queue, uint16_t conn_handle);
+
+/**
+ * @brief Handle BLE events from the SoftDevice.
+ *
+ * @details This function handles the BLE events received from the SoftDevice. If a BLE
+ *          event is relevant to the BGQ module, it is used to update internal variables,
+ *          process queued GATT requests and, if necessary, send errors to the application.
+ *
+ * @param[in] ble_evt     Pointer to the BLE event.
+ * @param[in] gatt_queue  Pointer to the @ref ble_gq instance.
+ */
+void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *gatt_queue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLE_GQ_H__ */
+
+/** @} */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_subdirectory_ifdef(CONFIG_BLE_ADV ble_adv)
 add_subdirectory_ifdef(CONFIG_BLE_CONN_PARAMS ble_conn_params)
+add_subdirectory_ifdef(CONFIG_BLE_GATT_QUEUE ble_gq)
 add_subdirectory_ifdef(CONFIG_BLE_RACP ble_racp)
 add_subdirectory_ifdef(CONFIG_EVENT_SCHEDULER event_scheduler)
 add_subdirectory_ifdef(CONFIG_LITE_BUTTONS lite_buttons)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -7,6 +7,7 @@ menu "Libraries"
 
 rsource "ble_adv/Kconfig"
 rsource "ble_conn_params/Kconfig"
+rsource "ble_gq/Kconfig"
 rsource "ble_racp/Kconfig"
 rsource "event_scheduler/Kconfig"
 rsource "lite_buttons/Kconfig"

--- a/lib/ble_gq/CMakeLists.txt
+++ b/lib/ble_gq/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+zephyr_library()
+zephyr_library_sources(gatt_queue.c)

--- a/lib/ble_gq/Kconfig
+++ b/lib/ble_gq/Kconfig
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+menuconfig BLE_GATT_QUEUE
+	bool "BLE GATT Queue"
+
+if BLE_GATT_QUEUE
+
+config BLE_GQ_MAX_CONNECTIONS
+	int "Max simultaneous connections"
+	default 1
+	help
+	  Default value used for GATT queue instances defined using BLE_GQ_DEF.
+	  Sets the max number of connections that a default GATT queue instance can manage.
+
+config BLE_GQ_QUEUE_SIZE
+	int "Request queue size (per connection)"
+	default 8
+	help
+	  Default value used for GATT queue instances defined using BLE_GQ_DEF.
+	  Sets the max number of requests that can be queued for each connection that
+	  have been registered to a GATT queue instance with default configuration.
+
+config BLE_GQ_HEAP_SIZE
+	int "Datapool heap size (bytes)"
+	default 256
+	help
+	  Default value used for GATT queue instances defined using BLE_GQ_DEF. Sets the heap size
+	  for storing additional data that can be of variable size.
+
+config BLE_GQ_OBSERVER_PRIO
+	int "SoftDevice event observer priority"
+	default 0
+
+module=BLE_GQ
+module-dep=LOG
+module-str=BLE GATT Queue
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # BLE_GATT_QUEUE

--- a/lib/ble_gq/gatt_queue.c
+++ b/lib/ble_gq/gatt_queue.c
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2018-2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ble_gq.h>
+#include <nrf_sdh_ble.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(ble_gatt_queue, CONFIG_BLE_GQ_LOG_LEVEL);
+
+/* Function prototype for preparing a request for storage.
+ *
+ * Functions of this type should:
+ * 1. Allocate memory for additional request data.
+ * 2. Copy request to the storage buffer.
+ *
+ * data_pool  Memory pool for storing additional request data.
+ * req        Request to be stored.
+ * req_buf    Request storage buffer.
+ *
+ * Should return:
+ *   0        if successful.
+ *   -ENOMEM  if there are no room in the data pool for a new allocation.
+ */
+typedef int (*req_data_store_t)(struct k_heap *data_pool, const struct ble_gq_req *req,
+				struct ble_gq_req *req_buf);
+
+/* Prepare a GATTC write request for storage. */
+static int gattc_write_store(struct k_heap *data_pool, const struct ble_gq_req *req,
+			     struct ble_gq_req *req_buf)
+{
+	const ble_gattc_write_params_t *const gattc_write = &req->gattc_write;
+	uint8_t *data;
+
+	/* Allocate additional memory for GATTC write request data. */
+	data = k_heap_aligned_alloc(data_pool, sizeof(void *), gattc_write->len, K_NO_WAIT);
+	if (data == NULL) {
+		return -ENOMEM;
+	}
+
+	LOG_DBG("Allocated heap memory with addr: %#lx", (uintptr_t)data);
+
+	/* Copy relevant data to the allocated heap space. */
+	memcpy(data, (void *)gattc_write->p_value, gattc_write->len);
+
+	/* Copy request to storage. */
+	*req_buf = *req;
+
+	/* Update pointers to point onto allocated data. */
+	req_buf->data = data;
+	req_buf->gattc_write.p_value = data;
+
+	return 0;
+}
+
+/* Prepare a GATTS notification or indication request for storage. */
+static int gatts_hvx_store(struct k_heap *data_pool, const struct ble_gq_req *req,
+			   struct ble_gq_req *req_buf)
+{
+	const ble_gatts_hvx_params_t *const gatts_hvx = &req->gatts_hvx;
+	uint8_t *data;
+
+	/* Allocate additional memory for GATTS notification or indication request data. */
+	data = k_heap_aligned_alloc(data_pool, sizeof(void *), *gatts_hvx->p_len + sizeof(uint16_t),
+				    K_NO_WAIT);
+	if (data == NULL) {
+		return -ENOMEM;
+	}
+
+	LOG_DBG("Allocated heap memory with addr: %#lx", (uintptr_t)data);
+
+	/* Copy relevant data to the allocated heap space. */
+	memcpy(&data[0], (void *)gatts_hvx->p_len, sizeof(uint16_t));
+	memcpy(&data[sizeof(uint16_t)], (void *)gatts_hvx->p_data, *gatts_hvx->p_len);
+
+	/* Copy request to storage. */
+	*req_buf = *req;
+
+	/* Update pointers to point onto allocated data. */
+	req_buf->data = data;
+	req_buf->gatts_hvx.p_len = (uint16_t *)&data[0];
+	req_buf->gatts_hvx.p_data = &data[sizeof(uint16_t)];
+
+	return 0;
+}
+
+/* Array of memory store functions for different GATT request types. */
+static const req_data_store_t req_data_store[BLE_GQ_REQ_NUM] = {
+	[BLE_GQ_REQ_GATTC_READ] = NULL,
+	[BLE_GQ_REQ_GATTC_WRITE] = gattc_write_store,
+	[BLE_GQ_REQ_SRV_DISCOVERY] = NULL,
+	[BLE_GQ_REQ_CHAR_DISCOVERY] = NULL,
+	[BLE_GQ_REQ_DESC_DISCOVERY] = NULL,
+	[BLE_GQ_REQ_GATTS_HVX] = gatts_hvx_store,
+};
+
+static void request_error_handle(const struct ble_gq_req *req, uint16_t conn_handle, uint32_t err)
+{
+	if (err == NRF_SUCCESS) {
+		LOG_DBG("SD GATT procedure (%d) succeeded on connection handle: %d.", req->type,
+			conn_handle);
+	} else {
+		LOG_DBG("SD GATT procedure (%d) failed on connection handle %d with nrf_error %#x",
+			req->type, conn_handle, err);
+		if (req->error_handler.cb != NULL) {
+			req->error_handler.cb(conn_handle, err, req->error_handler.ctx);
+		}
+	}
+}
+
+/* Process a single GATT request. */
+static bool request_process(const struct ble_gq_req *req, uint16_t conn_handle)
+{
+	uint32_t err_code;
+	uint16_t len;
+
+	switch (req->type) {
+	case BLE_GQ_REQ_GATTC_READ:
+		LOG_DBG("GATTC read request");
+		err_code = sd_ble_gattc_read(conn_handle, req->gattc_read.handle,
+					     req->gattc_read.offset);
+		break;
+	case BLE_GQ_REQ_GATTC_WRITE:
+		LOG_DBG("GATTC write request");
+		err_code = sd_ble_gattc_write(conn_handle, &req->gattc_write);
+		break;
+	case BLE_GQ_REQ_SRV_DISCOVERY:
+		LOG_DBG("GATTC primary services discovery request");
+		err_code = sd_ble_gattc_primary_services_discover(conn_handle,
+								  req->gattc_srv_disc.start_handle,
+								  &req->gattc_srv_disc.srvc_uuid);
+		break;
+	case BLE_GQ_REQ_CHAR_DISCOVERY:
+		LOG_DBG("GATTC characteristics discovery request");
+		err_code = sd_ble_gattc_characteristics_discover(conn_handle,
+								 &req->gattc_char_disc);
+		break;
+	case BLE_GQ_REQ_DESC_DISCOVERY:
+		LOG_DBG("GATTC characteristic descriptors discovery request");
+		err_code = sd_ble_gattc_descriptors_discover(conn_handle, &req->gattc_desc_disc);
+		break;
+	case BLE_GQ_REQ_GATTS_HVX:
+		LOG_DBG("GATTS notification or indication");
+		len = *(req->gatts_hvx.p_len);
+		err_code = sd_ble_gatts_hvx(conn_handle, &req->gatts_hvx);
+		if (err_code == NRF_SUCCESS && len != *(req->gatts_hvx.p_len)) {
+			err_code = NRF_ERROR_DATA_SIZE;
+		}
+		break;
+	default:
+		err_code = NRF_ERROR_NOT_SUPPORTED;
+		LOG_WRN("Unimplemented GATT request with type: %d", req->type);
+		break;
+	}
+
+	if (err_code == NRF_ERROR_BUSY) {
+		LOG_DBG("SD is currently busy. The GATT procedure will be attempted again later.");
+
+		/* SoftDevice was busy. */
+		return false;
+	}
+
+	request_error_handle(req, conn_handle, err_code);
+
+	/* Request was accepted by SoftDevice. */
+	return true;
+}
+
+/* Process a request from the GATT queue instance. */
+static void queue_process(const struct ble_gq *gq, uint16_t conn_handle, uint16_t conn_id)
+{
+	sys_snode_t *elem;
+	struct ble_gq_req *req;
+
+	elem = sys_slist_peek_head(&gq->req_queue[conn_id]);
+	if (elem == NULL) {
+		/* Queue is empty */
+		return;
+	}
+
+	req = CONTAINER_OF(elem, struct ble_gq_req, node);
+
+	const bool req_processed = request_process(req, conn_handle);
+
+	if (!req_processed) {
+		return;
+	}
+
+	/* Peeking was successful above. Queue should have at least one element.
+	 * The first element is already known. Dequeue it.
+	 */
+	(void)sys_slist_get_not_empty(&gq->req_queue[conn_id]);
+
+	/* Clear any additional data associated with the request. */
+	if (req->type >= BLE_GQ_REQ_NUM || req_data_store[req->type] != NULL) {
+		LOG_DBG("Freeing heap memory with addr %#lx", (uintptr_t)req->data);
+		k_heap_free(gq->data_pool, req->data);
+	}
+
+	/* Release the memory block back to its associated memory slab. */
+	k_mem_slab_free(gq->req_blocks, req);
+}
+
+/* Clear all requests from the queue identified by the conn_id. */
+static void req_queue_clear(const struct ble_gq *gq, uint16_t conn_id)
+{
+	sys_snode_t *elem;
+	struct ble_gq_req *req;
+
+	while (true) {
+		elem = sys_slist_get(&gq->req_queue[conn_id]);
+		if (elem == NULL) {
+			/* Clearing of request queue is done. Request queue is empty. */
+			break;
+		}
+
+		/* Based on offset, get pointer to the structure containing the list element. */
+		req = CONTAINER_OF(elem, struct ble_gq_req, node);
+
+		/* Clear any additional data associated with the request. */
+		if (req_data_store[req->type] != NULL) {
+			LOG_DBG("Freeing heap memory with addr %#lx", (uintptr_t)req->data);
+			k_heap_free(gq->data_pool, req->data);
+		}
+
+		/* Release the memory block back to its associated memory slab. */
+		k_mem_slab_free(gq->req_blocks, req);
+	}
+}
+
+/* Clear all requests from all queues marked for purging. */
+static void req_queues_purge(const struct ble_gq *gq)
+{
+	uint16_t conn_id;
+
+	__ASSERT_NO_MSG(gq != NULL);
+
+	for (uint32_t i = 0; i < gq->max_conns; i++) {
+		conn_id = gq->purge_list[i];
+		if (conn_id >= gq->max_conns) {
+			continue;
+		}
+
+		LOG_DBG("Purging request queue with id: %d", conn_id);
+
+		req_queue_clear(gq, conn_id);
+		gq->purge_list[i] = gq->max_conns;
+	}
+}
+
+/* Mark request queue identified with conn_id for purging.
+ * All pending requests in marked queues will be freed when req_queues_purge is invoked.
+ */
+static void req_queue_purge_schedule(const struct ble_gq *gq, uint16_t conn_id)
+{
+	uint16_t idx;
+
+	for (idx = 0; idx < gq->max_conns; idx++) {
+		if (gq->purge_list[idx] >= gq->max_conns) {
+			gq->purge_list[idx] = conn_id;
+			break;
+		}
+	}
+
+	/* Assert if there was no space in array to schedule purge of a request queue. */
+	__ASSERT_NO_MSG(idx == gq->max_conns);
+}
+
+/* Find connection ID for the provided connection handle within the GATT queue instance registery.
+ *
+ * Returns the connection ID, or gq->max_conns if a connection ID matching the connection handle
+ * was not found.
+ */
+static uint16_t conn_handle_id_find(const struct ble_gq *gq, uint16_t conn_handle)
+{
+	for (uint16_t id = 0; id < gq->max_conns; id++) {
+		if (conn_handle == gq->conn_handles[id]) {
+			return id;
+		}
+	}
+
+	return gq->max_conns;
+}
+
+/* Register the provided connection handle within the GATT queue instance registery. */
+static int conn_handle_register(const struct ble_gq *gq, uint16_t conn_handle)
+{
+	uint16_t unused_id = gq->max_conns;
+
+	for (uint16_t id = 0; id < gq->max_conns; id++) {
+		if (gq->conn_handles[id] == conn_handle) {
+			return 0;
+		}
+		if (gq->conn_handles[id] == BLE_CONN_HANDLE_INVALID && unused_id == gq->max_conns) {
+			unused_id = id;
+		}
+	}
+
+	if (unused_id == gq->max_conns) {
+		return -ENOMEM;
+	}
+
+	gq->conn_handles[unused_id] = conn_handle;
+	return 0;
+}
+
+int ble_gq_item_add(const struct ble_gq *gq, struct ble_gq_req *req, uint16_t conn_handle)
+{
+	int err;
+	uint16_t conn_id;
+	struct ble_gq_req *buffered_req;
+
+	if (gq == NULL || req == NULL) {
+		return -EFAULT;
+	}
+
+	/* Purge queues that are no longer used by any connection. */
+	req_queues_purge(gq);
+
+	/* Check if connection handle is registered and if GATT request is valid. */
+	conn_id = conn_handle_id_find(gq, conn_handle);
+	if (req->type >= BLE_GQ_REQ_NUM || conn_id >= gq->max_conns) {
+		return -EINVAL;
+	}
+
+	/* Try processing a request without buffering. */
+	if (sys_slist_is_empty(&gq->req_queue[conn_id])) {
+		const bool req_processed = request_process(req, conn_handle);
+
+		if (req_processed) {
+			return 0;
+		}
+	}
+
+	/* Request must be buffered for later processing. */
+
+	/* Allocate memory for holding the request. */
+	__ASSERT_NO_MSG(gq->req_blocks != NULL);
+	err = k_mem_slab_alloc(gq->req_blocks, (void **)&buffered_req, K_NO_WAIT);
+	if (err) {
+		return err;
+	}
+
+	/* Allocate extra memory if required by the request type. */
+	if (req_data_store[req->type] != NULL) {
+		__ASSERT_NO_MSG(gq->data_pool != NULL);
+		err = req_data_store[req->type](gq->data_pool, req, buffered_req);
+		if (err) {
+			k_mem_slab_free(gq->req_blocks, buffered_req);
+			return err;
+		}
+	} else {
+		/* Copy request. No extra memory needed. */
+		*buffered_req = *req;
+	}
+
+	/* Queue request for later processing when SoftDevice is ready (not busy). */
+	sys_slist_append(&gq->req_queue[conn_id], &buffered_req->node);
+
+	/* Check if SoftDevice is still busy. */
+	queue_process(gq, conn_handle, conn_id);
+	return 0;
+}
+
+int ble_gq_conn_handle_register(const struct ble_gq *gq, uint16_t conn_handle)
+{
+	int err;
+
+	if (gq == NULL) {
+		return -EFAULT;
+	}
+
+	/* Purge the queues that are no longer used by any connection. */
+	req_queues_purge(gq);
+
+	/* Find a free spot in the connection handle registery and register the connection. */
+	err = conn_handle_register(gq, conn_handle);
+	if (err) {
+		LOG_DBG("Failed to register connection handle 0x%04x", conn_handle);
+		return err;
+	}
+
+	LOG_DBG("Registered connection handle 0x%04x", conn_handle);
+	return 0;
+}
+
+void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *gatt_queue)
+{
+	const struct ble_gq *const gq = (struct ble_gq *)gatt_queue;
+	uint16_t conn_handle;
+	uint16_t conn_id;
+
+	if (ble_evt == NULL || gq == NULL) {
+		return;
+	}
+
+	/* Obtain connection handle and filter out events that do not trigger queue processing. */
+	if (ble_evt->header.evt_id == BLE_GAP_EVT_DISCONNECTED) {
+		conn_handle = ble_evt->evt.gap_evt.conn_handle;
+	} else if (IN_RANGE(ble_evt->header.evt_id, BLE_GATTC_EVT_BASE, BLE_GATTC_EVT_LAST)) {
+		conn_handle = ble_evt->evt.gattc_evt.conn_handle;
+	} else if (IN_RANGE(ble_evt->header.evt_id, BLE_GATTS_EVT_BASE, BLE_GATTS_EVT_LAST)) {
+		conn_handle = ble_evt->evt.gatts_evt.conn_handle;
+	} else {
+		/* Irrelevant event for this module. Do nothing. */
+		return;
+	}
+
+	/* Check if connection handle is registered. */
+	conn_id = conn_handle_id_find(gq, conn_handle);
+	if (conn_id >= gq->max_conns) {
+		return;
+	}
+
+	/* Perform operation on the queue. */
+	if (ble_evt->header.evt_id == BLE_GAP_EVT_DISCONNECTED) {
+		/* Remove connection from GATT queue registry on a disconnect event. */
+		gq->conn_handles[conn_id] = BLE_CONN_HANDLE_INVALID;
+
+		/* Signal a purge of the request queue on a disconnect event. */
+		req_queue_purge_schedule(gq, conn_id);
+	} else {
+		/* Check if SoftDevice is still busy. */
+		queue_process(gq, conn_handle, conn_id);
+	}
+}


### PR DESCRIPTION
Add gatt queue library. The library is for queuing GATT
requests when the softdevice is busy handling another request.