### PR TITLE
samples: buttons: correct button index

### DIFF
--- a/samples/buttons/src/main.c
+++ b/samples/buttons/src/main.c
@@ -84,7 +84,7 @@ int main(void)
 		return err;
 	}
 
-	LOG_INF("Buttons initialized, press button 4 to terminate");
+	LOG_INF("Buttons initialized, press button 3 to terminate");
 
 	while (running) {
 		/* Sleep */


### PR DESCRIPTION
Buttons on the nRF54L15DK is labeled 0 to 3 instead of 1 to 4. Correct log output to use button 3 to exit the application.