### PR TITLE
softdevice: let the NVIC state be part of the SoftDevice component

### DIFF
--- a/subsys/softdevice/CMakeLists.txt
+++ b/subsys/softdevice/CMakeLists.txt
@@ -11,4 +11,5 @@ if (CONFIG_SOFTDEVICE_S115)
   zephyr_include_directories(${NRF_LITE_DIR}/include/s115/)
 endif()
 
+zephyr_sources(nvic.c)
 zephyr_sources(tables.c)

--- a/subsys/softdevice/nvic.c
+++ b/subsys/softdevice/nvic.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf_nvic.h>
+
+/* Global NVIC state instance, required by nrf_nvic.h */
+nrf_nvic_state_t nrf_nvic_state;

--- a/subsys/softdevice_handler/nrf_sdh.c
+++ b/subsys/softdevice_handler/nrf_sdh.c
@@ -20,9 +20,6 @@ LOG_MODULE_REGISTER(nrf_sdh, CONFIG_NRF_SDH_LOG_LEVEL);
 #warning Please select NRF_CLOCK_LF_ACCURACY_500_PPM when using NRF_CLOCK_LF_SRC_RC
 #endif
 
-/* Global NVIC state instance, required by nrf_nvic.h */
-nrf_nvic_state_t nrf_nvic_state;
-
 static atomic_t sdh_enabled;	/* Whether the SoftDevice is enabled. */
 static atomic_t sdh_suspended;	/* Whether this module is suspended. */
 static atomic_t sdh_transition; /* Whether enable/disable process was started. */


### PR DESCRIPTION
Let the global NVIC state be part of the SoftDevice component (`CONFIG_SOFTDEVICE`) instead of the SoftDevice handler (`CONFIG_NRF_SDH`). This is more correct, as it is possible to use `nrf_nvic.h` without the SoftDevice handler. It may also be helpful in tests or to swich more cleanly on `CONFIG_SOFTDEVICE` instead of `CONFIG_NRF_SDH` when using NVIC functions.