### PR TITLE
workflows: build_samples: upload builds on dispatch only

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -50,12 +50,22 @@ jobs:
       run: |
         west twister -T samples --build-only -v --inline-logs --integration
 
-    - name: upload-results
+    - name: upload-logs
       uses: actions/upload-artifact@v4
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:
+        name: build-logs
+        path: nrf-lite/twister-out/**/*.log
+        retention-days: 5
+
+    - name: upload-artifacts-dispatch
+      uses: actions/upload-artifact@v4
+      if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true &&
+          github.event_name == 'workflow_dispatch'
+      with:
         name: build-artifacts
         path: nrf-lite/twister-out/**
+        retention-days: 5
 
     - name: save-cache-sdk
       if: always() && steps.cache-sdk.outputs.cache-hit != 'true'


### PR DESCRIPTION
Upload artifacts only on `workflow_dispatch` and add a limitation on the retention days.
This limits the consumption of GitHub resources in personal forks due to the size of the generated
artifacts (~200MB at the time of this commit).
By default upload only logs.

Originally it was not a problem due to the low number of firmware images built, but with the addition of nRF54L we are building everything twice, plus some custom variants for the buttons and timer samples.