### PR TITLE
lib: lite_timer: modify rtc1/grtc priority when initializing timer

### DIFF
--- a/lib/lite_timer/Kconfig
+++ b/lib/lite_timer/Kconfig
@@ -12,6 +12,15 @@ menuconfig LITE_TIMER
 
 if LITE_TIMER
 
+config LITE_TIMER_IRQ_PRIO
+	int "Timer interrupt priority (NVIC level)"
+	range 0 8
+	default 5 if SOFTDEVICE
+	default 3
+	help
+	  Interrupt priority level must be greater than 4 (softdevice low priority)
+	  when softdevice is used.
+
 module=LITE_TIMER
 module-dep=LOG
 module-str=Lite Timer

--- a/samples/ble_hrs/nrf52840dk_nrf52840.overlay
+++ b/samples/ble_hrs/nrf52840dk_nrf52840.overlay
@@ -25,8 +25,3 @@
 		zephyr,sram = &sram0;
 	};
 };
-
-/* Lower the priority of the application RTC. Required when timeout handlers call softdevice svcs */
-&rtc1 {
-	interrupts = <0x11 3>;
-};


### PR DESCRIPTION
Instead of modifying devicetree when using softdevice, lower rtc1/grtc interrupt priority level when initializing a timer with `lite_timer_init(...)`. Do this only if `CONFIG_SOFTDEVICE` is set.

`RTC1_IRQn` is used on nRF52840 devices.

On nRF54L15 there are four interrupt numbers (and handlers) associated with `GRTC`.
`GRTC_1_IRQn` is used on nRF54L15 devices if `NRF_TRUSTZONE_NONSECURE` is defined.
`GRTC_2_IRQn` is used  when `NRF_TRUSTZONE_NONSECURE` is not defined.
`nrf_grtc.h` defines `GRTC_IRQn` to either `GRTC_1_IRQn` or `GRTC_2_IRQn` depending on `NRF_TRUSTZONE_NONSECURE`.
Softdevice uses `GRTC_3_IRQn`.
`nrf_grtc.h` defines `GRTC_IRQn` to use `GRTC_0_IRQn` for FLPR.