### PR TITLE
ci: use runs-on.com

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,1 @@
+_extends: runs-on-cfg

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   build_samples_job:
     name: Build all samples within the project
-    runs-on: ubuntu-22.04
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=4cpu-linux-x64
     # Keep aligned with target NCS version
     container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.7.99
     defaults:


### PR DESCRIPTION
Use runs-on.com for running build job. See runs-on.com for full documentation.