### PR TITLE
workflows: build_samples: use twister

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -1,90 +1,66 @@
+# Copyright (c) 2025, Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build samples
 
-#  Controls when the workflow will run
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [push, opened, reopened, synchronize]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build_samples_job:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
     name: Build all samples within the project
+    runs-on: ubuntu-22.04
+    # Keep aligned with target NCS version
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.7.99
+    defaults:
+      run:
+        # Bash shell is needed to set toolchain related environment variables in docker container
+        # It is a workaround for GitHub Actions limitation https://github.com/actions/runner/issues/1964
+        shell: bash
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout the code
       uses: actions/checkout@v4
       with:
         path: nrf-lite
-        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
-    - name: cache-pip
-      uses: actions/cache@v4
+    - name: restore-cache-sdk
+      id: cache-sdk
+      uses: actions/cache/restore@v4
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-doc-pip
+        path: |
+          nrf-lite/nrf
+          nrf-lite/zephyr
+          nrf-lite/modules
+        key: ${{ runner.os }}-nrf-sdk
 
-    - name: Install python dependencies
-      working-directory: nrf-lite
+    - name: Prepare west project
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
-        pip3 install -U -r scripts/requirements-build.txt
-        pip3 show -f west
-        sudo apt install -y cmake ninja-build gperf ccache dfu-util device-tree-compiler xz-utils file make gcc gcc-multilib
-    - name: West init and update
-      env:
-        BASE_REF: ${{ github.base_ref }}
-      working-directory: nrf-lite
-      run: |
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
-        git remote -v
-        # Ensure there's no merge commits in the PR
-        #[[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
-        #(echo "::error ::Merge commits not allowed, rebase instead";false)
-        git rebase origin/${BASE_REF}
-        # debug
-        git log  --pretty=oneline | head -n 10
-        west init -l . || true
-        west config manifest.group-filter -- +ci,-optional
-        west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log
-
-    - name: Install Zephyr SDK
-      shell: sh
-      run: |
-        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/zephyr-sdk-0.17.0_linux-x86_64.tar.xz
-        wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/sha256.sum | shasum --check --ignore-missing
-        tar -xf zephyr-sdk-0.17.0_linux-x86_64.tar.xz
-        mv zephyr-sdk-0.17.0 zephyr-sdk
+        west init -l nrf-lite
+        west update -o=--depth=1 -n
 
     - name: Build samples
       working-directory: nrf-lite
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export PATH="$HOME/bin:$PATH"
-        export ZEPHYR_BASE="$(dirname "$(pwd)")/zephyr"
-        export ZEPHYR_TOOLCHAIN_VARIANT="zephyr"
-        export ZEPHYR_SDK_INSTALL_DIR="$(dirname "$(pwd)")/zephyr-sdk"
-
-        for sample in $(find samples -type f -name 'prj.conf' -exec dirname {} \;); do
-          echo "Building sample: $sample"
-          west build -b nrf52840dk/nrf52840 -s $sample -d build/$sample
-          if [ $? -ne 0 ]; then
-            echo "::error ::Build failed for sample: $sample"
-            exit 1
-          fi
-        done
+        west twister -T samples --build-only -v --inline-logs --integration
 
     - name: upload-results
       uses: actions/upload-artifact@v4
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:
         name: build-artifacts
-        path: nrf-lite/build/**
+        path: nrf-lite/twister-out/**
+
+    - name: save-cache-sdk
+      if: always() && steps.cache-sdk.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          nrf-lite/nrf
+          nrf-lite/zephyr
+          nrf-lite/modules
+        key: ${{ steps.cache-sdk.outputs.cache-primary-key }}


### PR DESCRIPTION
Updates the `build_samples` workflow to use
twister for building the samples.

Additional improvements:

* Use the NCS Docker container that comes with all pre-installed dependencies

* Remove unnecessary dependency installations

* Add caching for various NCS dependencies

* General cleanup

This update makes it seamless to transition towards supporting nRF54L by simply updating the `sample.yaml` configurations.