### PR TITLE
softdevice_handler: Set ble gap adv count to default

### DIFF
--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -58,6 +58,7 @@ static int default_cfg_set(void)
 #if CONFIG_SOFTDEVICE_PERIPHERAL
 		ble_cfg.gap_cfg.role_count_cfg.periph_role_count =
 			CONFIG_NRF_SDH_BLE_PERIPHERAL_LINK_COUNT;
+		ble_cfg.gap_cfg.role_count_cfg.adv_set_count = BLE_GAP_ADV_SET_COUNT_DEFAULT;
 #endif
 
 #if CONFIG_SOFTDEVICE_CENTRAL


### PR DESCRIPTION
Set BLE_GAP_ADV_SET_COUNT_DEFAULT instead of 0. This is needed for newer version of the softdevice.