### PR TITLE
softdevice: Add release note and migration document pdfs

### DIFF
--- a/subsys/softdevice/hex/s115/s115_9.0.0-1.prototype_migration-document.pdf
+++ b/subsys/softdevice/hex/s115/s115_9.0.0-1.prototype_migration-document.pdf
@@ -1,0 +1,3437 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R /F6 40 0 R 
+  /F7 42 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 89 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 57.02362 705.0236 0 ] /Rect [ 57.02362 724.8236 237.4361 735.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 57.02362 705.0236 0 ] /Rect [ 533.526 725.4611 538.252 735.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 77.02362 708.6236 153.0986 718.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 7 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 533.526 709.2611 538.252 719.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 692.4236 148.6706 702.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 693.0611 538.252 703.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 702.0236 0 ] /Rect [ 77.02362 676.2236 146.0011 686.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 702.0236 0 ] /Rect [ 533.526 676.8611 538.252 687.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 77.02362 660.0236 141.2666 670.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 39 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 533.526 660.6611 538.252 670.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 41 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 643.8236 125.0661 654.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 41 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 644.4611 538.252 654.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 41 0 R /XYZ 57.02362 690.0236 0 ] /Rect [ 77.02362 627.6236 141.2666 637.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+21 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 41 0 R /XYZ 57.02362 690.0236 0 ] /Rect [ 533.526 628.2611 538.252 638.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+22 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 611.4236 125.0661 621.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+23 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 612.0611 538.252 622.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+24 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 690.0236 0 ] /Rect [ 77.02362 595.2236 146.0011 605.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+25 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 690.0236 0 ] /Rect [ 533.526 595.8611 538.252 606.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+26 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 564.0236 0 ] /Rect [ 77.02362 579.0236 141.2666 589.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+27 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 43 0 R /XYZ 57.02362 564.0236 0 ] /Rect [ 533.526 579.6611 538.252 589.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+28 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 45 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 562.8236 125.0661 573.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+29 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 45 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 563.4611 538.252 573.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+30 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 45 0 R /XYZ 57.02362 678.0236 0 ] /Rect [ 77.02362 546.6236 141.2666 556.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+31 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 45 0 R /XYZ 57.02362 678.0236 0 ] /Rect [ 533.526 547.2611 538.252 557.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+32 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 530.4236 125.0661 540.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+33 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 531.0611 538.252 541.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+34 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 77.02362 514.2236 141.2666 524.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+35 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 533.526 514.8611 538.252 525.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+36 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 349.2236 0 ] /Rect [ 77.02362 498.0236 146.0011 508.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+37 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 47 0 R /XYZ 57.02362 349.2236 0 ] /Rect [ 533.526 498.6611 538.252 508.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+38 0 obj
+<<
+/Annots [ 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 
+  18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 
+  28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R ] /Contents 90 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+39 0 obj
+<<
+/Contents 91 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+40 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+41 0 obj
+<<
+/Contents 92 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+42 0 obj
+<<
+/BaseFont /Courier-Oblique /Encoding /WinAnsiEncoding /Name /F7 /Subtype /Type1 /Type /Font
+>>
+endobj
+43 0 obj
+<<
+/Contents 93 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+44 0 obj
+<<
+/Contents 94 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+45 0 obj
+<<
+/Contents 95 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+46 0 obj
+<<
+/Contents 96 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+47 0 obj
+<<
+/Contents 97 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+48 0 obj
+<<
+/Contents 98 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+49 0 obj
+<<
+/Contents 99 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+50 0 obj
+<<
+/Contents 100 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+51 0 obj
+<<
+/Contents 101 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 88 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+52 0 obj
+<<
+/Outlines 54 0 R /PageLabels 102 0 R /PageMode /UseNone /Pages 88 0 R /Type /Catalog
+>>
+endobj
+53 0 obj
+<<
+/Author () /CreationDate (D:20250325153827-01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250325153827-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (s115 migration document) /Trapped /False
+>>
+endobj
+54 0 obj
+<<
+/Count 27 /First 55 0 R /Last 75 0 R /Type /Outlines
+>>
+endobj
+55 0 obj
+<<
+/Count 1 /Dest [ 7 0 R /XYZ 57.02362 705.0236 0 ] /First 56 0 R /Last 56 0 R /Next 57 0 R /Parent 54 0 R 
+  /Title (Introduction to the s115 migration document)
+>>
+endobj
+56 0 obj
+<<
+/Dest [ 7 0 R /XYZ 57.02362 672.0236 0 ] /Parent 55 0 R /Title (About the document)
+>>
+endobj
+57 0 obj
+<<
+/Count 2 /Dest [ 39 0 R /XYZ 57.02362 765.0236 0 ] /First 58 0 R /Last 59 0 R /Next 60 0 R /Parent 54 0 R 
+  /Prev 55 0 R /Title (s115_9.0.0-1.prototype)
+>>
+endobj
+58 0 obj
+<<
+/Dest [ 39 0 R /XYZ 57.02362 702.0236 0 ] /Next 59 0 R /Parent 57 0 R /Title (Required changes)
+>>
+endobj
+59 0 obj
+<<
+/Dest [ 39 0 R /XYZ 57.02362 672.0236 0 ] /Parent 57 0 R /Prev 58 0 R /Title (New functionality)
+>>
+endobj
+60 0 obj
+<<
+/Count 1 /Dest [ 41 0 R /XYZ 57.02362 765.0236 0 ] /First 61 0 R /Last 61 0 R /Next 63 0 R /Parent 54 0 R 
+  /Prev 57 0 R /Title (s112_nrf52_7.2.0)
+>>
+endobj
+61 0 obj
+<<
+/Count -1 /Dest [ 41 0 R /XYZ 57.02362 690.0236 0 ] /First 62 0 R /Last 62 0 R /Parent 60 0 R /Title (New functionality)
+>>
+endobj
+62 0 obj
+<<
+/Dest [ 41 0 R /XYZ 57.02362 660.0236 0 ] /Parent 61 0 R /Title (Efficient discovery of 128-bit UUIDs)
+>>
+endobj
+63 0 obj
+<<
+/Count 2 /Dest [ 43 0 R /XYZ 57.02362 765.0236 0 ] /First 64 0 R /Last 65 0 R /Next 68 0 R /Parent 54 0 R 
+  /Prev 60 0 R /Title (s112_nrf52_7.0.1)
+>>
+endobj
+64 0 obj
+<<
+/Dest [ 43 0 R /XYZ 57.02362 690.0236 0 ] /Next 65 0 R /Parent 63 0 R /Title (Required changes)
+>>
+endobj
+65 0 obj
+<<
+/Count -2 /Dest [ 43 0 R /XYZ 57.02362 564.0236 0 ] /First 66 0 R /Last 67 0 R /Parent 63 0 R /Prev 64 0 R 
+  /Title (New functionality)
+>>
+endobj
+66 0 obj
+<<
+/Dest [ 43 0 R /XYZ 57.02362 534.0236 0 ] /Next 67 0 R /Parent 65 0 R /Title (Configurable inclusion of Central Address Resolution \(CAR\) characteristic and Peripheral Preferred Connection Parameters \(PPCP\))
+>>
+endobj
+67 0 obj
+<<
+/Dest [ 44 0 R /XYZ 57.02362 765.0236 0 ] /Parent 65 0 R /Prev 66 0 R /Title (Other additions to the API)
+>>
+endobj
+68 0 obj
+<<
+/Count 1 /Dest [ 45 0 R /XYZ 57.02362 765.0236 0 ] /First 69 0 R /Last 69 0 R /Next 75 0 R /Parent 54 0 R 
+  /Prev 63 0 R /Title (s112_nrf52_6.1.0)
+>>
+endobj
+69 0 obj
+<<
+/Count -5 /Dest [ 45 0 R /XYZ 57.02362 678.0236 0 ] /First 70 0 R /Last 74 0 R /Parent 68 0 R /Title (New functionality)
+>>
+endobj
+70 0 obj
+<<
+/Dest [ 45 0 R /XYZ 57.02362 648.0236 0 ] /Next 71 0 R /Parent 69 0 R /Title (API for removing a Vendor Specific base UUID)
+>>
+endobj
+71 0 obj
+<<
+/Dest [ 45 0 R /XYZ 57.02362 543.0236 0 ] /Next 72 0 R /Parent 69 0 R /Prev 70 0 R /Title (API to enable or disable extended RC calibration)
+>>
+endobj
+72 0 obj
+<<
+/Dest [ 45 0 R /XYZ 57.02362 396.0236 0 ] /Next 73 0 R /Parent 69 0 R /Prev 71 0 R /Title (API to get the advertiser Bluetooth device address)
+>>
+endobj
+73 0 obj
+<<
+/Dest [ 45 0 R /XYZ 57.02362 261.0236 0 ] /Next 74 0 R /Parent 69 0 R /Prev 72 0 R /Title (Hardware resource usage API)
+>>
+endobj
+74 0 obj
+<<
+/Dest [ 46 0 R /XYZ 57.02362 671.0236 0 ] /Parent 69 0 R /Prev 73 0 R /Title (Other additions to the API)
+>>
+endobj
+75 0 obj
+<<
+/Count 2 /Dest [ 47 0 R /XYZ 57.02362 765.0236 0 ] /First 76 0 R /Last 79 0 R /Parent 54 0 R /Prev 68 0 R 
+  /Title (s112_nrf52_6.0.0)
+>>
+endobj
+76 0 obj
+<<
+/Count -2 /Dest [ 47 0 R /XYZ 57.02362 620.0236 0 ] /First 77 0 R /Last 78 0 R /Next 79 0 R /Parent 75 0 R 
+  /Title (New functionality)
+>>
+endobj
+77 0 obj
+<<
+/Dest [ 47 0 R /XYZ 57.02362 590.0236 0 ] /Next 78 0 R /Parent 76 0 R /Title (Write to SoftDevice protected registers)
+>>
+endobj
+78 0 obj
+<<
+/Dest [ 47 0 R /XYZ 57.02362 479.0236 0 ] /Parent 76 0 R /Prev 77 0 R /Title (Usage)
+>>
+endobj
+79 0 obj
+<<
+/Count -7 /Dest [ 47 0 R /XYZ 57.02362 349.2236 0 ] /First 80 0 R /Last 87 0 R /Parent 75 0 R /Prev 76 0 R 
+  /Title (Required changes)
+>>
+endobj
+80 0 obj
+<<
+/Dest [ 47 0 R /XYZ 57.02362 319.2236 0 ] /Next 81 0 R /Parent 79 0 R /Title (Updated advertiser API)
+>>
+endobj
+81 0 obj
+<<
+/Dest [ 47 0 R /XYZ 57.02362 152.2236 0 ] /Next 82 0 R /Parent 79 0 R /Prev 80 0 R /Title (Configuring and updating an advertising set)
+>>
+endobj
+82 0 obj
+<<
+/Dest [ 48 0 R /XYZ 57.02362 711.0236 0 ] /Next 83 0 R /Parent 79 0 R /Prev 81 0 R /Title (Configuring advertising parameters for an advertising set)
+>>
+endobj
+83 0 obj
+<<
+/Count -1 /Dest [ 49 0 R /XYZ 57.02362 543.0236 0 ] /First 84 0 R /Last 84 0 R /Next 85 0 R /Parent 79 0 R 
+  /Prev 82 0 R /Title (Other Advertising API changes)
+>>
+endobj
+84 0 obj
+<<
+/Dest [ 50 0 R /XYZ 57.02362 765.0236 0 ] /Parent 83 0 R /Title (Usage)
+>>
+endobj
+85 0 obj
+<<
+/Dest [ 50 0 R /XYZ 57.02362 209.8236 0 ] /Next 86 0 R /Parent 79 0 R /Prev 83 0 R /Title (Updated RSSI API)
+>>
+endobj
+86 0 obj
+<<
+/Dest [ 51 0 R /XYZ 57.02362 701.0236 0 ] /Next 87 0 R /Parent 79 0 R /Prev 85 0 R /Title (TX power API)
+>>
+endobj
+87 0 obj
+<<
+/Dest [ 51 0 R /XYZ 57.02362 622.0236 0 ] /Parent 79 0 R /Prev 86 0 R /Title (Updated Flash API)
+>>
+endobj
+88 0 obj
+<<
+/Count 13 /Kids [ 7 0 R 38 0 R 39 0 R 41 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 
+  49 0 R 50 0 R 51 0 R ] /Type /Pages
+>>
+endobj
+89 0 obj
+<<
+/Length 2973
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 741.0236 cm
+q
+.133333 .133333 .133333 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL (s115 migration document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Introduction to the s115 migration document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (About the document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 624.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This document describes how to migrate to new versions of the s115 SoftDevice. The s115 release notes) Tj T* (should be read in conjunction with this document.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 606.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (For each version, we have the following sections:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 600.0236 cm
+Q
+q
+1 0 0 1 57.02362 600.0236 cm
+Q
+q
+1 0 0 1 57.02362 576.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL ("Required changes" describes the changes that need to be done in the application when migrating from) Tj T* (an older version of the SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 570.0236 cm
+Q
+q
+1 0 0 1 57.02362 534.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg ("New functionality" describes how to use new features and functionality offered by this version of the) Tj T* (SoftDevice. ) Tj /F4 10 Tf (Note) Tj /F1 10 Tf ( : Not all new functionality may be covered; the release notes will contain a full list of) Tj T* (new features and functionality.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 530.0236 cm
+Q
+q
+1 0 0 1 57.02362 476.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (Each section describes how to migrate to a given version from the previous version. If you are migrating to) Tj T* (the current version from the previous version, follow the instructions in that section. To migrate between) Tj T* (versions that are more than one version apart, follow the migration steps for all intermediate versions in) Tj T* (order.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 446.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F4 10 Tf 0 0 0 rg (Example) Tj /F1 10 Tf (: To migrate from version 5.0.0 to version 5.2.0, first follow the instructions to migrate to 5.1.0 from) Tj T* (5.0.0, then follow the instructions to migrate to 5.2.0 from 5.1.0.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 428.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Copyright \251 Nordic Semiconductor ASA. All rights reserved.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 428.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 1) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+90 0 obj
+<<
+/Length 3824
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Contents) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 495.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 229.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (Introduction to the s115 migration document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 229.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (1) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 213.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (About the document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 213.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (1) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 197.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s115_9.0.0-1.prototype) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 197.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (3) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 181.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 181.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (3) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 165 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 165 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (3) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 148.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.2.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 148.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (4) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 132.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 132.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (4) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 116.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.0.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 116.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 100.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 100.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 84 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 84 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 67.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_6.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 67.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (7) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 51.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 51.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (7) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 35.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_6.0.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 35.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 19.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 19.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 3 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 495.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 2) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+91 0 obj
+<<
+/Length 800
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s115_9.0.0-1.prototype) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This section describes how to use the new features of s115_9.0.0-1.prototype when migrating from) Tj T* (s115_7.2.0.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 3) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+92 0 obj
+<<
+/Length 2113
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.2.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (This section describes how to use the new features of s112_nrf52_7.2.0 when migrating from) Tj T* (s112_nrf52_7.0.1. As with all minor releases, the s112_nrf52_7.2.0 is binary compatible with) Tj T* (s112_nrf52_7.0.1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 645.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Efficient discovery of 128-bit UUIDs) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 615.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (By default, any discovered 128-bit UUIDs that are not present in the Vendor Specific UUID table, will have) Tj T* (the ) Tj /F3 10 Tf (ble_uuid_t::type) Tj /F1 10 Tf ( set to ) Tj /F3 10 Tf (BLE_UUID_TYPE_UNKNOWN) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 585.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To change this default behavior and enable the automatic insertion of discovered 128-bit UUIDs to the) Tj T* (Vendor Specific UUID table, the following option can be used:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 543.4236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 480.0283 32.4 re S
+Q
+q
+BT 1 0 0 1 0 11.9 Tm 10.2 TL /F3 8.5 Tf 0 0 0 rg (sd_ble_opt_set) Tj (\() Tj (BLE_GATTC_OPT_UUID_DISC) Tj (,) Tj .733333 .733333 .733333 rg  T* (              ) Tj 0 0 0 rg (&) Tj (\() Tj (ble_opt_t) Tj (\){.) Tj (gattc_opt) Tj (.) Tj (uuid_disc) Tj (.) Tj (auto_add_vs_enable) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 0 .866667 rg (1) Tj /F3 8.5 Tf 0 0 0 rg (}\);) Tj .733333 .733333 .733333 rg  T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 535.4236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 4) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+93 0 obj
+<<
+/Length 7511
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.0.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (This section describes how to use the new features of s112_nrf52_7.0.1 when migrating from) Tj T* (s112_nrf52_6.1.1. The s112_nrf52_7.0.1 has changed the \(Application Programming Interface\) API) Tj T* (compared to s112_nrf52_6.1.1 which requires applications to be recompiled.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The application can no longer use the option ) Tj /F3 10 Tf 1 0 0 rg (BLE_COMMON_OPT_ADV_SCHED_CFG) Tj /F1 10 Tf 0 0 0 rg (. The advertiser will) Tj T* (always use improved scheduling. This was previously defined as ) Tj /F3 10 Tf 1 0 0 rg (ADV_SCHED_CFG_IMPROVED) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 576.0236 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macros ) Tj /F3 10 Tf 1 0 0 rg (NRF_SOC_APP_PPI_CHANNELS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg (,) Tj T* /F3 10 Tf 1 0 0 rg (NRF_SOC_APP_PPI_CHANNELS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg (, ) Tj /F3 10 Tf 1 0 0 rg (NRF_SOC_APP_PPI_GROUPS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg (,) Tj T* (and ) Tj /F3 10 Tf 1 0 0 rg (NRF_SOC_APP_PPI_GROUPS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( are removed. The application can use the macros) Tj T* /F3 10 Tf 1 0 0 rg (NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( and ) Tj /F3 10 Tf 1 0 0 rg (NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( to) Tj T* (deduce the PPI channels and groups available to the application.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 546.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 504.0236 cm
+q
+BT 1 0 0 1 0 17.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Configurable inclusion of Central Address Resolution \(CAR\) characteristic and) Tj T* (Peripheral Preferred Connection Parameters \(PPCP\)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 486.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (API Updates) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 480.0236 cm
+Q
+q
+1 0 0 1 57.02362 480.0236 cm
+Q
+q
+1 0 0 1 57.02362 456.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (BLE_GAP_CFG_CAR_INCL_CONFIG) Tj /F1 10 Tf 0 0 0 rg (: This allows the application to include or exclude the CAR) Tj T* (characteristic from the GAP Service.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 450.0236 cm
+Q
+q
+1 0 0 1 57.02362 426.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (BLE_GAP_CFG_PPCP_INCL_CONFIG) Tj /F1 10 Tf 0 0 0 rg (: This allows the application to include or exclude the PPCP) Tj T* (characteristic from the GAP Service.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 422.0236 cm
+Q
+q
+1 0 0 1 57.02362 404.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (For the above inclusion configuration APIs, the application can use:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 398.0236 cm
+Q
+q
+1 0 0 1 57.02362 398.0236 cm
+Q
+q
+1 0 0 1 57.02362 386.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (BLE_GAP_CHAR_INCL_CONFIG_INCLUDE) Tj /F1 10 Tf 0 0 0 rg (: The characteristic is included.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+Q
+q
+1 0 0 1 57.02362 356.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITH_SPACE) Tj /F1 10 Tf 0 0 0 rg (: The characteristic is excluded, but the) Tj T* (SoftDevice will reserve the attribute handles which are otherwise used for this characteristic.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITHOUT_SPACE) Tj /F1 10 Tf 0 0 0 rg (: The characteristic is excluded.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 334.0236 cm
+Q
+q
+1 0 0 1 57.02362 316.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (Usage) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 286.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The code snippet below illustrates how to configure the SoftDevice to exclude both CAR and PPCP from the) Tj T* (GAP Service.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 98.14954 cm
+q
+q
+.868957 0 0 .868957 0 0 cm
+q
+1 0 0 1 6.6 7.595313 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 552.6 205.8 re S
+Q
+q
+BT 1 0 0 1 0 185.3 Tm 10.2 TL /F6 8.5 Tf .533333 .533333 .533333 rg (int) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .4 .733333 rg (main) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj /F6 8.5 Tf .533333 .533333 .533333 rg (void) Tj /F3 8.5 Tf 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg ({) Tj .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (ble_cfg_t) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (cfg) Tj (;) Tj .733333 .733333 .733333 rg  T*  T*  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Exclude CAR from GAP service, but reserve the ATT Handles that will otherwise be used up by CAR. */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (cfg) Tj (.) Tj (gap_cfg) Tj (.) Tj (car_include_cfg) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITH_SPACE) Tj (;) Tj .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_cfg_set) Tj (\() Tj (BLE_GAP_CFG_CAR_INCL_CONFIG) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (&) Tj (cfg) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (..\);) Tj .733333 .733333 .733333 rg  T*  T*  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Exclude PPCP from GAP service, but reserve the ATT Handles that will otherwise be used up by PPCP. */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (cfg) Tj (.) Tj (gap_cfg) Tj (.) Tj (ppcp_include_cfg) Tj (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITH_SPACE) Tj (;) Tj .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_cfg_set) Tj (\() Tj (BLE_GAP_CFG_PPCP_INCL_CONFIG) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (&) Tj (cfg) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (..\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Enable the BLE Stack. */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_enable) Tj (\(...\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj 0 0 0 rg ([...]) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (}) Tj .733333 .733333 .733333 rg  T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 5) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+94 0 obj
+<<
+/Length 839
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 750.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Other additions to the API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 738.0236 cm
+Q
+q
+1 0 0 1 57.02362 738.0236 cm
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_next_conn_evt_counter_get\(\)) Tj /F1 10 Tf 0 0 0 rg (. This API can be used to retrieve the next) Tj T* (connection event counter.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 710.0236 cm
+Q
+q
+1 0 0 1 57.02362 710.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 6) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+95 0 obj
+<<
+/Length 7275
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_6.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (This section describes how to use the new features of s112_nrf52_6.1.0 when migrating from) Tj T* (s112_nrf52_6.0.0. As with all minor releases, the s112_nrf52_6.1.0 is binary compatible with) Tj T* (s112_nrf52_6.0.0. Hence existing applications running on s112_nrf52_6.0.0 need not be recompiled unless) Tj T* (the new features are needed.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 633.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (API for removing a Vendor Specific base UUID) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 555.0236 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F1 10 Tf 0 0 0 rg (Using ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_uuid_vs_remove\(\)) Tj /F1 10 Tf 0 0 0 rg (, the application can now remove a Vendor Specific base UUID that) Tj T* (has been added with ) Tj /F3 10 Tf (sd_ble_uuid_vs_add\(\)) Tj /F1 10 Tf (. This allows the application to reuse memory allocated for) Tj T* (Vendor Specific base UUIDs. The application must provide a pointer to the UUID type to be removed as an) Tj T* (input parameter to ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_uuid_vs_remove\(\)) Tj /F1 10 Tf 0 0 0 rg (. The UUID type must not be in use by the ATT Server. A) Tj T* (limitation with the current implementation is that the input parameter can only point to) Tj T* /F3 10 Tf (BLE_UUID_TYPE_UNKNOWN) Tj /F1 10 Tf ( or the last added UUID type.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 528.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (API to enable or disable extended RC calibration) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 450.0236 cm
+q
+BT 1 0 0 1 0 62 Tm -0.005444 Tw 12 TL /F1 10 Tf 0 0 0 rg (Extended RC calibration is a new SoftDevice feature that performs additional RC oscillator drift detection and) Tj T* 0 Tw (calibration when the SoftDevice is acting as a peripheral and the RC oscillator is used as the SoftDevice) Tj T* (clock source. The extended RC calibration is performed in addition to the periodic calibration which is) Tj T* (configured when calling ) Tj /F3 10 Tf (sd_softdevice_enable\(\)) Tj /F1 10 Tf (. If using only peripheral connections, the periodic) Tj T* (calibration can then be configured with a much longer interval because the peripheral can detect and adjust) Tj T* (automatically to clock drift and calibrate when required.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 408.0236 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The extended RC calibration is enabled by default. The option ) Tj /F3 10 Tf 0 .501961 0 rg (BLE_COMMON_OPT_EXTENDED_RC_CAL) Tj /F1 10 Tf 0 0 0 rg ( is) Tj T* (added to the BLE option API, allowing the application to enable or disable this feature. When using this API,) Tj T* (set ) Tj /F3 10 Tf 0 .501961 0 rg (ble_common_opt_t::extended_rc_cal::enable) Tj /F1 10 Tf 0 0 0 rg ( to '1' to enable, or to '0' to disable.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 381.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (API to get the advertiser Bluetooth device address) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 327.0236 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new API ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_addr_get\(\)) Tj /F1 10 Tf 0 0 0 rg ( enables the application to get the local Bluetooth device) Tj T* (address that is used by the advertiser. The application must provide the advertising handle of the advertiser) Tj T* -0.030647 Tw (for the ) Tj /F3 10 Tf 0 .501961 0 rg (adv_handle) Tj /F1 10 Tf 0 0 0 rg ( input parameter, and a pointer to an address structure ) Tj /F3 10 Tf 0 .501961 0 rg (p_addr) Tj /F1 10 Tf 0 0 0 rg ( to be used as the output) Tj T* 0 Tw (parameter. The function may only be called when advertising is enabled.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 273.0236 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Note: If privacy is enabled, the SoftDevice will generate a new private address every) Tj T* /F3 10 Tf (ble_gap_privacy_params_t::private_addr_cycle_s) Tj /F1 10 Tf (, which is configured when calling) Tj T* /F3 10 Tf (sd_ble_gap_privacy_set\(\)) Tj /F1 10 Tf (. Depending on when ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_addr_get\(\)) Tj /F1 10 Tf 0 0 0 rg ( is called, the) Tj T* (returned address may not be the address that is currently used by the advertiser.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 246.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Hardware resource usage API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 216.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The API now contains new macros to inform the application about the hardware resources used by the) Tj T* (SoftDevice.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 210.0236 cm
+Q
+q
+1 0 0 1 57.02362 210.0236 cm
+Q
+q
+1 0 0 1 57.02362 198.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macro ) Tj /F3 10 Tf 0 .501961 0 rg (__NRF_NVIC_SD_IRQ_PRIOS) Tj /F1 10 Tf 0 0 0 rg ( indicates the interrupt priority levels used by the SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 192.0236 cm
+Q
+q
+1 0 0 1 57.02362 168.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macro ) Tj /F3 10 Tf 0 .501961 0 rg (__NRF_NVIC_APP_IRQ_PRIOS) Tj /F1 10 Tf 0 0 0 rg ( indicates the interrupt priority levels available to the) Tj T* (application.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 162.0236 cm
+Q
+q
+1 0 0 1 57.02362 126.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macros ) Tj /F3 10 Tf 0 .501961 0 rg (NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( and) Tj T* /F3 10 Tf 0 .501961 0 rg (NRF_SOC_SD_PPI_CHANNELS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( can be used to identify the PPI channels reserved) Tj T* (by the SoftDevice when the SoftDevice is enabled or disabled respectively.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 120.0236 cm
+Q
+q
+1 0 0 1 57.02362 84.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macros ) Tj /F3 10 Tf 0 .501961 0 rg (NRF_SOC_APP_PPI_CHANNELS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( and) Tj T* /F3 10 Tf 0 .501961 0 rg (NRF_SOC_APP_PPI_CHANNELS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( can be used to identify the PPI channels) Tj T* (available to the application when the SoftDevice is enabled or disabled respectively.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 78.02362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 7) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+96 0 obj
+<<
+/Length 2467
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 729.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macros ) Tj /F3 10 Tf 0 .501961 0 rg (NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( and) Tj T* /F3 10 Tf 0 .501961 0 rg (NRF_SOC_SD_PPI_GROUPS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( can be used to identify the PPI groups reserved by) Tj T* (the SoftDevice when the SoftDevice is enabled or disabled respectively.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 723.0236 cm
+Q
+q
+1 0 0 1 57.02362 687.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macros ) Tj /F3 10 Tf 0 .501961 0 rg (NRF_SOC_APP_PPI_GROUPS_SD_ENABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( and) Tj T* /F3 10 Tf 0 .501961 0 rg (NRF_SOC_APP_PPI_GROUPS_SD_DISABLED_MSK) Tj /F1 10 Tf 0 0 0 rg ( can be used to identify the PPI groups available to) Tj T* (the application when the SoftDevice is enabled or disabled respectively.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 683.0236 cm
+Q
+q
+1 0 0 1 57.02362 656.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Other additions to the API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 644.0236 cm
+Q
+q
+1 0 0 1 57.02362 644.0236 cm
+Q
+q
+1 0 0 1 57.02362 632.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macro ) Tj /F3 10 Tf 0 .501961 0 rg (SD_VARIANT_ID) Tj /F1 10 Tf 0 0 0 rg ( indicates the SoftDevice variant.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The macro ) Tj /F3 10 Tf 0 .501961 0 rg (SD_FLASH_SIZE) Tj /F1 10 Tf 0 0 0 rg ( indicates the amount of flash memory used by the SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 610.0236 cm
+Q
+q
+1 0 0 1 57.02362 610.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 8) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+97 0 obj
+<<
+/Length 7926
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_6.0.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This section describes how to migrate to s112_nrf52_6.0.0 from s132_nrf52_5.1.0 \(which is API compatible) Tj T* (with s112_nrf52810_5.1.0\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (s112_nrf52_6.0.0 has changed the API compared to s132_nrf52_5.1.0 which requires applications to) Tj T* (be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.026281 Tw (s112_nrf52_6.0.0 includes some features that are not Bluetooth qualified. For more information, see the) Tj T* 0 Tw (release notes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 632.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 575.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Write to SoftDevice protected registers) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 533.0236 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new API, ) Tj /F3 10 Tf 0 .501961 0 rg (sd_protected_register_write\(\)) Tj /F1 10 Tf 0 0 0 rg ( , has been added to give the application the possibility to) Tj T* (write to a register that is write-protected by the SoftDevice . A write-protected peripheralshall only be) Tj T* (accessed through the SoftDevice API when the SoftDevice is enabled.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 491.0236 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The new API supports writing to the Block Protection \() Tj /F3 10 Tf (BPROT) Tj /F1 10 Tf (\) peripheral. The application can use) Tj T* /F3 10 Tf 0 .501961 0 rg (sd_protected_register_write\(\)) Tj /F1 10 Tf 0 0 0 rg ( instead of ) Tj /F3 10 Tf (sd_flash_protect\(\)) Tj /F1 10 Tf ( to set the flash protection) Tj T* (configuration registers.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 464.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Usage) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 361.2236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 480.0283 93.6 re S
+Q
+q
+BT 1 0 0 1 0 73.1 Tm 10.2 TL /F7 8.5 Tf .533333 .533333 .533333 rg (/* Old API: */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* 0 0 0 rg (errcode) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (sd_flash_protect) Tj (\() Tj (value0) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value1) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value2) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value3) Tj (\)) Tj .733333 .733333 .733333 rg  T*  T* /F7 8.5 Tf .533333 .533333 .533333 rg (/* New API: */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* 0 0 0 rg (errcode) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (sd_protected_register_write) Tj (\() Tj (&) Tj (\() Tj (NRF_BPROT) Tj (-) Tj (>) Tj (CONFIG0) Tj (\),) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value0) Tj (\)) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (errcode) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (sd_protected_register_write) Tj (\() Tj (&) Tj (\() Tj (NRF_BPROT) Tj (-) Tj (>) Tj (CONFIG1) Tj (\),) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value1) Tj (\)) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (errcode) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (sd_protected_register_write) Tj (\() Tj (&) Tj (\() Tj (NRF_BPROT) Tj (-) Tj (>) Tj (CONFIG2) Tj (\),) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value2) Tj (\)) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (errcode) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (sd_protected_register_write) Tj (\() Tj (&) Tj (\() Tj (NRF_BPROT) Tj (-) Tj (>) Tj (CONFIG3) Tj (\),) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (value3) Tj (\)) Tj .733333 .733333 .733333 rg  T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 331.2236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Required changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 304.2236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Updated advertiser API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 286.2236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (sd_ble_gap_adv_data_set\(\)) Tj /F1 10 Tf 0 0 0 rg ( has been removed.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 268.2236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new API, ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf 0 0 0 rg (, has been added with the following functionalities:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 262.2236 cm
+Q
+q
+1 0 0 1 57.02362 262.2236 cm
+Q
+q
+1 0 0 1 57.02362 250.2236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Configuring and updating the advertising parameters of an advertising set.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 244.2236 cm
+Q
+q
+1 0 0 1 57.02362 168.2236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Setting, clearing, or updating advertising and scan response data.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Note: The advertising data must be kept alive in memory until advertising is terminated. Not doing) Tj T* (so will lead to undefined behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Note: Updating advertising data while advertising can only be done by providing new advertising) Tj T* (data buffers.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 164.2236 cm
+Q
+q
+1 0 0 1 57.02362 137.2236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Configuring and updating an advertising set) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 119.2236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Advertising Set is a term introduced in Bluetooth Core Specification v5.0.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 77.22362 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Each advertising set is identified by an advertising handle. To configure a new advertising set and obtain a) Tj T* (new advertising handle, ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf 0 0 0 rg ( should be called with a pointer) Tj T* /F3 10 Tf 0 .501961 0 rg (p_adv_handle) Tj /F1 10 Tf 0 0 0 rg ( pointing to an advertising handle set to ) Tj /F3 10 Tf (BLE_GAP_ADV_SET_HANDLE_NOT_SET.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 9) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+98 0 obj
+<<
+/Length 10576
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 741.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (To update an existing advertising set, ) Tj /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf 0 0 0 rg ( should be called with a) Tj T* (previously configured advertising handle.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 723.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Note: Currently only one advertising set can be configured in the SoftDevice.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Configuring advertising parameters for an advertising set) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Setting advertising parameters has been moved from ) Tj /F3 10 Tf (sd_ble_gap_adv_start\(\)) Tj /F1 10 Tf ( to) Tj T* /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The content of ) Tj /F3 10 Tf (ble_gap_adv_params_t) Tj /F1 10 Tf ( has changed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 630.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (ble_gap_adv_params_t::type) Tj /F1 10 Tf 0 0 0 rg ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 624.0236 cm
+Q
+q
+1 0 0 1 57.02362 342.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 267 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 267 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new parameter, ) Tj /F3 10 Tf 0 .501961 0 rg (properties) Tj /F1 10 Tf 0 0 0 rg (, of the new type ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_adv_properties_t) Tj /F1 10 Tf 0 0 0 rg ( has been added.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 261 cm
+Q
+q
+1 0 0 1 23 261 cm
+Q
+q
+1 0 0 1 23 249 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The advertising type must now be set through ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_adv_properties_t::type) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 243 cm
+Q
+q
+1 0 0 1 23 143 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 85 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 73 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The advertising type definitions \() Tj /F3 10 Tf (BLE_GAP_ADV_TYPES) Tj /F1 10 Tf (\) have changed, and new types have been) Tj T* (added. These advertising types are referred to as ) Tj /F5 10 Tf (legacy) Tj /F1 10 Tf ( advertising types:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (type = BLE_GAP_ADV_TYPE_ADV_IND) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (type = BLE_GAP_ADV_TYPE_ADV_DIRECT_IND) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (type = BLE_GAP_ADV_TYPE_ADV_SCAN_IND) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (type = BLE_GAP_ADV_TYPE_ADV_NONCONN_IND) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 139 cm
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 124 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Their corresponding new types are:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 20 118 cm
+Q
+q
+1 0 0 1 20 118 cm
+Q
+q
+1 0 0 1 20 106 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (properties.type = BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 100 cm
+Q
+q
+1 0 0 1 20 64 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (properties.type =) Tj T* (BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED_HIGH_DUTY_CYCLE) Tj /F1 10 Tf 0 0 0 rg ( or) Tj T* /F3 10 Tf 0 .501961 0 rg (BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 58 cm
+Q
+q
+1 0 0 1 20 34 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 14 Tm /F3 10 Tf 12 TL (properties.type =) Tj T* (BLE_GAP_ADV_TYPE_NONCONNECTABLE_SCANNABLE_UNDIRECTED) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 28 cm
+Q
+q
+1 0 0 1 20 4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 14 Tm /F3 10 Tf 12 TL (properties.type =) Tj T* (BLE_GAP_ADV_TYPE_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 0 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 336.0236 cm
+Q
+q
+1 0 0 1 57.02362 324.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (ble_gap_adv_params_t::fp) Tj /F1 10 Tf 0 0 0 rg ( has been renamed ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_adv_params_t::filter_policy) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 318.0236 cm
+Q
+q
+1 0 0 1 57.02362 294.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 1 0 0 rg (ble_gap_adv_params_t::timeout) Tj /F1 10 Tf 0 0 0 rg ( has been renamed ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_adv_params_t::duration) Tj /F1 10 Tf 0 0 0 rg  T* (and is now measured in 10 ms units.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 288.0236 cm
+Q
+q
+1 0 0 1 57.02362 110.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 163 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 151 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 1 0 0 rg (ble_gap_adv_params_t::channel_mask) Tj /F1 10 Tf 0 0 0 rg ( type has been changed from) Tj T* /F3 10 Tf 1 0 0 rg (ble_gap_adv_ch_mask_t) Tj /F1 10 Tf 0 0 0 rg ( to the new type ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_ch_mask_t) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 145 cm
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 142 cm
+Q
+q
+1 0 0 1 20 142 cm
+Q
+q
+1 0 0 1 20 130 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Note: At least one of the primary channels that is channel index 37-39 must be set to 0.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 124 cm
+Q
+q
+1 0 0 1 20 112 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Note: Masking away secondary channels is currently not supported.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 106 cm
+Q
+q
+1 0 0 1 20 4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 87 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 75 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The mapping from old type ) Tj /F3 10 Tf 1 0 0 rg (ble_gap_adv_ch_mask_t) Tj /F1 10 Tf 0 0 0 rg ( to the new type) Tj T* /F3 10 Tf 0 .501961 0 rg (ble_gap_ch_mask_t) Tj /F1 10 Tf 0 0 0 rg ( is shown below:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 69 cm
+Q
+q
+1 0 0 1 23 -3 cm
+q
+1 1 1 rg
+n 0 72 415.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 54 415.2283 -18 re f*
+1 1 1 rg
+n 0 36 415.2283 -18 re f*
+.878431 .878431 .878431 rg
+n 0 18 415.2283 -18 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (Old) Tj T* ET
+Q
+Q
+q
+1 0 0 1 210.5155 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F4 10 Tf 12 TL (New) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 39 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask.ch_37_off = 1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 210.5155 39 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask = 0x2000000000) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 21 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask.ch_38_off = 1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 210.5155 21 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask = 0x4000000000) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 3 cm
+q
+1 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask.ch_39_off = 1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 210.5155 3 cm
+q
+0 .501961 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL (channel_mask = 0x8000000000) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 54 m 415.2283 54 l S
+n 0 36 m 415.2283 36 l S
+n 0 18 m 415.2283 18 l S
+n 204.5155 0 m 204.5155 72 l S
+n 0 72 m 415.2283 72 l S
+n 0 0 m 415.2283 0 l S
+n 0 0 m 0 72 l S
+n 415.2283 0 m 415.2283 72 l S
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 20 0 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 104.0236 cm
+Q
+q
+1 0 0 1 57.02362 86.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (ble_gap_adv_params_t) Tj /F1 10 Tf ( has several new parameters:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 10) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+99 0 obj
+<<
+/Length 7582
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 559.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 193 Tm  T* ET
+q
+1 0 0 1 23 179 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (max_adv_evts) Tj /F1 10 Tf 0 0 0 rg ( has been added to allow the application to advertise for a given number of) Tj T* (advertising events.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 173 cm
+Q
+q
+1 0 0 1 23 137 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (scan_req_notification) Tj /F1 10 Tf 0 0 0 rg ( flag has been added to give the application the possibility to receive) Tj T* (events of type ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_evt_scan_req_report_t) Tj /F1 10 Tf 0 0 0 rg (. This replaces) Tj T* /F3 10 Tf 1 0 0 rg (BLE_GAP_OPT_SCAN_REQ_REPORT) Tj /F1 10 Tf 0 0 0 rg ( .) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 131 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 97 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (primary_phy) Tj /F1 10 Tf 0 0 0 rg ( and ) Tj /F3 10 Tf 0 .501961 0 rg (secondary_phy) Tj /F1 10 Tf 0 0 0 rg ( allow the application to select PHYs for primary and) Tj T* (secondary advertising channels.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (primary_phy) Tj /F1 10 Tf 0 0 0 rg ( should be set to ) Tj /F3 10 Tf (BLE_GAP_PHY_AUTO) Tj /F1 10 Tf ( or ) Tj /F3 10 Tf (BLE_GAP_PHY_1MBPS) Tj /F1 10 Tf ( for legacy) Tj T* (advertising types. For extended advertising types, it should be set to ) Tj /F3 10 Tf (BLE_GAP_PHY_1MBPS) Tj /F1 10 Tf  T* (or ) Tj /F3 10 Tf (BLE_GAP_PHY_CODED) Tj /F1 10 Tf ( if supported by the SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (secondary_phy) Tj /F1 10 Tf 0 0 0 rg ( can be ignored for legacy advertising. For extended advertising types, it) Tj T* (should be set to ) Tj /F3 10 Tf (BLE_GAP_PHY_1MBPS,) Tj ( ) Tj (BLE_GAP_PHY_2MBPS,) Tj /F1 10 Tf ( or ) Tj /F3 10 Tf (BLE_GAP_PHY_CODED) Tj /F1 10 Tf  T* (if supported by the SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 .501961 0 rg (set_id) Tj /F1 10 Tf 0 0 0 rg ( has been added to allow the application to choose the set ID of an extended advertiser .) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 555.0236 cm
+Q
+q
+1 0 0 1 57.02362 528.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Other Advertising API changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 516.0236 cm
+Q
+q
+1 0 0 1 57.02362 516.0236 cm
+Q
+q
+1 0 0 1 57.02362 458.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (BLE_GAP_TIMEOUT_SRC_ADVERTISING) Tj /F1 10 Tf 0 0 0 rg ( has been removed.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new event, ) Tj /F3 10 Tf 0 .501961 0 rg (BLE_GAP_EVT_ADVERTISING_SET_TERMINATED) Tj /F1 10 Tf 0 0 0 rg ( with structure) Tj T* /F3 10 Tf 0 .501961 0 rg (ble_gap_evt_adv_set_terminated_t) Tj /F1 10 Tf 0 0 0 rg (, has been introduced to let the application know when) Tj T* (and why an advertising set has terminated.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 452.0236 cm
+Q
+q
+1 0 0 1 57.02362 416.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new configuration parameter, ) Tj /F3 10 Tf 0 .501961 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf 0 0 0 rg (, has been) Tj T* (introduced to set the maximum number of advertising sets. Note: The maximum number of supported) Tj T* (advertising sets is ) Tj /F3 10 Tf 0 .501961 0 rg (BLE_GAP_ADV_SET_COUNT_MAX) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 410.0236 cm
+Q
+q
+1 0 0 1 57.02362 398.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (BLE_GAP_ADV_MAX_SIZE) Tj /F1 10 Tf 0 0 0 rg ( has been replaced with ) Tj /F3 10 Tf 0 .501961 0 rg (BLE_GAP_ADV_SET_DATA_SIZE_MAX) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 392.0236 cm
+Q
+q
+1 0 0 1 57.02362 368.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (ble_gap_evt_connected_t) Tj /F1 10 Tf ( now includes ) Tj /F3 10 Tf 0 .501961 0 rg (adv_handle) Tj /F1 10 Tf 0 0 0 rg ( and ) Tj /F3 10 Tf 0 .501961 0 rg (adv_data) Tj /F1 10 Tf 0 0 0 rg ( of the new type) Tj T* /F3 10 Tf 0 .501961 0 rg (ble_gap_adv_data_t) Tj /F1 10 Tf 0 0 0 rg ( .These are set when the device connects as a peripheral.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 362.0236 cm
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (ble_gap_evt_scan_req_report_t) Tj /F1 10 Tf ( now includes ) Tj /F3 10 Tf 0 .501961 0 rg (adv_handle) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 344.0236 cm
+Q
+q
+1 0 0 1 57.02362 332.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F3 10 Tf 1 0 0 rg (BLE_GAP_OPT_SCAN_REQ_REPORT) Tj /F1 10 Tf 0 0 0 rg ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 326.0236 cm
+Q
+q
+1 0 0 1 57.02362 302.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (BLE_GAP_ADV_TIMEOUT_LIMITED_MAX) Tj /F1 10 Tf ( has been changed from 180 to 18000 as) Tj T* /F3 10 Tf 0 .501961 0 rg (sd_ble_gap_adv_params_t::duration) Tj /F1 10 Tf 0 0 0 rg ( is now measured in 10 ms units.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 298.0236 cm
+Q
+q
+1 0 0 1 57.02362 298.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 11) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+100 0 obj
+<<
+/Length 10545
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 753.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf .133333 .133333 .133333 rg (Usage) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 221.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 480.0283 522 re S
+Q
+q
+BT 1 0 0 1 0 501.5 Tm 10.2 TL /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf .533333 .533333 .533333 rg (uint8_t) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_adv_data_buffer1) Tj ([) Tj (BLE_GAP_ADV_SET_DATA_SIZE_MAX) Tj (];) Tj .733333 .733333 .733333 rg  T* /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf .533333 .533333 .533333 rg (uint8_t) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_scan_rsp_data_buffer1) Tj ([) Tj (BLE_GAP_ADV_SET_DATA_SIZE_MAX) Tj (];) Tj .733333 .733333 .733333 rg  T* /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (ble_gap_adv_data_t) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (adv_data1) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ({) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (adv_data) Tj (.) Tj (p_data) Tj .733333 .733333 .733333 rg (      ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_adv_data_buffer1) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (adv_data) Tj (.) Tj (len) Tj .733333 .733333 .733333 rg (         ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .533333 0 rg (sizeof) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj (raw_adv_data_buffer1) Tj (\),) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (scan_rsp_data) Tj (.) Tj (p_data) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_scan_rsp_data_buffer1) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (scan_rsp_data) Tj (.) Tj (len) Tj .733333 .733333 .733333 rg (    ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .533333 0 rg (sizeof) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj (raw_scan_rsp_data_buffer1) Tj (\)};) Tj .733333 .733333 .733333 rg  T*  T* /F7 8.5 Tf .533333 .533333 .533333 rg (/* A second advertising data buffer for later updating advertising data while) Tj T* ( * advertising */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf .533333 .533333 .533333 rg (uint8_t) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_adv_data_buffer2) Tj ([) Tj (BLE_GAP_ADV_SET_DATA_SIZE_MAX) Tj (];) Tj .733333 .733333 .733333 rg  T* /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf .533333 .533333 .533333 rg (uint8_t) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_scan_rsp_data_buffer2) Tj ([) Tj (BLE_GAP_ADV_SET_DATA_SIZE_MAX) Tj (];) Tj .733333 .733333 .733333 rg  T* /F6 8.5 Tf 0 .533333 0 rg (static) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (ble_gap_adv_data_t) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (adv_data2) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ({) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (adv_data) Tj (.) Tj (p_data) Tj .733333 .733333 .733333 rg (      ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_adv_data_buffer2) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (adv_data) Tj (.) Tj (len) Tj .733333 .733333 .733333 rg (         ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .533333 0 rg (sizeof) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj (raw_adv_data_buffer2) Tj (\),) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (scan_rsp_data) Tj (.) Tj (p_data) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (raw_scan_rsp_data_buffer2) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (scan_rsp_data) Tj (.) Tj (len) Tj .733333 .733333 .733333 rg (    ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .533333 0 rg (sizeof) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj (raw_scan_rsp_data_buffer2) Tj (\)};) Tj .733333 .733333 .733333 rg  T*  T* /F6 8.5 Tf .533333 .533333 .533333 rg (int) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 .4 .733333 rg (main) Tj /F3 8.5 Tf 0 0 0 rg (\() Tj /F6 8.5 Tf .533333 .533333 .533333 rg (void) Tj /F3 8.5 Tf 0 0 0 rg (\)) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg ({) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F6 8.5 Tf .533333 .533333 .533333 rg (uint8_t) Tj /F3 8.5 Tf .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (adv_handle) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_ADV_SET_HANDLE_NOT_SET) Tj (;) Tj .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (ble_gap_adv_params_t) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (adv_params) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ({) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (properties) Tj (=) Tj ({.) Tj (type) Tj (=) Tj (BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED) Tj (},) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (interval) Tj .733333 .733333 .733333 rg (              ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_ADV_INTERVAL_MAX) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (duration) Tj .733333 .733333 .733333 rg (              ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_ADV_TIMEOUT_LIMITED_MAX) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (channel_mask) Tj .733333 .733333 .733333 rg (          ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg ({) Tj /F6 8.5 Tf 0 0 .866667 rg (0) Tj /F3 8.5 Tf 0 0 0 rg (},) Tj .733333 .733333 .733333 rg ( ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Advertising on all the primary channels */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (max_adv_evts) Tj .733333 .733333 .733333 rg (          ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 0 .866667 rg (0) Tj /F3 8.5 Tf 0 0 0 rg (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (filter_policy) Tj .733333 .733333 .733333 rg (         ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_ADV_FP_ANY) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (primary_phy) Tj .733333 .733333 .733333 rg (           ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_GAP_PHY_AUTO) Tj (,) Tj .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (.) Tj (scan_req_notification) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (=) Tj .733333 .733333 .733333 rg ( ) Tj /F6 8.5 Tf 0 0 .866667 rg (1) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (       ) Tj 0 0 0 rg (};) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Enable the BLE Stack */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_enable) Tj (\(...\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj 0 0 0 rg ([...]) Tj .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_gap_adv_set_configure) Tj (\() Tj (&) Tj (adv_handle) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (&) Tj (adv_data1) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (&) Tj (adv_params) Tj (\);) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Start advertising */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_gap_adv_start) Tj (\() Tj (adv_handle) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (BLE_CONN_CFG_TAG_DEFAULT) Tj (\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj 0 0 0 rg ([...]) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Update advertising data while advertising */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_gap_adv_set_configure) Tj (\() Tj (&) Tj (adv_handle) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 0 0 rg (&) Tj (adv_data2) Tj (,) Tj .733333 .733333 .733333 rg ( ) Tj 0 .2 .533333 rg (NULL) Tj 0 0 0 rg (\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj 0 0 0 rg ([...]) Tj .733333 .733333 .733333 rg  T* (  ) Tj /F7 8.5 Tf .533333 .533333 .533333 rg (/* Stop advertising */) Tj /F3 8.5 Tf .733333 .733333 .733333 rg  T* (  ) Tj 0 0 0 rg (sd_ble_gap_adv_stop) Tj (\() Tj (adv_handle) Tj (\);) Tj .733333 .733333 .733333 rg  T*  T* (  ) Tj 0 0 0 rg ([...]) Tj .733333 .733333 .733333 rg  T* 0 0 0 rg (}) Tj .733333 .733333 .733333 rg  T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 194.8236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Updated RSSI API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 164.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The RSSI API has been changed so that the SoftDevice can provide the application with the channel index) Tj T* (on which the reported RSSI measurements are made.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 158.8236 cm
+Q
+q
+1 0 0 1 57.02362 158.8236 cm
+Q
+q
+1 0 0 1 57.02362 134.8236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (sd_ble_gap_rssi_get\(\)) Tj /F1 10 Tf ( takes an additional parameter ) Tj /F3 10 Tf 0 .501961 0 rg (p_ch_index) Tj /F1 10 Tf 0 0 0 rg (. For this parameter, provide a) Tj T* (pointer to a location where the channel index for the RSSI measurement should be stored.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 128.8236 cm
+Q
+q
+1 0 0 1 57.02362 92.82362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The event structure for the ) Tj /F3 10 Tf (BLE_GAP_EVT_RSSI_CHANGED) Tj /F1 10 Tf ( event has a new parameter) Tj T* /F3 10 Tf 0 .501961 0 rg (ble_gap_evt_rssi_changed_t::ch_index) Tj /F1 10 Tf 0 0 0 rg (. This is the Data Channel Index \(0-36\) on which the) Tj T* (RSSI is measured.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 86.82362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 12) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+101 0 obj
+<<
+/Length 2674
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 717.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (The event structure for the ) Tj /F3 10 Tf (BLE_GAP_EVT_ADV_REPORT) Tj /F1 10 Tf ( event has a new parameter) Tj T* /F3 10 Tf 0 .501961 0 rg (ble_gap_evt_adv_report_t::ch_index) Tj /F1 10 Tf 0 0 0 rg (. This is the Channel Index \(0-39\) on which the last) Tj T* (advertising packet is received. The corresponding measured RSSI for this packet can be read from) Tj T* /F3 10 Tf (ble_gap_evt_adv_report_t::rssi) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 713.0236 cm
+Q
+q
+1 0 0 1 57.02362 686.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (TX power API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 668.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The TX power API now supports setting individual transmit power for each link or role.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 662.0236 cm
+Q
+q
+1 0 0 1 57.02362 662.0236 cm
+Q
+q
+1 0 0 1 57.02362 638.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F3 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (sd_ble_gap_tx_power_set\(\)) Tj /F1 10 Tf ( takes two new parameters, ) Tj /F3 10 Tf 0 .501961 0 rg (role) Tj /F1 10 Tf 0 0 0 rg ( and ) Tj /F3 10 Tf 0 .501961 0 rg (handle) Tj /F1 10 Tf 0 0 0 rg (, in addition to) Tj T* /F3 10 Tf (tx_power) Tj /F1 10 Tf (. For available roles and TX power values, see ble_gap.h.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 634.0236 cm
+Q
+q
+1 0 0 1 57.02362 607.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Updated Flash API) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 577.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (sd_flash_write\(\)) Tj /F1 10 Tf ( now triggers a HardFault if the application tries to write to a protected page.) Tj T* /F3 10 Tf (NRF_ERROR_FORBIDDEN) Tj /F1 10 Tf ( is returned if the application tries to write to a page outside application flash area.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 547.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F3 10 Tf 0 0 0 rg (sd_flash_page_erase\(\)) Tj /F1 10 Tf ( now triggers a HardFault if the application tries to erase a protected page.) Tj T* /F3 10 Tf (NRF_ERROR_FORBIDDEN) Tj /F1 10 Tf ( is returned if the application tries to erase a page outside application flash area.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F5 10 Tf 0 0 0 rg (Page 13) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+102 0 obj
+<<
+/Nums [ 0 103 0 R 1 104 0 R 2 105 0 R 3 106 0 R 4 107 0 R 
+  5 108 0 R 6 109 0 R 7 110 0 R 8 111 0 R 9 112 0 R 
+  10 113 0 R 11 114 0 R 12 115 0 R ]
+>>
+endobj
+103 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+104 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+105 0 obj
+<<
+/S /D /St 3
+>>
+endobj
+106 0 obj
+<<
+/S /D /St 4
+>>
+endobj
+107 0 obj
+<<
+/S /D /St 5
+>>
+endobj
+108 0 obj
+<<
+/S /D /St 6
+>>
+endobj
+109 0 obj
+<<
+/S /D /St 7
+>>
+endobj
+110 0 obj
+<<
+/S /D /St 8
+>>
+endobj
+111 0 obj
+<<
+/S /D /St 9
+>>
+endobj
+112 0 obj
+<<
+/S /D /St 10
+>>
+endobj
+113 0 obj
+<<
+/S /D /St 11
+>>
+endobj
+114 0 obj
+<<
+/S /D /St 12
+>>
+endobj
+115 0 obj
+<<
+/S /D /St 13
+>>
+endobj
+xref
+0 116
+0000000000 65535 f 
+0000000073 00000 n 
+0000000169 00000 n 
+0000000276 00000 n 
+0000000385 00000 n 
+0000000490 00000 n 
+0000000602 00000 n 
+0000000717 00000 n 
+0000000922 00000 n 
+0000001089 00000 n 
+0000001254 00000 n 
+0000001422 00000 n 
+0000001588 00000 n 
+0000001757 00000 n 
+0000001924 00000 n 
+0000002093 00000 n 
+0000002260 00000 n 
+0000002429 00000 n 
+0000002596 00000 n 
+0000002765 00000 n 
+0000002932 00000 n 
+0000003101 00000 n 
+0000003268 00000 n 
+0000003437 00000 n 
+0000003604 00000 n 
+0000003773 00000 n 
+0000003940 00000 n 
+0000004109 00000 n 
+0000004276 00000 n 
+0000004445 00000 n 
+0000004612 00000 n 
+0000004781 00000 n 
+0000004948 00000 n 
+0000005117 00000 n 
+0000005284 00000 n 
+0000005453 00000 n 
+0000005620 00000 n 
+0000005789 00000 n 
+0000005956 00000 n 
+0000006388 00000 n 
+0000006594 00000 n 
+0000006705 00000 n 
+0000006911 00000 n 
+0000007025 00000 n 
+0000007231 00000 n 
+0000007437 00000 n 
+0000007643 00000 n 
+0000007849 00000 n 
+0000008055 00000 n 
+0000008261 00000 n 
+0000008467 00000 n 
+0000008674 00000 n 
+0000008881 00000 n 
+0000008988 00000 n 
+0000009269 00000 n 
+0000009344 00000 n 
+0000009527 00000 n 
+0000009633 00000 n 
+0000009809 00000 n 
+0000009927 00000 n 
+0000010046 00000 n 
+0000010216 00000 n 
+0000010359 00000 n 
+0000010484 00000 n 
+0000010654 00000 n 
+0000010772 00000 n 
+0000010931 00000 n 
+0000011164 00000 n 
+0000011292 00000 n 
+0000011462 00000 n 
+0000011605 00000 n 
+0000011751 00000 n 
+0000011914 00000 n 
+0000012079 00000 n 
+0000012221 00000 n 
+0000012349 00000 n 
+0000012506 00000 n 
+0000012665 00000 n 
+0000012806 00000 n 
+0000012913 00000 n 
+0000013071 00000 n 
+0000013195 00000 n 
+0000013353 00000 n 
+0000013525 00000 n 
+0000013709 00000 n 
+0000013803 00000 n 
+0000013934 00000 n 
+0000014061 00000 n 
+0000014180 00000 n 
+0000014328 00000 n 
+0000017353 00000 n 
+0000021229 00000 n 
+0000022080 00000 n 
+0000024245 00000 n 
+0000031808 00000 n 
+0000032698 00000 n 
+0000040025 00000 n 
+0000042544 00000 n 
+0000050522 00000 n 
+0000061151 00000 n 
+0000068785 00000 n 
+0000079384 00000 n 
+0000082111 00000 n 
+0000082283 00000 n 
+0000082318 00000 n 
+0000082353 00000 n 
+0000082388 00000 n 
+0000082423 00000 n 
+0000082458 00000 n 
+0000082493 00000 n 
+0000082528 00000 n 
+0000082563 00000 n 
+0000082598 00000 n 
+0000082634 00000 n 
+0000082670 00000 n 
+0000082706 00000 n 
+trailer
+<<
+/ID 
+[<5005694ab6518b3b9730db5fa10bff88><5005694ab6518b3b9730db5fa10bff88>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 53 0 R
+/Root 52 0 R
+/Size 116
+>>
+startxref
+82742
+%%EOF

--- a/subsys/softdevice/hex/s115/s115_9.0.0-1.prototype_release-notes.pdf
+++ b/subsys/softdevice/hex/s115/s115_9.0.0-1.prototype_release-notes.pdf
@@ -1,0 +1,20710 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 6 0 R /F5 180 0 R /F6 185 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 317 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 5 0 R /XYZ 57.02362 705.0236 0 ] /Rect [ 57.02362 724.8236 210.0661 735.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 5 0 R /XYZ 57.02362 705.0236 0 ] /Rect [ 533.526 725.4611 538.252 735.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 5 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 77.02362 708.6236 153.0986 718.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 5 0 R /XYZ 57.02362 672.0236 0 ] /Rect [ 533.526 709.2611 538.252 719.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 692.4236 148.6706 702.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 693.0611 538.252 703.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 656.0236 0 ] /Rect [ 77.02362 676.2236 158.2751 686.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 656.0236 0 ] /Rect [ 533.526 676.8611 538.252 687.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 456.0236 0 ] /Rect [ 77.02362 660.0236 111.0406 670.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 456.0236 0 ] /Rect [ 533.526 660.6611 538.252 670.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 148.0236 0 ] /Rect [ 77.02362 643.8236 117.6451 654.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 181 0 R /XYZ 57.02362 148.0236 0 ] /Rect [ 533.526 644.4611 538.252 654.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 489.0236 0 ] /Rect [ 77.02362 627.6236 129.9361 637.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 182 0 R /XYZ 57.02362 489.0236 0 ] /Rect [ 533.526 628.2611 538.252 638.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+21 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 611.4236 125.0661 621.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+22 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 533.526 612.0611 538.252 622.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+23 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 77.02362 595.2236 158.2751 605.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+24 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 533.526 595.8611 538.252 606.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+25 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 77.02362 579.0236 114.8146 589.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+26 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 533.526 579.6611 538.252 589.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+27 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 276.0236 0 ] /Rect [ 77.02362 562.8236 117.6451 573.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+28 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 184 0 R /XYZ 57.02362 276.0236 0 ] /Rect [ 533.526 563.4611 538.252 573.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+29 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 186 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 77.02362 546.6236 129.9361 556.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+30 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 186 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 533.526 547.2611 538.252 557.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+31 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 530.4236 125.0661 540.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+32 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 531.0611 538.252 541.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+33 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 632.0236 0 ] /Rect [ 77.02362 514.2236 158.2751 524.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+34 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 632.0236 0 ] /Rect [ 528.8 514.8611 538.252 525.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+35 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 380.0236 0 ] /Rect [ 77.02362 498.0236 114.8146 508.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+36 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 380.0236 0 ] /Rect [ 528.8 498.6611 538.252 508.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+37 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 276.0236 0 ] /Rect [ 77.02362 481.8236 117.6451 492.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+38 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 188 0 R /XYZ 57.02362 276.0236 0 ] /Rect [ 528.8 482.4611 538.252 492.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+39 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 189 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 77.02362 465.6236 129.9361 475.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+40 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 189 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 528.8 466.2611 538.252 476.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+41 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 449.4236 125.0661 459.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+42 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 450.0611 538.252 460.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+43 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 77.02362 433.2236 158.2751 443.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+44 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 528.8 433.8611 538.252 444.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+45 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 77.02362 417.0236 129.9276 427.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+46 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 528.8 417.6611 538.252 427.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+47 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 252.0236 0 ] /Rect [ 77.02362 400.8236 114.8146 411.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+48 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 252.0236 0 ] /Rect [ 528.8 401.4611 538.252 411.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+49 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 108.0236 0 ] /Rect [ 77.02362 384.6236 117.6451 394.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+50 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 191 0 R /XYZ 57.02362 108.0236 0 ] /Rect [ 528.8 385.2611 538.252 395.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+51 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 501.0236 0 ] /Rect [ 77.02362 368.4236 129.9361 378.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+52 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 192 0 R /XYZ 57.02362 501.0236 0 ] /Rect [ 528.8 369.0611 538.252 379.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+53 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 352.2236 125.0661 362.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+54 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 352.8611 538.252 363.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+55 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 604.0236 0 ] /Rect [ 77.02362 336.0236 158.2751 346.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+56 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 604.0236 0 ] /Rect [ 528.8 336.6611 538.252 346.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+57 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 352.0236 0 ] /Rect [ 77.02362 319.8236 129.9276 330.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+58 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 352.0236 0 ] /Rect [ 528.8 320.4611 538.252 330.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+59 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 260.0236 0 ] /Rect [ 77.02362 303.6236 114.8146 313.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+60 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 260.0236 0 ] /Rect [ 528.8 304.2611 538.252 314.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+61 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 156.0236 0 ] /Rect [ 77.02362 287.4236 117.6451 297.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+62 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 194 0 R /XYZ 57.02362 156.0236 0 ] /Rect [ 528.8 288.0611 538.252 298.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+63 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 549.0236 0 ] /Rect [ 77.02362 271.2236 129.9361 281.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+64 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 195 0 R /XYZ 57.02362 549.0236 0 ] /Rect [ 528.8 271.8611 538.252 282.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+65 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 255.0236 125.0661 265.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+66 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 255.6611 538.252 265.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+67 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 77.02362 238.8236 158.2751 249.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+68 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 620.0236 0 ] /Rect [ 528.8 239.4611 538.252 249.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+69 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 77.02362 222.6236 129.9276 232.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+70 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 368.0236 0 ] /Rect [ 528.8 223.2611 538.252 233.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+71 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 212.0236 0 ] /Rect [ 77.02362 206.4236 111.0406 216.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+72 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 197 0 R /XYZ 57.02362 212.0236 0 ] /Rect [ 528.8 207.0611 538.252 217.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+73 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 697.0236 0 ] /Rect [ 77.02362 190.2236 114.8146 200.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+74 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 697.0236 0 ] /Rect [ 528.8 190.8611 538.252 201.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+75 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 593.0236 0 ] /Rect [ 77.02362 174.0236 117.6451 184.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+76 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 593.0236 0 ] /Rect [ 528.8 174.6611 538.252 184.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+77 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 299.0236 0 ] /Rect [ 77.02362 157.8236 129.9361 168.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+78 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 198 0 R /XYZ 57.02362 299.0236 0 ] /Rect [ 528.8 158.4611 538.252 168.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+79 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 141.6236 125.0661 151.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+80 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 142.2611 538.252 152.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+81 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 614.0236 0 ] /Rect [ 77.02362 125.4236 158.2751 135.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+82 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 614.0236 0 ] /Rect [ 528.8 126.0611 538.252 136.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+83 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 374.0236 0 ] /Rect [ 77.02362 109.2236 141.2666 119.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+84 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 374.0236 0 ] /Rect [ 528.8 109.8611 538.252 120.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+85 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 294.0236 0 ] /Rect [ 77.02362 93.02362 117.6451 103.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+86 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 200 0 R /XYZ 57.02362 294.0236 0 ] /Rect [ 528.8 93.66112 538.252 103.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+87 0 obj
+<<
+/Annots [ 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 
+  17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 
+  27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 
+  37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 
+  47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 
+  57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 
+  67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 
+  77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R ] /Contents 318 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+88 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 201 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 77.02362 751.8236 129.9361 762.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+89 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 201 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 752.4611 538.252 762.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+90 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 735.6236 125.0661 745.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+91 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 736.2611 538.252 746.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+92 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 596.0236 0 ] /Rect [ 77.02362 719.4236 158.2751 729.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+93 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 596.0236 0 ] /Rect [ 528.8 720.0611 538.252 730.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+94 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 344.0236 0 ] /Rect [ 77.02362 703.2236 111.0406 713.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+95 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 344.0236 0 ] /Rect [ 528.8 703.8611 538.252 714.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+96 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 140.0236 0 ] /Rect [ 77.02362 687.0236 111.9841 697.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+97 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 202 0 R /XYZ 57.02362 140.0236 0 ] /Rect [ 528.8 687.6611 538.252 697.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+98 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 709.0236 0 ] /Rect [ 77.02362 670.8236 117.6451 681.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+99 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 709.0236 0 ] /Rect [ 528.8 671.4611 538.252 681.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+100 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 505.0236 0 ] /Rect [ 77.02362 654.6236 129.9361 664.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+101 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 203 0 R /XYZ 57.02362 505.0236 0 ] /Rect [ 528.8 655.2611 538.252 665.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+102 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 205 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 638.4236 179.3811 648.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+103 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 205 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 639.0611 538.252 649.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+104 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 205 0 R /XYZ 57.02362 614.0236 0 ] /Rect [ 77.02362 622.2236 158.2751 632.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+105 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 205 0 R /XYZ 57.02362 614.0236 0 ] /Rect [ 528.8 622.8611 538.252 633.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+106 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 606.0236 125.0661 616.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+107 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 606.6611 538.252 616.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+108 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 644.0236 0 ] /Rect [ 77.02362 589.8236 159.2186 600.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+109 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 644.0236 0 ] /Rect [ 528.8 590.4611 538.252 600.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+110 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 428.0236 0 ] /Rect [ 77.02362 573.6236 111.0406 583.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+111 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 428.0236 0 ] /Rect [ 528.8 574.2611 538.252 584.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+112 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 282.0236 0 ] /Rect [ 77.02362 557.4236 114.8146 567.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+113 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 282.0236 0 ] /Rect [ 528.8 558.0611 538.252 568.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+114 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 190.0236 0 ] /Rect [ 77.02362 541.2236 117.6451 551.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+115 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 208 0 R /XYZ 57.02362 190.0236 0 ] /Rect [ 528.8 541.8611 538.252 552.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+116 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 591.0236 0 ] /Rect [ 77.02362 525.0236 129.9361 535.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+117 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 209 0 R /XYZ 57.02362 591.0236 0 ] /Rect [ 528.8 525.6611 538.252 535.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+118 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 508.8236 125.0661 519.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+119 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 509.4611 538.252 519.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+120 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 644.0236 0 ] /Rect [ 77.02362 492.6236 159.2186 502.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+121 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 644.0236 0 ] /Rect [ 528.8 493.2611 538.252 503.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+122 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 468.0236 0 ] /Rect [ 77.02362 476.4236 144.0971 486.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+123 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 468.0236 0 ] /Rect [ 528.8 477.0611 538.252 487.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+124 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 294.0236 0 ] /Rect [ 77.02362 460.2236 111.0406 470.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+125 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 210 0 R /XYZ 57.02362 294.0236 0 ] /Rect [ 528.8 460.8611 538.252 471.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+126 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 575.0236 0 ] /Rect [ 77.02362 444.0236 114.8146 454.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+127 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 211 0 R /XYZ 57.02362 575.0236 0 ] /Rect [ 528.8 444.6611 538.252 454.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+128 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 77.02362 427.8236 117.6451 438.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+129 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 428.4611 538.252 438.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+130 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 561.0236 0 ] /Rect [ 77.02362 411.6236 129.9361 421.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+131 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 212 0 R /XYZ 57.02362 561.0236 0 ] /Rect [ 528.8 412.2611 538.252 422.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+132 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 395.4236 125.0661 405.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+133 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 396.0611 538.252 406.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+134 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 584.0236 0 ] /Rect [ 77.02362 379.2236 158.2751 389.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+135 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 584.0236 0 ] /Rect [ 528.8 379.8611 538.252 390.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+136 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 408.0236 0 ] /Rect [ 77.02362 363.0236 141.2666 373.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+137 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 408.0236 0 ] /Rect [ 528.8 363.6611 538.252 373.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+138 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 240.0236 0 ] /Rect [ 77.02362 346.8236 111.0406 357.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+139 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 213 0 R /XYZ 57.02362 240.0236 0 ] /Rect [ 528.8 347.4611 538.252 357.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+140 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 603.0236 0 ] /Rect [ 77.02362 330.6236 111.9841 340.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+141 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 603.0236 0 ] /Rect [ 528.8 331.2611 538.252 341.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+142 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 293.0236 0 ] /Rect [ 77.02362 314.4236 117.6451 324.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+143 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 214 0 R /XYZ 57.02362 293.0236 0 ] /Rect [ 528.8 315.0611 538.252 325.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+144 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 215 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 77.02362 298.2236 129.9361 308.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+145 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 215 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 298.8611 538.252 309.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+146 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 282.0236 139.2441 292.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+147 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 282.6611 538.252 292.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+148 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 596.0236 0 ] /Rect [ 77.02362 265.8236 158.2751 276.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+149 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 596.0236 0 ] /Rect [ 528.8 266.4611 538.252 276.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+150 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 450.0236 0 ] /Rect [ 77.02362 249.6236 154.0081 259.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+151 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 450.0236 0 ] /Rect [ 528.8 250.2611 538.252 260.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+152 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 360.0236 0 ] /Rect [ 77.02362 233.4236 141.2666 243.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+153 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 360.0236 0 ] /Rect [ 528.8 234.0611 538.252 244.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+154 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 312.0236 0 ] /Rect [ 77.02362 217.2236 111.0406 227.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+155 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 217 0 R /XYZ 57.02362 312.0236 0 ] /Rect [ 528.8 217.8611 538.252 228.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+156 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 513.0236 0 ] /Rect [ 77.02362 201.0236 111.9841 211.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+157 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 513.0236 0 ] /Rect [ 528.8 201.6611 538.252 211.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+158 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 173.0236 0 ] /Rect [ 77.02362 184.8236 117.6451 195.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+159 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 218 0 R /XYZ 57.02362 173.0236 0 ] /Rect [ 528.8 185.4611 538.252 195.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+160 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 219 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 77.02362 168.6236 129.9361 178.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+161 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 219 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 528.8 169.2611 538.252 179.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+162 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 57.02362 152.4236 171.3656 162.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+163 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 765.0236 0 ] /Rect [ 528.8 153.0611 538.252 163.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+164 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 678.0236 0 ] /Rect [ 77.02362 136.2236 158.2751 146.4236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+165 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 678.0236 0 ] /Rect [ 528.8 136.8611 538.252 147.0611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+166 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 580.0236 0 ] /Rect [ 77.02362 120.0236 154.0081 130.2236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+167 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 580.0236 0 ] /Rect [ 528.8 120.6611 538.252 130.8611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+168 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 490.0236 0 ] /Rect [ 77.02362 103.8236 141.2666 114.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+169 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 490.0236 0 ] /Rect [ 528.8 104.4611 538.252 114.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+170 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 430.0236 0 ] /Rect [ 77.02362 87.62362 111.0406 97.82362 ] /Subtype /Link /Type /Annot
+>>
+endobj
+171 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 220 0 R /XYZ 57.02362 430.0236 0 ] /Rect [ 528.8 88.26112 538.252 98.46112 ] /Subtype /Link /Type /Annot
+>>
+endobj
+172 0 obj
+<<
+/Annots [ 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R 97 0 R 
+  98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 106 0 R 107 0 R 
+  108 0 R 109 0 R 110 0 R 111 0 R 112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R 
+  118 0 R 119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 125 0 R 126 0 R 127 0 R 
+  128 0 R 129 0 R 130 0 R 131 0 R 132 0 R 133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 
+  138 0 R 139 0 R 140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R 146 0 R 147 0 R 
+  148 0 R 149 0 R 150 0 R 151 0 R 152 0 R 153 0 R 154 0 R 155 0 R 156 0 R 157 0 R 
+  158 0 R 159 0 R 160 0 R 161 0 R 162 0 R 163 0 R 164 0 R 165 0 R 166 0 R 167 0 R 
+  168 0 R 169 0 R 170 0 R 171 0 R ] /Contents 319 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+173 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 221 0 R /XYZ 57.02362 364.0236 0 ] /Rect [ 77.02362 751.8236 111.9841 762.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+174 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 221 0 R /XYZ 57.02362 364.0236 0 ] /Rect [ 528.8 752.4611 538.252 762.6611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+175 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 221 0 R /XYZ 57.02362 208.0236 0 ] /Rect [ 77.02362 735.6236 117.6451 745.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+176 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 221 0 R /XYZ 57.02362 208.0236 0 ] /Rect [ 528.8 736.2611 538.252 746.4611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+177 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 222 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 77.02362 719.4236 129.9361 729.6236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+178 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 222 0 R /XYZ 57.02362 657.0236 0 ] /Rect [ 528.8 720.0611 538.252 730.2611 ] /Subtype /Link /Type /Annot
+>>
+endobj
+179 0 obj
+<<
+/Annots [ 173 0 R 174 0 R 175 0 R 176 0 R 177 0 R 178 0 R ] /Contents 320 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+180 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+181 0 obj
+<<
+/Contents 321 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+182 0 obj
+<<
+/Contents 322 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+183 0 obj
+<<
+/Contents 323 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+184 0 obj
+<<
+/Contents 324 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+185 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+186 0 obj
+<<
+/Contents 325 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+187 0 obj
+<<
+/Contents 326 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+188 0 obj
+<<
+/Contents 327 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+189 0 obj
+<<
+/Contents 328 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+190 0 obj
+<<
+/Contents 329 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+191 0 obj
+<<
+/Contents 330 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+192 0 obj
+<<
+/Contents 331 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+193 0 obj
+<<
+/Contents 332 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+194 0 obj
+<<
+/Contents 333 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+195 0 obj
+<<
+/Contents 334 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+196 0 obj
+<<
+/Contents 335 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+197 0 obj
+<<
+/Contents 336 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+198 0 obj
+<<
+/Contents 337 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+199 0 obj
+<<
+/Contents 338 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+200 0 obj
+<<
+/Contents 339 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+201 0 obj
+<<
+/Contents 340 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+202 0 obj
+<<
+/Contents 341 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+203 0 obj
+<<
+/Contents 342 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+204 0 obj
+<<
+/Contents 343 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+205 0 obj
+<<
+/Contents 344 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+206 0 obj
+<<
+/Contents 345 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+207 0 obj
+<<
+/Contents 346 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+208 0 obj
+<<
+/Contents 347 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+209 0 obj
+<<
+/Contents 348 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+210 0 obj
+<<
+/Contents 349 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+211 0 obj
+<<
+/Contents 350 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+212 0 obj
+<<
+/Contents 351 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+213 0 obj
+<<
+/Contents 352 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+214 0 obj
+<<
+/Contents 353 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+215 0 obj
+<<
+/Contents 354 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+216 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://infocenter.nordicsemi.com/)
+>> /Border [ 0 0 0 ] /Rect [ 367.3736 551.0236 511.8736 563.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+217 0 obj
+<<
+/Annots [ 216 0 R ] /Contents 355 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+218 0 obj
+<<
+/Contents 356 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+219 0 obj
+<<
+/Contents 357 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+220 0 obj
+<<
+/Contents 358 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+221 0 obj
+<<
+/Contents 359 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+222 0 obj
+<<
+/Contents 360 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 316 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+223 0 obj
+<<
+/Outlines 225 0 R /PageLabels 361 0 R /PageMode /UseNone /Pages 316 0 R /Type /Catalog
+>>
+endobj
+224 0 obj
+<<
+/Author () /CreationDate (D:20250325153825-01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250325153825-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (s115 release notes) /Trapped /False
+>>
+endobj
+225 0 obj
+<<
+/Count 101 /First 226 0 R /Last 308 0 R /Type /Outlines
+>>
+endobj
+226 0 obj
+<<
+/Count 1 /Dest [ 5 0 R /XYZ 57.02362 705.0236 0 ] /First 227 0 R /Last 227 0 R /Next 228 0 R /Parent 225 0 R 
+  /Title (Introduction to the s115 release notes)
+>>
+endobj
+227 0 obj
+<<
+/Dest [ 5 0 R /XYZ 57.02362 672.0236 0 ] /Parent 226 0 R /Title (About the document)
+>>
+endobj
+228 0 obj
+<<
+/Count 4 /Dest [ 181 0 R /XYZ 57.02362 765.0236 0 ] /First 229 0 R /Last 232 0 R /Next 233 0 R /Parent 225 0 R 
+  /Prev 226 0 R /Title (s115_9.0.0-1.prototype)
+>>
+endobj
+229 0 obj
+<<
+/Dest [ 181 0 R /XYZ 57.02362 656.0236 0 ] /Next 230 0 R /Parent 228 0 R /Title (SoftDevice properties)
+>>
+endobj
+230 0 obj
+<<
+/Dest [ 181 0 R /XYZ 57.02362 456.0236 0 ] /Next 231 0 R /Parent 228 0 R /Prev 229 0 R /Title (Changes)
+>>
+endobj
+231 0 obj
+<<
+/Dest [ 181 0 R /XYZ 57.02362 148.0236 0 ] /Next 232 0 R /Parent 228 0 R /Prev 230 0 R /Title (Limitations)
+>>
+endobj
+232 0 obj
+<<
+/Dest [ 182 0 R /XYZ 57.02362 489.0236 0 ] /Parent 228 0 R /Prev 231 0 R /Title (Known Issues)
+>>
+endobj
+233 0 obj
+<<
+/Count 4 /Dest [ 184 0 R /XYZ 57.02362 765.0236 0 ] /First 234 0 R /Last 237 0 R /Next 238 0 R /Parent 225 0 R 
+  /Prev 228 0 R /Title (s112_nrf52_7.3.2)
+>>
+endobj
+234 0 obj
+<<
+/Dest [ 184 0 R /XYZ 57.02362 620.0236 0 ] /Next 235 0 R /Parent 233 0 R /Title (SoftDevice properties)
+>>
+endobj
+235 0 obj
+<<
+/Dest [ 184 0 R /XYZ 57.02362 368.0236 0 ] /Next 236 0 R /Parent 233 0 R /Prev 234 0 R /Title (Bug Fixes)
+>>
+endobj
+236 0 obj
+<<
+/Dest [ 184 0 R /XYZ 57.02362 276.0236 0 ] /Next 237 0 R /Parent 233 0 R /Prev 235 0 R /Title (Limitations)
+>>
+endobj
+237 0 obj
+<<
+/Dest [ 186 0 R /XYZ 57.02362 657.0236 0 ] /Parent 233 0 R /Prev 236 0 R /Title (Known Issues)
+>>
+endobj
+238 0 obj
+<<
+/Count 4 /Dest [ 188 0 R /XYZ 57.02362 765.0236 0 ] /First 239 0 R /Last 242 0 R /Next 243 0 R /Parent 225 0 R 
+  /Prev 233 0 R /Title (s112_nrf52_7.3.1)
+>>
+endobj
+239 0 obj
+<<
+/Dest [ 188 0 R /XYZ 57.02362 632.0236 0 ] /Next 240 0 R /Parent 238 0 R /Title (SoftDevice properties)
+>>
+endobj
+240 0 obj
+<<
+/Dest [ 188 0 R /XYZ 57.02362 380.0236 0 ] /Next 241 0 R /Parent 238 0 R /Prev 239 0 R /Title (Bug Fixes)
+>>
+endobj
+241 0 obj
+<<
+/Dest [ 188 0 R /XYZ 57.02362 276.0236 0 ] /Next 242 0 R /Parent 238 0 R /Prev 240 0 R /Title (Limitations)
+>>
+endobj
+242 0 obj
+<<
+/Dest [ 189 0 R /XYZ 57.02362 657.0236 0 ] /Parent 238 0 R /Prev 241 0 R /Title (Known Issues)
+>>
+endobj
+243 0 obj
+<<
+/Count 5 /Dest [ 191 0 R /XYZ 57.02362 765.0236 0 ] /First 244 0 R /Last 248 0 R /Next 249 0 R /Parent 225 0 R 
+  /Prev 238 0 R /Title (s112_nrf52_7.3.0)
+>>
+endobj
+244 0 obj
+<<
+/Dest [ 191 0 R /XYZ 57.02362 620.0236 0 ] /Next 245 0 R /Parent 243 0 R /Title (SoftDevice properties)
+>>
+endobj
+245 0 obj
+<<
+/Dest [ 191 0 R /XYZ 57.02362 368.0236 0 ] /Next 246 0 R /Parent 243 0 R /Prev 244 0 R /Title (New Features)
+>>
+endobj
+246 0 obj
+<<
+/Dest [ 191 0 R /XYZ 57.02362 252.0236 0 ] /Next 247 0 R /Parent 243 0 R /Prev 245 0 R /Title (Bug Fixes)
+>>
+endobj
+247 0 obj
+<<
+/Dest [ 191 0 R /XYZ 57.02362 108.0236 0 ] /Next 248 0 R /Parent 243 0 R /Prev 246 0 R /Title (Limitations)
+>>
+endobj
+248 0 obj
+<<
+/Dest [ 192 0 R /XYZ 57.02362 501.0236 0 ] /Parent 243 0 R /Prev 247 0 R /Title (Known Issues)
+>>
+endobj
+249 0 obj
+<<
+/Count 5 /Dest [ 194 0 R /XYZ 57.02362 765.0236 0 ] /First 250 0 R /Last 254 0 R /Next 255 0 R /Parent 225 0 R 
+  /Prev 243 0 R /Title (s112_nrf52_7.2.1)
+>>
+endobj
+250 0 obj
+<<
+/Dest [ 194 0 R /XYZ 57.02362 604.0236 0 ] /Next 251 0 R /Parent 249 0 R /Title (SoftDevice properties)
+>>
+endobj
+251 0 obj
+<<
+/Dest [ 194 0 R /XYZ 57.02362 352.0236 0 ] /Next 252 0 R /Parent 249 0 R /Prev 250 0 R /Title (New Features)
+>>
+endobj
+252 0 obj
+<<
+/Dest [ 194 0 R /XYZ 57.02362 260.0236 0 ] /Next 253 0 R /Parent 249 0 R /Prev 251 0 R /Title (Bug Fixes)
+>>
+endobj
+253 0 obj
+<<
+/Dest [ 194 0 R /XYZ 57.02362 156.0236 0 ] /Next 254 0 R /Parent 249 0 R /Prev 252 0 R /Title (Limitations)
+>>
+endobj
+254 0 obj
+<<
+/Dest [ 195 0 R /XYZ 57.02362 549.0236 0 ] /Parent 249 0 R /Prev 253 0 R /Title (Known Issues)
+>>
+endobj
+255 0 obj
+<<
+/Count 6 /Dest [ 197 0 R /XYZ 57.02362 765.0236 0 ] /First 256 0 R /Last 261 0 R /Next 262 0 R /Parent 225 0 R 
+  /Prev 249 0 R /Title (s112_nrf52_7.2.0)
+>>
+endobj
+256 0 obj
+<<
+/Dest [ 197 0 R /XYZ 57.02362 620.0236 0 ] /Next 257 0 R /Parent 255 0 R /Title (SoftDevice properties)
+>>
+endobj
+257 0 obj
+<<
+/Dest [ 197 0 R /XYZ 57.02362 368.0236 0 ] /Next 258 0 R /Parent 255 0 R /Prev 256 0 R /Title (New Features)
+>>
+endobj
+258 0 obj
+<<
+/Dest [ 197 0 R /XYZ 57.02362 212.0236 0 ] /Next 259 0 R /Parent 255 0 R /Prev 257 0 R /Title (Changes)
+>>
+endobj
+259 0 obj
+<<
+/Dest [ 198 0 R /XYZ 57.02362 697.0236 0 ] /Next 260 0 R /Parent 255 0 R /Prev 258 0 R /Title (Bug Fixes)
+>>
+endobj
+260 0 obj
+<<
+/Dest [ 198 0 R /XYZ 57.02362 593.0236 0 ] /Next 261 0 R /Parent 255 0 R /Prev 259 0 R /Title (Limitations)
+>>
+endobj
+261 0 obj
+<<
+/Dest [ 198 0 R /XYZ 57.02362 299.0236 0 ] /Parent 255 0 R /Prev 260 0 R /Title (Known Issues)
+>>
+endobj
+262 0 obj
+<<
+/Count 4 /Dest [ 200 0 R /XYZ 57.02362 765.0236 0 ] /First 263 0 R /Last 266 0 R /Next 267 0 R /Parent 225 0 R 
+  /Prev 255 0 R /Title (s112_nrf52_7.1.0)
+>>
+endobj
+263 0 obj
+<<
+/Dest [ 200 0 R /XYZ 57.02362 614.0236 0 ] /Next 264 0 R /Parent 262 0 R /Title (SoftDevice properties)
+>>
+endobj
+264 0 obj
+<<
+/Dest [ 200 0 R /XYZ 57.02362 374.0236 0 ] /Next 265 0 R /Parent 262 0 R /Prev 263 0 R /Title (New functionality)
+>>
+endobj
+265 0 obj
+<<
+/Dest [ 200 0 R /XYZ 57.02362 294.0236 0 ] /Next 266 0 R /Parent 262 0 R /Prev 264 0 R /Title (Limitations)
+>>
+endobj
+266 0 obj
+<<
+/Dest [ 201 0 R /XYZ 57.02362 765.0236 0 ] /Parent 262 0 R /Prev 265 0 R /Title (Known Issues)
+>>
+endobj
+267 0 obj
+<<
+/Count 5 /Dest [ 202 0 R /XYZ 57.02362 765.0236 0 ] /First 268 0 R /Last 272 0 R /Next 273 0 R /Parent 225 0 R 
+  /Prev 262 0 R /Title (s112_nrf52_7.0.1)
+>>
+endobj
+268 0 obj
+<<
+/Dest [ 202 0 R /XYZ 57.02362 596.0236 0 ] /Next 269 0 R /Parent 267 0 R /Title (SoftDevice properties)
+>>
+endobj
+269 0 obj
+<<
+/Dest [ 202 0 R /XYZ 57.02362 344.0236 0 ] /Next 270 0 R /Parent 267 0 R /Prev 268 0 R /Title (Changes)
+>>
+endobj
+270 0 obj
+<<
+/Dest [ 202 0 R /XYZ 57.02362 140.0236 0 ] /Next 271 0 R /Parent 267 0 R /Prev 269 0 R /Title (Bug fixes)
+>>
+endobj
+271 0 obj
+<<
+/Dest [ 203 0 R /XYZ 57.02362 709.0236 0 ] /Next 272 0 R /Parent 267 0 R /Prev 270 0 R /Title (Limitations)
+>>
+endobj
+272 0 obj
+<<
+/Dest [ 203 0 R /XYZ 57.02362 505.0236 0 ] /Parent 267 0 R /Prev 271 0 R /Title (Known Issues)
+>>
+endobj
+273 0 obj
+<<
+/Count 1 /Dest [ 205 0 R /XYZ 57.02362 765.0236 0 ] /First 274 0 R /Last 274 0 R /Next 280 0 R /Parent 225 0 R 
+  /Prev 267 0 R /Title (s112_nrf52_7.0.0 \(Deprecated\))
+>>
+endobj
+274 0 obj
+<<
+/Count -5 /Dest [ 205 0 R /XYZ 57.02362 614.0236 0 ] /First 275 0 R /Last 279 0 R /Parent 273 0 R /Title (SoftDevice properties)
+>>
+endobj
+275 0 obj
+<<
+/Dest [ 205 0 R /XYZ 57.02362 374.0236 0 ] /Next 276 0 R /Parent 274 0 R /Title (New functionality)
+>>
+endobj
+276 0 obj
+<<
+/Dest [ 205 0 R /XYZ 57.02362 279.0236 0 ] /Next 277 0 R /Parent 274 0 R /Prev 275 0 R /Title (Changes)
+>>
+endobj
+277 0 obj
+<<
+/Dest [ 205 0 R /XYZ 57.02362 150.0236 0 ] /Next 278 0 R /Parent 274 0 R /Prev 276 0 R /Title (Bug fixes)
+>>
+endobj
+278 0 obj
+<<
+/Dest [ 206 0 R /XYZ 57.02362 669.0236 0 ] /Next 279 0 R /Parent 274 0 R /Prev 277 0 R /Title (Limitations)
+>>
+endobj
+279 0 obj
+<<
+/Dest [ 206 0 R /XYZ 57.02362 468.0236 0 ] /Parent 274 0 R /Prev 278 0 R /Title (Known Issues)
+>>
+endobj
+280 0 obj
+<<
+/Count 5 /Dest [ 208 0 R /XYZ 57.02362 765.0236 0 ] /First 281 0 R /Last 285 0 R /Next 286 0 R /Parent 225 0 R 
+  /Prev 273 0 R /Title (s112_nrf52_6.1.1)
+>>
+endobj
+281 0 obj
+<<
+/Dest [ 208 0 R /XYZ 57.02362 644.0236 0 ] /Next 282 0 R /Parent 280 0 R /Title (SoftDevice Properties)
+>>
+endobj
+282 0 obj
+<<
+/Dest [ 208 0 R /XYZ 57.02362 428.0236 0 ] /Next 283 0 R /Parent 280 0 R /Prev 281 0 R /Title (Changes)
+>>
+endobj
+283 0 obj
+<<
+/Dest [ 208 0 R /XYZ 57.02362 282.0236 0 ] /Next 284 0 R /Parent 280 0 R /Prev 282 0 R /Title (Bug Fixes)
+>>
+endobj
+284 0 obj
+<<
+/Dest [ 208 0 R /XYZ 57.02362 190.0236 0 ] /Next 285 0 R /Parent 280 0 R /Prev 283 0 R /Title (Limitations)
+>>
+endobj
+285 0 obj
+<<
+/Dest [ 209 0 R /XYZ 57.02362 591.0236 0 ] /Parent 280 0 R /Prev 284 0 R /Title (Known Issues)
+>>
+endobj
+286 0 obj
+<<
+/Count 6 /Dest [ 210 0 R /XYZ 57.02362 765.0236 0 ] /First 287 0 R /Last 292 0 R /Next 293 0 R /Parent 225 0 R 
+  /Prev 280 0 R /Title (s112_nrf52_6.1.0)
+>>
+endobj
+287 0 obj
+<<
+/Dest [ 210 0 R /XYZ 57.02362 644.0236 0 ] /Next 288 0 R /Parent 286 0 R /Title (SoftDevice Properties)
+>>
+endobj
+288 0 obj
+<<
+/Dest [ 210 0 R /XYZ 57.02362 468.0236 0 ] /Next 289 0 R /Parent 286 0 R /Prev 287 0 R /Title (New Functionality)
+>>
+endobj
+289 0 obj
+<<
+/Dest [ 210 0 R /XYZ 57.02362 294.0236 0 ] /Next 290 0 R /Parent 286 0 R /Prev 288 0 R /Title (Changes)
+>>
+endobj
+290 0 obj
+<<
+/Dest [ 211 0 R /XYZ 57.02362 575.0236 0 ] /Next 291 0 R /Parent 286 0 R /Prev 289 0 R /Title (Bug Fixes)
+>>
+endobj
+291 0 obj
+<<
+/Dest [ 212 0 R /XYZ 57.02362 765.0236 0 ] /Next 292 0 R /Parent 286 0 R /Prev 290 0 R /Title (Limitations)
+>>
+endobj
+292 0 obj
+<<
+/Dest [ 212 0 R /XYZ 57.02362 561.0236 0 ] /Parent 286 0 R /Prev 291 0 R /Title (Known Issues)
+>>
+endobj
+293 0 obj
+<<
+/Count 6 /Dest [ 213 0 R /XYZ 57.02362 765.0236 0 ] /First 294 0 R /Last 299 0 R /Next 300 0 R /Parent 225 0 R 
+  /Prev 286 0 R /Title (s112_nrf52_6.0.0)
+>>
+endobj
+294 0 obj
+<<
+/Dest [ 213 0 R /XYZ 57.02362 584.0236 0 ] /Next 295 0 R /Parent 293 0 R /Title (SoftDevice properties)
+>>
+endobj
+295 0 obj
+<<
+/Dest [ 213 0 R /XYZ 57.02362 408.0236 0 ] /Next 296 0 R /Parent 293 0 R /Prev 294 0 R /Title (New functionality)
+>>
+endobj
+296 0 obj
+<<
+/Dest [ 213 0 R /XYZ 57.02362 240.0236 0 ] /Next 297 0 R /Parent 293 0 R /Prev 295 0 R /Title (Changes)
+>>
+endobj
+297 0 obj
+<<
+/Dest [ 214 0 R /XYZ 57.02362 603.0236 0 ] /Next 298 0 R /Parent 293 0 R /Prev 296 0 R /Title (Bug fixes)
+>>
+endobj
+298 0 obj
+<<
+/Dest [ 214 0 R /XYZ 57.02362 293.0236 0 ] /Next 299 0 R /Parent 293 0 R /Prev 297 0 R /Title (Limitations)
+>>
+endobj
+299 0 obj
+<<
+/Dest [ 215 0 R /XYZ 57.02362 765.0236 0 ] /Parent 293 0 R /Prev 298 0 R /Title (Known Issues)
+>>
+endobj
+300 0 obj
+<<
+/Count 7 /Dest [ 217 0 R /XYZ 57.02362 765.0236 0 ] /First 301 0 R /Last 307 0 R /Next 308 0 R /Parent 225 0 R 
+  /Prev 293 0 R /Title (s112_nrf52810_5.1.0)
+>>
+endobj
+301 0 obj
+<<
+/Dest [ 217 0 R /XYZ 57.02362 596.0236 0 ] /Next 302 0 R /Parent 300 0 R /Title (SoftDevice properties)
+>>
+endobj
+302 0 obj
+<<
+/Dest [ 217 0 R /XYZ 57.02362 450.0236 0 ] /Next 303 0 R /Parent 300 0 R /Prev 301 0 R /Title (Device Compatibility)
+>>
+endobj
+303 0 obj
+<<
+/Dest [ 217 0 R /XYZ 57.02362 360.0236 0 ] /Next 304 0 R /Parent 300 0 R /Prev 302 0 R /Title (New functionality)
+>>
+endobj
+304 0 obj
+<<
+/Dest [ 217 0 R /XYZ 57.02362 312.0236 0 ] /Next 305 0 R /Parent 300 0 R /Prev 303 0 R /Title (Changes)
+>>
+endobj
+305 0 obj
+<<
+/Dest [ 218 0 R /XYZ 57.02362 513.0236 0 ] /Next 306 0 R /Parent 300 0 R /Prev 304 0 R /Title (Bug fixes)
+>>
+endobj
+306 0 obj
+<<
+/Dest [ 218 0 R /XYZ 57.02362 173.0236 0 ] /Next 307 0 R /Parent 300 0 R /Prev 305 0 R /Title (Limitations)
+>>
+endobj
+307 0 obj
+<<
+/Dest [ 219 0 R /XYZ 57.02362 657.0236 0 ] /Parent 300 0 R /Prev 306 0 R /Title (Known Issues)
+>>
+endobj
+308 0 obj
+<<
+/Count 7 /Dest [ 220 0 R /XYZ 57.02362 765.0236 0 ] /First 309 0 R /Last 315 0 R /Parent 225 0 R /Prev 300 0 R 
+  /Title (s112_nrf52810_5.1.0-2.alpha)
+>>
+endobj
+309 0 obj
+<<
+/Dest [ 220 0 R /XYZ 57.02362 678.0236 0 ] /Next 310 0 R /Parent 308 0 R /Title (SoftDevice properties)
+>>
+endobj
+310 0 obj
+<<
+/Dest [ 220 0 R /XYZ 57.02362 580.0236 0 ] /Next 311 0 R /Parent 308 0 R /Prev 309 0 R /Title (Device Compatibility)
+>>
+endobj
+311 0 obj
+<<
+/Dest [ 220 0 R /XYZ 57.02362 490.0236 0 ] /Next 312 0 R /Parent 308 0 R /Prev 310 0 R /Title (New functionality)
+>>
+endobj
+312 0 obj
+<<
+/Dest [ 220 0 R /XYZ 57.02362 430.0236 0 ] /Next 313 0 R /Parent 308 0 R /Prev 311 0 R /Title (Changes)
+>>
+endobj
+313 0 obj
+<<
+/Dest [ 221 0 R /XYZ 57.02362 364.0236 0 ] /Next 314 0 R /Parent 308 0 R /Prev 312 0 R /Title (Bug fixes)
+>>
+endobj
+314 0 obj
+<<
+/Dest [ 221 0 R /XYZ 57.02362 208.0236 0 ] /Next 315 0 R /Parent 308 0 R /Prev 313 0 R /Title (Limitations)
+>>
+endobj
+315 0 obj
+<<
+/Dest [ 222 0 R /XYZ 57.02362 657.0236 0 ] /Parent 308 0 R /Prev 314 0 R /Title (Known Issues)
+>>
+endobj
+316 0 obj
+<<
+/Count 44 /Kids [ 5 0 R 87 0 R 172 0 R 179 0 R 181 0 R 182 0 R 183 0 R 184 0 R 186 0 R 187 0 R 
+  188 0 R 189 0 R 190 0 R 191 0 R 192 0 R 193 0 R 194 0 R 195 0 R 196 0 R 197 0 R 
+  198 0 R 199 0 R 200 0 R 201 0 R 202 0 R 203 0 R 204 0 R 205 0 R 206 0 R 207 0 R 
+  208 0 R 209 0 R 210 0 R 211 0 R 212 0 R 213 0 R 214 0 R 215 0 R 217 0 R 218 0 R 
+  219 0 R 220 0 R 221 0 R 222 0 R ] /Type /Pages
+>>
+endobj
+317 0 obj
+<<
+/Length 1808
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 741.0236 cm
+q
+.133333 .133333 .133333 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL (s115 release notes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Introduction to the s115 release notes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (About the document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (These release notes describe the changes in the s115 from version to version.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 594.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The release notes are intended to list all relevant changes in a given version. They are kept brief to make it) Tj T* (easy to get an overview of the changes. More details regarding changes and new features may be found in) Tj T* (the s115 migration document \(normally available for major releases only\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 564.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This document may be updated for an already released version of SoftDevice. The changes will be tagged) Tj T* (with "Update X", where X is a number incremented each time the document has been revised.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 546.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Issue numbers in parentheses are for internal use and should be disregarded by the customer.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 528.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Copyright \251 Nordic Semiconductor ASA. All rights reserved.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 528.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 1) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+318 0 obj
+<<
+/Length 9399
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (Contents) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 90.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 634.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (Introduction to the s115 release notes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 634.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (1) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 618.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (About the document) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 618.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (1) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 602.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s115_9.0.0-1.prototype) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 602.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 586.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 586.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 570 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 570 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 553.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 553.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (5) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 537.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 537.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (6) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 521.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.3.2) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 521.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 67.274 0 Td (8) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 505.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 505.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (8) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 489 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 489 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (8) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 472.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 472.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (8) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 456.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 456.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 67.274 0 Td (9) Tj T* -67.274 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 440.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.3.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 440.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (11) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 424.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 424.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (11) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 408 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 408 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (11) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 391.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 391.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (11) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 375.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 375.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (12) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 359.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.3.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 359.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 343.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 343.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 327 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 327 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 310.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 310.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 294.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 294.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (14) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 278.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 278.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (15) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 262.2 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.2.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 262.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 246 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 246 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 229.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 229.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 213.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 213.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 197.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 197.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (17) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 181.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 181.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (18) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 165 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.2.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 165 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 148.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 148.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 132.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 132.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 116.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 116.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (20) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 100.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 100.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 84 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 84 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 67.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 67.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (21) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 51.6 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 51.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 35.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 35.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 19.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 19.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 3 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (23) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 2) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+319 0 obj
+<<
+/Length 9740
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 84.62362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 667.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 667.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (24) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 651 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.0.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 651 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (25) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 634.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 634.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (25) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 618.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 618.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (25) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 602.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 602.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (25) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 586.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 586.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (26) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 570 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 570 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (26) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 553.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_7.0.0 \(Deprecated\)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 553.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (28) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 537.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 537.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (28) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 521.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_6.1.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 521.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 505.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice Properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 505.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 489 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 489 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 472.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 472.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 456.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 456.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (31) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 440.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 440.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (32) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 424.2 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_6.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 424.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 408 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice Properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 408 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 391.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New Functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 391.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 375.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 375.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (33) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 359.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 359.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (34) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 343.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 343.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 327 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 327 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (35) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 310.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52_6.0.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 310.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 294.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 294.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 278.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 278.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 262.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 262.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (36) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 246 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 246 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (37) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 229.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 229.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (37) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 213.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 213.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (38) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 197.4 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52810_5.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 197.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 181.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 181.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 165 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Device Compatibility) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 165 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 148.8 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 148.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 132.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 132.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (39) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 116.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 116.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (40) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 100.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 100.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (40) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 84 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 84 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (41) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 67.8 cm
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F4 8.5 Tf 0 .4 .6 rg (s112_nrf52810_5.1.0-2.alpha) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 67.8 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F4 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 51.6 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 51.6 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 35.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Device Compatibility) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 35.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 19.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 19.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 3 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (42) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 3) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+320 0 obj
+<<
+/Length 933
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 716.4236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 35.4 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 35.4 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (43) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 19.2 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 19.2 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (43) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 20 1.7 Tm 10.2 TL /F1 8.5 Tf 0 .4 .6 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 409.2283 3 cm
+q
+0 .4 .6 rg
+BT 1 0 0 1 0 1.7 Tm /F1 8.5 Tf 10.2 TL 62.548 0 Td (44) Tj T* -62.548 0 Td ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 716.4236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 4) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+321 0 obj
+<<
+/Length 8886
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s115_9.0.0-1.prototype) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This version is a major release, providing support for nRF54L series devices.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 708.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This release has changed the API. This requires changes to applications.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_7.3.2.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 668.0236 cm
+Q
+q
+1 0 0 1 57.02362 638.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF54L15.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 608.0236 cm
+Q
+q
+1 0 0 1 57.02362 490.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (NVM: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (4.9 kB) Tj /F1 10 Tf ( \(0x1380 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.8 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 484.0236 cm
+Q
+q
+1 0 0 1 57.02362 472.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x30D2.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 468.0236 cm
+Q
+q
+1 0 0 1 57.02362 438.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 426.0236 cm
+Q
+q
+1 0 0 1 57.02362 426.0236 cm
+Q
+q
+1 0 0 1 57.02362 164.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 247 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 247 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 241 cm
+Q
+q
+1 0 0 1 23 241 cm
+Q
+q
+1 0 0 1 23 217 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The function ) Tj /F5 10 Tf (sd_flash_page_erase) Tj /F1 10 Tf ( has been removed for devices that do not require page) Tj T* (erase before write.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 211 cm
+Q
+q
+1 0 0 1 23 199 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The function ) Tj /F5 10 Tf (sd_flash_protect) Tj /F1 10 Tf ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 193 cm
+Q
+q
+1 0 0 1 23 181 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The function ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 163 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The function ) Tj /F5 10 Tf (sd_power_pof_thresholdvddh_set) Tj /F1 10 Tf ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 157 cm
+Q
+q
+1 0 0 1 23 133 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The functions ) Tj /F5 10 Tf (sd_power_ram_power_set) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_power_ram_power_clr) Tj /F1 10 Tf (, and) Tj T* /F5 10 Tf (sd_power_ram_power_get) Tj /F1 10 Tf ( have been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 127 cm
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The functions ) Tj /F5 10 Tf (sd_power_dcdc_mode_set) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (sd_power_dcdc_mode_get) Tj /F1 10 Tf ( have been) Tj T* (removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 73 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The functions ) Tj /F5 10 Tf (sd_power_reset_reason_get) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (sd_power_reset_reason_clr) Tj /F1 10 Tf ( have been) Tj T* (removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The function ) Tj /F5 10 Tf (sd_power_system_off) Tj /F1 10 Tf ( has been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (The functions ) Tj /F5 10 Tf (sd_ppi_channel_enable_get) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ppi_channel_enable_set) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (sd_ppi_channel_enable_clr) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ppi_channel_assign) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ppi_group_task_enable) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (sd_ppi_group_task_disable) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ppi_group_assign) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (sd_ppi_group_get) Tj /F1 10 Tf ( have) Tj T* (been removed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 160.0236 cm
+Q
+q
+1 0 0 1 57.02362 130.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 118.0236 cm
+Q
+q
+1 0 0 1 57.02362 118.0236 cm
+Q
+q
+1 0 0 1 57.02362 100.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 5) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+322 0 obj
+<<
+/Length 9117
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 557.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 195 Tm  T* ET
+q
+1 0 0 1 23 181 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 151 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 145 cm
+Q
+q
+1 0 0 1 23 109 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 103 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Configuring multiple connection configurations \(see ) Tj /F3 10 Tf (ble_conn_cfg_t::conn_cfg_tag) Tj /F1 10 Tf (\) is not) Tj T* (supported \(DRGN-23839\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 551.0236 cm
+Q
+q
+1 0 0 1 57.02362 505.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification, there shall be no secondary service that is not) Tj T* (referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 501.0236 cm
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 459.0236 cm
+Q
+q
+1 0 0 1 57.02362 459.0236 cm
+Q
+q
+1 0 0 1 57.02362 371.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 73 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 73 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The Radio Notification signal is not yet supported. The function) Tj T* /F5 10 Tf (sd_radio_notification_cfg_set) Tj /F1 10 Tf ( must not be used \(DRGN-24324\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The API functions in ) Tj /F5 10 Tf (nrf_nvic.h) Tj /F1 10 Tf ( that operate on interrupts are not yet supported. This includes) Tj T* (the functions ) Tj /F5 10 Tf (sd_nvic_critical_region_enter) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (sd_nvic_critical_region_exit) Tj /F1 10 Tf  T* (\(DRGN-23477\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 365.0236 cm
+Q
+q
+1 0 0 1 57.02362 331.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (L2CAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Receiving fragmented L2CAP packets is not yet supported \(DRGN-23305\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 325.0236 cm
+Q
+q
+1 0 0 1 57.02362 183.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 127 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 127 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 121 cm
+Q
+q
+1 0 0 1 23 121 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the Peer Preferred Connection Parameters Characteristic \(PPCP\) contains "No specific values) Tj T* (indication \(0xFFFF\)", application should not perform a peripheral initiated connection parameter) Tj T* (update using PPCP. Otherwise invalid values will be used in) Tj T* /F5 10 Tf (L2CAP_CONNECTION_PARAMETER_UPDATE_REQ) Tj /F1 10 Tf (. A workaround is to always specify the) Tj T* (connection parameters in the ) Tj /F5 10 Tf (sd_ble_gap_conn_param_update) Tj /F1 10 Tf ( call \(DRGN-15111\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LE Secure Connections are not yet supported \(DRGN-23305\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 177.0236 cm
+Q
+q
+1 0 0 1 57.02362 143.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (ATT MTU size greater than 23 octets is not yet supported \(DRGN-23305\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 137.0236 cm
+Q
+q
+1 0 0 1 57.02362 91.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Queued Writes are not yet supported. Receiving the ) Tj /F5 10 Tf (ATT_PREPARE_WRITE_REQ) Tj /F1 10 Tf ( PDU will lead to) Tj T* (assert \(DRGN-23848\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 85.02362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 6) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+323 0 obj
+<<
+/Length 2416
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 647.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 86 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing. When the application has called) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf  T* (\(DRGN-11300\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 641.0236 cm
+Q
+q
+1 0 0 1 57.02362 583.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 579.0236 cm
+Q
+q
+1 0 0 1 57.02362 579.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 7) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+324 0 obj
+<<
+/Length 8431
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.3.2) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The only change in this version compared to the s112_nrf52_7.3.1 version is that it fixes an issue where the) Tj T* (SoftDevice might not process a packet correctly if all host header bytes were not in the first LL fragment on) Tj T* (air.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.3.1.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible with the s112_nrf52_7.3.1, and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 632.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820, and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 560.0236 cm
+Q
+q
+1 0 0 1 57.02362 526.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 520.0236 cm
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xEB8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.8 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 396.0236 cm
+Q
+q
+1 0 0 1 57.02362 384.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0xFFFE.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 292.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice might not process a packet correctly if all host header bytes) Tj T* (were not in the first LL fragment on air \(DRGN-22138\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 288.0236 cm
+Q
+q
+1 0 0 1 57.02362 258.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 246.0236 cm
+Q
+q
+1 0 0 1 57.02362 246.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 156.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 156.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 150.3307 cm
+Q
+q
+1 0 0 1 23 150.3307 cm
+Q
+q
+1 0 0 1 23 126.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 120.3307 cm
+Q
+q
+1 0 0 1 23 96.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 90.33071 cm
+Q
+q
+1 0 0 1 23 54.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 48.33071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 30.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 6.330709 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 8) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+325 0 obj
+<<
+/Length 8514
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 23 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 719.0236 cm
+Q
+q
+1 0 0 1 57.02362 673.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v5.2, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 669.0236 cm
+Q
+q
+1 0 0 1 57.02362 639.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 557.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 551.0236 cm
+Q
+q
+1 0 0 1 57.02362 365.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 140.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (When running on nRF52820 using ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf ( API can lead to undefined) Tj T* (behavior \(DRGN-12447\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 134.4 cm
+Q
+q
+1 0 0 1 23 86.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. A workaround is to remove the) Tj T* (device address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 80.4 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 64.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). It can be fixed by editing) Tj T* /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 434.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 359.6236 cm
+Q
+q
+1 0 0 1 57.02362 139.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 139 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the Peer Preferred Connection Parameters Characteristic \(PPCP\) contains "No specific values) Tj T* (indication \(0xFFFF\)", application should not perform a peripheral initiated connection parameter) Tj T* (update using PPCP. Otherwise invalid values will be used in) Tj T* /F5 10 Tf (L2CAP_CONNECTION_PARAMETER_UPDATE_REQ) Tj /F1 10 Tf (. A workaround is to always specify the) Tj T* (connection parameters in the ) Tj /F5 10 Tf (sd_ble_gap_conn_param_update) Tj /F1 10 Tf ( call \(DRGN-15111\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 97 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 91 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf ( configuration parameter is not functional.) Tj T* (The application should set it to ) Tj /F5 10 Tf (BLE_GAP_ADV_SET_COUNT_DEFAULT) Tj /F1 10 Tf ( when configuring the role) Tj T* (count \(DRGN-14113\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 133.6236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37.93071 cm
+Q
+q
+1 0 0 1 23 37.93071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 7.930709 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 230.7692 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 9) Tj T* -230.7692 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+326 0 obj
+<<
+/Length 1950
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 689.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 63 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 59 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing. When the application has called) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf  T* (\(DRGN-11300\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 683.0236 cm
+Q
+q
+1 0 0 1 57.02362 625.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 621.0236 cm
+Q
+q
+1 0 0 1 57.02362 621.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 10) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+327 0 obj
+<<
+/Length 8488
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.3.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The only change of this version compared to the s112_nrf52_7.3.0 version is that it fixes an issue where the) Tj T* (slave waited for a link to time out when tearing down the connection.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.3.0.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible with the s112_nrf52_7.3.0, and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 644.0236 cm
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+Q
+q
+1 0 0 1 57.02362 578.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820, and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 572.0236 cm
+Q
+q
+1 0 0 1 57.02362 538.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 532.0236 cm
+Q
+q
+1 0 0 1 57.02362 414.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xEB8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.8 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 408.0236 cm
+Q
+q
+1 0 0 1 57.02362 396.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x0165.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 392.0236 cm
+Q
+q
+1 0 0 1 57.02362 362.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+Q
+q
+1 0 0 1 57.02362 292.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the slave waited for a link to time out when tearing down the connection.) Tj T* -0.091547 Tw (This happened when the central would acknowledge ) Tj /F5 10 Tf (TERMINATE_IND) Tj /F1 10 Tf ( in the same event as it was) Tj T* 0 Tw (being sent \(DRGN-21637\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 288.0236 cm
+Q
+q
+1 0 0 1 57.02362 258.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 246.0236 cm
+Q
+q
+1 0 0 1 57.02362 246.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 156.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 156.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 150.3307 cm
+Q
+q
+1 0 0 1 23 150.3307 cm
+Q
+q
+1 0 0 1 23 126.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 120.3307 cm
+Q
+q
+1 0 0 1 23 96.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 90.33071 cm
+Q
+q
+1 0 0 1 23 54.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 48.33071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 30.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 6.330709 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 11) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+328 0 obj
+<<
+/Length 8515
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 23 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 719.0236 cm
+Q
+q
+1 0 0 1 57.02362 673.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v5.2, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 669.0236 cm
+Q
+q
+1 0 0 1 57.02362 639.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 557.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 551.0236 cm
+Q
+q
+1 0 0 1 57.02362 365.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 140.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (When running on nRF52820 using ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf ( API can lead to undefined) Tj T* (behavior \(DRGN-12447\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 134.4 cm
+Q
+q
+1 0 0 1 23 86.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. A workaround is to remove the) Tj T* (device address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 80.4 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 64.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). It can be fixed by editing) Tj T* /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 434.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 359.6236 cm
+Q
+q
+1 0 0 1 57.02362 139.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 139 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the Peer Preferred Connection Parameters Characteristic \(PPCP\) contains "No specific values) Tj T* (indication \(0xFFFF\)", application should not perform a peripheral initiated connection parameter) Tj T* (update using PPCP. Otherwise invalid values will be used in) Tj T* /F5 10 Tf (L2CAP_CONNECTION_PARAMETER_UPDATE_REQ) Tj /F1 10 Tf (. A workaround is to always specify the) Tj T* (connection parameters in the ) Tj /F5 10 Tf (sd_ble_gap_conn_param_update) Tj /F1 10 Tf ( call \(DRGN-15111\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 97 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 91 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf ( configuration parameter is not functional.) Tj T* (The application should set it to ) Tj /F5 10 Tf (BLE_GAP_ADV_SET_COUNT_DEFAULT) Tj /F1 10 Tf ( when configuring the role) Tj T* (count \(DRGN-14113\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 133.6236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37.93071 cm
+Q
+q
+1 0 0 1 23 37.93071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 7.930709 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 12) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+329 0 obj
+<<
+/Length 1950
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 689.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 63 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 59 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing. When the application has called) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf  T* (\(DRGN-11300\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 683.0236 cm
+Q
+q
+1 0 0 1 57.02362 625.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 621.0236 cm
+Q
+q
+1 0 0 1 57.02362 621.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 13) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+330 0 obj
+<<
+/Length 8342
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.3.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The main new feature of this version compared to the s112_nrf52_7.2.1 version is the possibility for the) Tj T* (application to configure the slave to wake up every connection event if it detects that the master is not) Tj T* (receiving its packets.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.2.1.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible with the s112_nrf52_7.2.1, and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 632.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820, and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 560.0236 cm
+Q
+q
+1 0 0 1 57.02362 526.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 520.0236 cm
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xEB8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.8 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 396.0236 cm
+Q
+q
+1 0 0 1 57.02362 384.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x0126.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 268.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A new option named ) Tj /F5 10 Tf (BLE_GAP_SLAVE_LATENCY_WAIT_FOR_ACK) Tj /F1 10 Tf ( is available to the application.) Tj T* -0.058508 Tw (This can be used to configure the slave to wake up every connection event if it has not received an) Tj T* 0 Tw (ACK from the master for at least the length of the slave latency events. This configuration may) Tj T* (increase the power consumption in environments with a lot of radio activity \(DRGN-15555\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+Q
+q
+1 0 0 1 57.02362 234.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 222.0236 cm
+Q
+q
+1 0 0 1 57.02362 222.0236 cm
+Q
+q
+1 0 0 1 57.02362 176.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the last advertising event within the configured advertising duration may end) Tj T* (with sending a packet without listening for a ) Tj /F5 10 Tf (CONNECT_IND) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (SCAN_REQ) Tj /F1 10 Tf ( packet \(DRGN-15484\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 170.0236 cm
+Q
+q
+1 0 0 1 57.02362 124.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the application might not receive a ) Tj /F5 10 Tf (BLE_GAP_EVT_DISCONNECTED) Tj /F1 10 Tf ( event if) Tj T* (the application does not continuously pull events from the SoftDevice \(DRGN-15619\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 120.0236 cm
+Q
+q
+1 0 0 1 57.02362 90.02362 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 78.02362 cm
+Q
+q
+1 0 0 1 57.02362 78.02362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 14) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+331 0 obj
+<<
+/Length 8503
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 569.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 181 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 181 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 151 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 145 cm
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 563.0236 cm
+Q
+q
+1 0 0 1 57.02362 517.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v5.2, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 513.0236 cm
+Q
+q
+1 0 0 1 57.02362 483.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+Q
+q
+1 0 0 1 57.02362 401.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 395.0236 cm
+Q
+q
+1 0 0 1 57.02362 209.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 170.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 140.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (When running on nRF52820 using ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf ( API can lead to undefined) Tj T* (behavior \(DRGN-12447\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 134.4 cm
+Q
+q
+1 0 0 1 23 86.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. A workaround is to remove the) Tj T* (device address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 80.4 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 64.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). It can be fixed by editing) Tj T* /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 434.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 203.6236 cm
+Q
+q
+1 0 0 1 57.02362 80.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 107.9307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 107.9307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 101.9307 cm
+Q
+q
+1 0 0 1 23 101.9307 cm
+Q
+q
+1 0 0 1 23 41.93071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the Peer Preferred Connection Parameters Characteristic \(PPCP\) contains "No specific values) Tj T* (indication \(0xFFFF\)", application should not perform a peripheral initiated connection parameter) Tj T* (update using PPCP. Otherwise invalid values will be used in) Tj T* /F5 10 Tf (L2CAP_CONNECTION_PARAMETER_UPDATE_REQ) Tj /F1 10 Tf (. A workaround is to always specify the) Tj T* (connection parameters in the ) Tj /F5 10 Tf (sd_ble_gap_conn_param_update) Tj /F1 10 Tf ( call \(DRGN-15111\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 35.93071 cm
+Q
+q
+1 0 0 1 23 -0.069291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 15) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+332 0 obj
+<<
+/Length 3717
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 671.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 81 Tm  T* ET
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf ( configuration parameter is not functional.) Tj T* (The application should set it to ) Tj /F5 10 Tf (BLE_GAP_ADV_SET_COUNT_DEFAULT) Tj /F1 10 Tf ( when configuring the role) Tj T* (count \(DRGN-14113\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 665.0236 cm
+Q
+q
+1 0 0 1 57.02362 547.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 86 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing. When the application has called) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf  T* (\(DRGN-11300\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 541.0236 cm
+Q
+q
+1 0 0 1 57.02362 483.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 479.0236 cm
+Q
+q
+1 0 0 1 57.02362 479.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 16) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+333 0 obj
+<<
+/Length 8641
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.2.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The main new features of this version compared to the s112_nrf52_7.2.0 version are:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 720.0236 cm
+Q
+q
+1 0 0 1 57.02362 720.0236 cm
+Q
+q
+1 0 0 1 57.02362 708.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The application can configure CCCD permission for the service change characteristic.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixing an issue where the high duty cycle advertiser did not connect successfully.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 686.0236 cm
+Q
+q
+1 0 0 1 57.02362 668.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 662.0236 cm
+Q
+q
+1 0 0 1 57.02362 662.0236 cm
+Q
+q
+1 0 0 1 57.02362 650.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.2.0.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 644.0236 cm
+Q
+q
+1 0 0 1 57.02362 620.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible with the s112_nrf52_7.2.0 and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 616.0236 cm
+Q
+q
+1 0 0 1 57.02362 586.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 574.0236 cm
+Q
+q
+1 0 0 1 57.02362 574.0236 cm
+Q
+q
+1 0 0 1 57.02362 550.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820 and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 544.0236 cm
+Q
+q
+1 0 0 1 57.02362 510.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 504.0236 cm
+Q
+q
+1 0 0 1 57.02362 386.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xEB8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.75 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+Q
+q
+1 0 0 1 57.02362 368.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x0119.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 364.0236 cm
+Q
+q
+1 0 0 1 57.02362 334.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 322.0236 cm
+Q
+q
+1 0 0 1 57.02362 322.0236 cm
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The application can configure CCCD permission for the Service Changed characteristic, using) Tj T* /F5 10 Tf (BLE_GATTS_CFG_SERVICE_CHANGED_CCCD_PERM) Tj /F1 10 Tf ( \(DRGN-15034\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 272.0236 cm
+Q
+q
+1 0 0 1 57.02362 242.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 230.0236 cm
+Q
+q
+1 0 0 1 57.02362 230.0236 cm
+Q
+q
+1 0 0 1 57.02362 172.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Fixed an issue where the high duty cycle advertiser did not always connect successfully if the RC) Tj T* (was used as the source for the LFCLK, and the peer didn't initiate the connection fast enough) Tj T* (\(DRGN-15003\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 168.0236 cm
+Q
+q
+1 0 0 1 57.02362 138.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 126.0236 cm
+Q
+q
+1 0 0 1 57.02362 126.0236 cm
+Q
+q
+1 0 0 1 57.02362 80.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 30.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 30.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 24.33071 cm
+Q
+q
+1 0 0 1 23 24.33071 cm
+Q
+q
+1 0 0 1 23 .330709 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 17) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+334 0 obj
+<<
+/Length 8496
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 617.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 135 Tm  T* ET
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 611.0236 cm
+Q
+q
+1 0 0 1 57.02362 565.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v5.2, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 561.0236 cm
+Q
+q
+1 0 0 1 57.02362 531.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 519.0236 cm
+Q
+q
+1 0 0 1 57.02362 519.0236 cm
+Q
+q
+1 0 0 1 57.02362 449.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 443.0236 cm
+Q
+q
+1 0 0 1 57.02362 215.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 212.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 212.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 206.4 cm
+Q
+q
+1 0 0 1 23 206.4 cm
+Q
+q
+1 0 0 1 23 170.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 RG
+n 127.27 28.5 m 173.96 28.5 l S
+BT 1 0 0 1 0 26 Tm 12 TL /F4 10 Tf 0 0 0 rg (Update 1:) Tj /F1 10 Tf ( When running on ) Tj (nRF52811) Tj ( nRF52820, using ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf  T* (API can lead to undefined behavior \(DRGN-12447\). The previous version of these release notes) Tj T* (stated an incorrect board.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 164.4 cm
+Q
+q
+1 0 0 1 23 140.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 RG
+n 48.34 16.5 m 402.98 16.5 l S
+n 0 4.5 m 111.14 4.5 l S
+BT 1 0 0 1 0 14 Tm 12 TL /F4 10 Tf 0 0 0 rg (Update 1:) Tj /F1 10 Tf ( ) Tj (When running on nRF52811, using sd_power_usb_* APIs can lead to undefined) Tj T* (behavior \(DRGN-12720\).) Tj ( This is now documented in the API.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 134.4 cm
+Q
+q
+1 0 0 1 23 86.4 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. A workaround is to remove the) Tj T* (device address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 80.4 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 64.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). It can be fixed by editing) Tj T* /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 434.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 209.6236 cm
+Q
+q
+1 0 0 1 57.02362 84.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 110.6 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 110.6 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 104.6 cm
+Q
+q
+1 0 0 1 23 104.6 cm
+Q
+q
+1 0 0 1 23 44.6 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the Peer Preferred Connection Parameters Characteristic \(PPCP\) contains "No specific values) Tj T* (indication \(0xFFFF\)", application should not perform a peripheral initiated connection parameter) Tj T* (update using PPCP. Otherwise invalid values will be used in) Tj T* /F5 10 Tf (L2CAP_CONNECTION_PARAMETER_UPDATE_REQ) Tj /F1 10 Tf (. A workaround is to always specify the) Tj T* (connection parameters in the ) Tj /F5 10 Tf (sd_ble_gap_conn_param_update) Tj /F1 10 Tf ( call \(DRGN-15111\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 38.6 cm
+Q
+q
+1 0 0 1 23 2.6 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 18) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+335 0 obj
+<<
+/Length 3722
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 671.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 81 Tm  T* ET
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf ( configuration parameter is not functional.) Tj T* (The application should set it to ) Tj /F5 10 Tf (BLE_GAP_ADV_SET_COUNT_DEFAULT) Tj /F1 10 Tf ( when configuring the role) Tj T* (count \(DRGN-14113\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 665.0236 cm
+Q
+q
+1 0 0 1 57.02362 559.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 69 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 74 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if the) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing \(DRGN-11300\). When the) Tj T* (application has called ) Tj /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 553.0236 cm
+Q
+q
+1 0 0 1 57.02362 495.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 491.0236 cm
+Q
+q
+1 0 0 1 57.02362 491.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 19) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+336 0 obj
+<<
+/Length 8216
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.2.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The main new features of this version compared to the s112_nrf52_7.0.1 version is the efficient discovery of) Tj T* (128-bit UUIDs, and access to the USB power registers. This release makes 8dBm tx power available on) Tj T* (nRF52820.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.0.1.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible with the s112_nrf52_7.0.1, and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 632.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 590.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820 and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 560.0236 cm
+Q
+q
+1 0 0 1 57.02362 526.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 520.0236 cm
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xEB8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.75 kB) Tj /F1 10 Tf ( \(0x700 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 396.0236 cm
+Q
+q
+1 0 0 1 57.02362 384.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x0103.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+Q
+q
+1 0 0 1 57.02362 350.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New Features) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 338.0236 cm
+Q
+q
+1 0 0 1 57.02362 280.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (128-bit UUIDs can be discovered more efficiently by enabling the ) Tj /F5 10 Tf (BLE_GATTC_OPT_UUID_DISC) Tj /F1 10 Tf  T* (option. This option enables the automatic insertion of discovered 128-bit UUIDs to the Vendor) Tj T* (Specific UUID table \(DRGN-9653\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 274.0236 cm
+Q
+q
+1 0 0 1 57.02362 228.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (API for reading USB power register and USB power events have been added to this variant of the) Tj T* (SoftDevice. See the API documentation for ) Tj /F5 10 Tf (sd_power_usb_*) Tj /F1 10 Tf ( \(DRGN-14468\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 224.0236 cm
+Q
+q
+1 0 0 1 57.02362 194.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 182.0236 cm
+Q
+q
+1 0 0 1 57.02362 182.0236 cm
+Q
+q
+1 0 0 1 57.02362 124.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (For nRF52820 the ) Tj /F5 10 Tf (sd_ble_gap_tx_power_set\(\)) Tj /F1 10 Tf ( is extended to support a bigger range of) Tj T* (radio output power levels. The highest possible radio output power level is now +8dBm) Tj T* (\(DRGN-14449\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 118.0236 cm
+Q
+q
+1 0 0 1 57.02362 100.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 20) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+337 0 obj
+<<
+/Length 7880
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 713.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 39 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (The slave accepts an ) Tj /F5 10 Tf (LL_REJECT_IND) Tj /F1 10 Tf ( as a valid response to an ) Tj /F5 10 Tf (LL_PHY_UPDATE_REQ) Tj /F1 10 Tf ( for) Tj T* (aborting a self-initiated PHY update procedure. This change was added to improve the) Tj T* (interoperability with devices not conforming to the Bluetooth Specification when aborting the PHY) Tj T* (update procedure \(DRGN-14193\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 709.0236 cm
+Q
+q
+1 0 0 1 57.02362 679.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 667.0236 cm
+Q
+q
+1 0 0 1 57.02362 667.0236 cm
+Q
+q
+1 0 0 1 57.02362 609.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the peripheral raised a ) Tj /F5 10 Tf (BLE_GAP_EVT_CONN_PARAM_UPDATE) Tj /F1 10 Tf ( event) Tj T* (delayed by 30 s. This was happening when the connection parameter update resulted in the) Tj T* (already active parameters for the link \(DRGN-9865\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 605.0236 cm
+Q
+q
+1 0 0 1 57.02362 575.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 563.0236 cm
+Q
+q
+1 0 0 1 57.02362 563.0236 cm
+Q
+q
+1 0 0 1 57.02362 367.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 181 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 181 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 175 cm
+Q
+q
+1 0 0 1 23 151 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 145 cm
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the Bluetooth LE) Tj T* (stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications must not modify the SEVONPEND flag in the SCR register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 62 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events when connected, based on peer actions, meaning) Tj T* (without previous action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event,) Tj T* (for instance, is generated when a connected peer sends a Phy Update Request, even when an) Tj T* (application does not include logic to change PHY. There are several such events that may require) Tj T* (action from an application if they are received. For more information, see the ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf  T* (API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 361.0236 cm
+Q
+q
+1 0 0 1 57.02362 315.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v5.2, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 311.0236 cm
+Q
+q
+1 0 0 1 57.02362 281.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 269.0236 cm
+Q
+q
+1 0 0 1 57.02362 269.0236 cm
+Q
+q
+1 0 0 1 57.02362 199.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 193.0236 cm
+Q
+q
+1 0 0 1 57.02362 91.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 87 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 87 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 81 cm
+Q
+q
+1 0 0 1 23 81 cm
+Q
+q
+1 0 0 1 23 57 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (When running on nRF52820, using ) Tj /F5 10 Tf (sd_protected_register_write) Tj /F1 10 Tf ( API can lead to) Tj T* (undefined behavior \(DRGN-12447\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 51 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. A workaround is to remove the) Tj T* (device address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 21) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+338 0 obj
+<<
+/Length 5526
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 681.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 70.4 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 64.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). It can be fixed by editing) Tj T* /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 431.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 675.6236 cm
+Q
+q
+1 0 0 1 57.02362 521.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 139 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 139 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 97 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (BLE_GAP_EVT_SEC_INFO_REQUEST) Tj /F1 10 Tf ( event will not report the identity address of the peer to) Tj T* (the application. A workaround is to do a mapping of the connection handle to the peer's identity) Tj T* (address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 91 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_cfg_role_count_t::adv_set_count) Tj /F1 10 Tf ( configuration parameter is not functional.) Tj T* (The application should set it to ) Tj /F5 10 Tf (BLE_GAP_ADV_SET_COUNT_DEFAULT) Tj /F1 10 Tf ( when configuring the role) Tj T* (count \(DRGN-14113\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 515.6236 cm
+Q
+q
+1 0 0 1 57.02362 397.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 81 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 86 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing. When the application has called) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf  T* (\(DRGN-11300\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 391.6236 cm
+Q
+q
+1 0 0 1 57.02362 333.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\)) Tj /F1 10 Tf (, it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 329.6236 cm
+Q
+q
+1 0 0 1 57.02362 329.6236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 22) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+339 0 obj
+<<
+/Length 8627
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This is a production release that only adds one new feature to the 7.0.1 release.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (For some combinations of SoftDevice and nRF52 IC, only Bluetooth Core Specification v5.1 qualified listings) Tj T* (are available with corresponding QDIDs from v7.0.1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+Q
+q
+1 0 0 1 57.02362 672.0236 cm
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_7.0.1.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+Q
+q
+1 0 0 1 57.02362 630.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible to the s112_nrf52_7.0.1 and memory requirements have not) Tj T* (changed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+Q
+q
+1 0 0 1 57.02362 572.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811 and nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 532.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 526.0236 cm
+Q
+q
+1 0 0 1 57.02362 408.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xeb8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.5 kB) Tj /F1 10 Tf ( \(0x600 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+Q
+q
+1 0 0 1 57.02362 390.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00D6.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 386.0236 cm
+Q
+q
+1 0 0 1 57.02362 356.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 344.0236 cm
+Q
+q
+1 0 0 1 57.02362 344.0236 cm
+Q
+q
+1 0 0 1 57.02362 310.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Added a new options API to enable a callback before every radio event \(DRGN-12903\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 306.0236 cm
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+Q
+q
+1 0 0 1 57.02362 158.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197/FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 152.0236 cm
+Q
+q
+1 0 0 1 57.02362 106.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 102.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 23) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+340 0 obj
+<<
+/Length 5769
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 747.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 665.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 659.0236 cm
+Q
+q
+1 0 0 1 57.02362 481.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 163 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 163 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 157 cm
+Q
+q
+1 0 0 1 23 157 cm
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The BLE_GAP_EVT_SEC_INFO_REQUEST event will not report the identity address of the peer) Tj T* (to the application. This issue was also present in previous releases. A workaround is to do a) Tj T* (mapping of the connection handle to the peer's identity address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 50 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. This issue was present also in) Tj T* -0.121203 Tw (previous releases. A workaround is to set the IRK to zero or to remove the device address from the) Tj T* 0 Tw (device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 475.0236 cm
+Q
+q
+1 0 0 1 57.02362 369.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 69 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 74 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing \(DRGN-11300\). When the) Tj T* (application has called ) Tj /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 363.0236 cm
+Q
+q
+1 0 0 1 57.02362 305.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\),) Tj /F1 10 Tf ( it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 301.0236 cm
+Q
+q
+1 0 0 1 57.02362 301.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 24) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+341 0 obj
+<<
+/Length 8347
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.0.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This is a production release that contains minor, backward compatible, changes to the 7.0.0 release.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (For some combinations of SoftDevice and nRF52 IC, only Bluetooth Core Specification v5.1 qualified listings) Tj T* (are available with corresponding QDIDs from v7.0.1.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Updating to this version from v7.0.0 is recommended.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since the s112_nrf52_7.0.0 release.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+Q
+q
+1 0 0 1 57.02362 612.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible to the s112_nrf52_7.0.0 and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 608.0236 cm
+Q
+q
+1 0 0 1 57.02362 578.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 542.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811, nRF52820 and) Tj T* (nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 536.0236 cm
+Q
+q
+1 0 0 1 57.02362 502.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 496.0236 cm
+Q
+q
+1 0 0 1 57.02362 378.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xeb8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevic e is ) Tj /F4 10 Tf (1.75 kB) Tj /F1 10 Tf ( \(0x700 bytes\) . Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 372.0236 cm
+Q
+q
+1 0 0 1 57.02362 360.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00CD.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 356.0236 cm
+Q
+q
+1 0 0 1 57.02362 326.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 314.0236 cm
+Q
+q
+1 0 0 1 57.02362 314.0236 cm
+Q
+q
+1 0 0 1 57.02362 220.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 79 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Bluetooth Core Specification v5.1 compatibility \(DRGN-12400\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The VersNr field in the LL_VERSION_IND packet now contains the value 0x0A to indicate) Tj T* (Bluetooth Core Specification v 5.1 compatibility \(DRGN-12466\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.034478 Tw (References to Errata are added to the documentation of all the events and APIs which report RSSI) Tj T* 0 Tw (and should be observed if using RSSI measurements.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 214.0236 cm
+Q
+q
+1 0 0 1 57.02362 156.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Bluetooth Core Specification Erratum #10818 is incorporated, allow HCI ACL data packets with) Tj T* (0-length payload, but do not transmit anything until receiving the next non-zero continuation) Tj T* (fragment \(DRGN-11430\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 152.0236 cm
+Q
+q
+1 0 0 1 57.02362 122.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 110.0236 cm
+Q
+q
+1 0 0 1 57.02362 110.0236 cm
+Q
+q
+1 0 0 1 57.02362 92.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 25) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+342 0 obj
+<<
+/Length 8437
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the time scheduled for a flash write or flash page erase using) Tj T* /F5 10 Tf (sd_flash_write) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_flash_page_erase) Tj /F1 10 Tf ( APIs on nRF52811 will be longer than required) Tj T* (and the same as for nRF52832 \(DRGN-12539\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 721.0236 cm
+Q
+q
+1 0 0 1 57.02362 691.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 679.0236 cm
+Q
+q
+1 0 0 1 57.02362 679.0236 cm
+Q
+q
+1 0 0 1 57.02362 573.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(DRGN-5197/FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 567.0236 cm
+Q
+q
+1 0 0 1 57.02362 521.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 517.0236 cm
+Q
+q
+1 0 0 1 57.02362 487.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 475.0236 cm
+Q
+q
+1 0 0 1 57.02362 475.0236 cm
+Q
+q
+1 0 0 1 57.02362 405.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 399.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 309.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 309.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 303.3307 cm
+Q
+q
+1 0 0 1 23 303.3307 cm
+Q
+q
+1 0 0 1 23 267.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The BLE_GAP_EVT_SEC_INFO_REQUEST event will not report the identity address of the peer) Tj T* (to the application. This issue was also present in previous releases. A workaround is to do a) Tj T* (mapping of the connection handle to the peer's identity address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 261.3307 cm
+Q
+q
+1 0 0 1 23 213.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 207.3307 cm
+Q
+q
+1 0 0 1 23 147.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 50 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* (enabled and the local device address is set to a public address. This issue was present also in) Tj T* -0.121203 Tw (previous releases. A workaround is to set the IRK to zero or to remove the device address from the) Tj T* 0 Tw (device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 141.3307 cm
+Q
+q
+1 0 0 1 23 81.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice may generate several events, when connected, based on peer actions, i.e. without) Tj T* (prior action from the application. The ) Tj /F5 10 Tf (BLE_GAP_EVT_PHY_UPDATE_REQUEST) Tj /F1 10 Tf ( event, for instance,) Tj T* (will be generated when a connected peer sends a Phy Update Request, even when an application) Tj T* (does not include logic to change phy. There are several such events that may require action from) Tj T* (an application if they are received. For more details check sd_ble_enable\(\) API in SoftDevice.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 75.33071 cm
+Q
+q
+1 0 0 1 23 15 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 45.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The following issue was previously mistakenly removed from the release notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 3.330709 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). This issue was present also in) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 26) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+343 0 obj
+<<
+/Length 3151
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 705.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 46.4 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 42.4 Tm  T* ET
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (previous releases. It can be fixed by editing ) Tj /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it) Tj T* (becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 431.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 699.6236 cm
+Q
+q
+1 0 0 1 57.02362 593.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 69 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 74 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing \(DRGN-11300\). When the) Tj T* (application has called ) Tj /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 587.6236 cm
+Q
+q
+1 0 0 1 57.02362 529.6236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If the application adds an all zeroes IRK with the ) Tj /F5 10 Tf (sd_ble_gap_device_identities_set\(\),) Tj /F1 10 Tf ( it) Tj T* (will be treated as a valid entry in the device identity list. An all zeroes IRK is invalid and must not) Tj T* (be added \(DRGN-9083\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 525.6236 cm
+Q
+q
+1 0 0 1 57.02362 525.6236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 27) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+344 0 obj
+<<
+/Length 9037
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_7.0.0 \(Deprecated\)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The main new feature of this version compared to the s112_nrf52_6.1.1 is the ability to configure the) Tj T* (inclusion of the Central Address Resolution \(CAR\) and Peripheral Preferred Connection Parameters \(PPCP\)) Tj T* (characteristics.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 678.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This release has changed the API. This requires applications to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The memory requirements of the s112 SoftDevice have changed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 630.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52_6.1.1.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+Q
+q
+1 0 0 1 57.02362 572.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice variant is compatible with nRF52805, nRF52810, nRF52811 and nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 532.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 526.0236 cm
+Q
+q
+1 0 0 1 57.02362 408.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.7 kB) Tj /F1 10 Tf ( \(0xeb8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Call stack: The SoftDevice uses a call stack combined with the application. The worst-case stack) Tj T* (usage for the SoftDevice is ) Tj /F4 10 Tf (1.5 kB) Tj /F1 10 Tf ( \(0x600 bytes\). Application writers should ensure that enough) Tj T* (stack space is reserved to cover the worst-case SoftDevice call stack usage combined with the) Tj T* (worst-case application call stack usage.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 402.0236 cm
+Q
+q
+1 0 0 1 57.02362 390.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00C4.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 386.0236 cm
+Q
+q
+1 0 0 1 57.02362 359.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 347.0236 cm
+Q
+q
+1 0 0 1 57.02362 347.0236 cm
+Q
+q
+1 0 0 1 57.02362 295.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (API to obtain the next connection event counter \(DRGN-10913\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (API for inclusion configuration of the CAR and PPCP characteristics \(DRGN-10874\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 291.0236 cm
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 252.0236 cm
+Q
+q
+1 0 0 1 57.02362 252.0236 cm
+Q
+q
+1 0 0 1 57.02362 218.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Removed macros defining PPI channels and groups available to the application \(DRGN-10382\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 212.0236 cm
+Q
+q
+1 0 0 1 57.02362 166.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The API for configuring improved advertiser role scheduling is removed. The SoftDevice now uses) Tj T* (the improved scheduling configuration by default \(DRGN-10754\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 162.0236 cm
+Q
+q
+1 0 0 1 57.02362 135.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 123.0236 cm
+Q
+q
+1 0 0 1 57.02362 123.0236 cm
+Q
+q
+1 0 0 1 57.02362 80.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 27.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 27.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 21.33071 cm
+Q
+q
+1 0 0 1 23 21.33071 cm
+Q
+q
+1 0 0 1 23 -2.669291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where utilizing the MWU on nRF52832 would lead to undefined behavior) Tj T* (\(DRGN-10917\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 28) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+345 0 obj
+<<
+/Length 8720
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 737.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 15 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the application would be blocked when requesting an earliest possible Radio) Tj T* (Timeslot \(DRGN-10402\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 731.0236 cm
+Q
+q
+1 0 0 1 57.02362 685.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the slave might disconnect if many packets where lost and there was an) Tj T* (ongoing Connection Parameter Update \(DRGN-11147\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 681.0236 cm
+Q
+q
+1 0 0 1 57.02362 654.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 536.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 530.0236 cm
+Q
+q
+1 0 0 1 57.02362 484.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 480.0236 cm
+Q
+q
+1 0 0 1 57.02362 453.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 441.0236 cm
+Q
+q
+1 0 0 1 57.02362 441.0236 cm
+Q
+q
+1 0 0 1 57.02362 371.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (When copying the Bootloader on the nRF52805 or nRF52811 using the) Tj T* /F5 10 Tf (SD_MBR_COMMAND_COPY_BL) Tj /F1 10 Tf ( MBR command, the MBR will not write-protect itself. This does not) Tj T* (change the behavior of the MBR or DFU process as the MBR cannot be configured to overwrite) Tj T* (itself \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 365.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 275.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 275.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 269.3307 cm
+Q
+q
+1 0 0 1 23 269.3307 cm
+Q
+q
+1 0 0 1 23 233.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The time scheduled for a flash write or flash page erase using ) Tj /F5 10 Tf (sd_flash_write) Tj /F1 10 Tf ( or) Tj T* /F5 10 Tf (sd_flash_page_erase) Tj /F1 10 Tf ( APIs on nRF52805 or nRF52811 will be longer than required and the) Tj T* (same as for nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 227.3307 cm
+Q
+q
+1 0 0 1 23 191.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The BLE_GAP_EVT_SEC_INFO_REQUEST event will not report the identity address of the peer) Tj T* (to the application. This issue was also present in previous releases. A workaround is to do a) Tj T* (mapping of the connection handle to the peer's identity address \(DRGN-10340\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 185.3307 cm
+Q
+q
+1 0 0 1 23 137.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 131.3307 cm
+Q
+q
+1 0 0 1 23 39.93071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 76.4 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 28.4 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (A memory access fault \() Tj /F5 10 Tf (NRF_FAULT_ID_APP_MEMACC) Tj /F1 10 Tf (\) can occur in) Tj T* /F5 10 Tf (sd_nvic_critical_region_exit\(\)) Tj /F1 10 Tf ( if a high priority SoftDevice interrupt occurs during a) Tj T* (critical section, for example due to radio traffic \(DRGN-10613\). This issue was present also in) Tj T* (previous releases. It can be fixed by editing ) Tj /F5 10 Tf (__NRF_NVIC_SD_IRQS_1) Tj /F1 10 Tf ( in nrf_nvic.h so that it) Tj T* (becomes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+n -6 -6 431.0283 22.2 re S
+Q
+q
+BT 1 0 0 1 0 1.7 Tm 10.2 TL /F6 8.5 Tf .8 0 0 rg (#define __NRF_NVIC_SD_IRQS_1 \(\(uint32_t\)\(1U ) Tj (<) Tj (<) Tj ( \(MWU_IRQn - 32\)\)\)) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 33.93071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 15.93071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 3.930709 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 29) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+346 0 obj
+<<
+/Length 2132
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 23 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (if privacy is not enabled and the local device address is set to a public address. This issue was) Tj T* (present also in previous releases. A workaround is to set the IRK to zero or to remove the device) Tj T* (address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 719.0236 cm
+Q
+q
+1 0 0 1 57.02362 613.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTC) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 69 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 74 Tm 12 TL /F1 10 Tf 0 0 0 rg (The ) Tj /F5 10 Tf (ble_gattc_service_t::uuid) Tj /F1 10 Tf ( field is incorrectly populated in the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event if) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\)) Tj /F1 10 Tf ( is called when) Tj T* (a Primary Service Discovery by Service UUID is already ongoing \(DRGN-11300\). When the) Tj T* (application has called ) Tj /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf (, it should wait for the) Tj T* /F5 10 Tf (BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP) Tj /F1 10 Tf ( event before calling) Tj T* /F5 10 Tf (sd_ble_gattc_primary_services_discover\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gattc_read\(\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 609.0236 cm
+Q
+q
+1 0 0 1 57.02362 609.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 30) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+347 0 obj
+<<
+/Length 8102
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_6.1.1) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This is a production release that contains minor but important changes to the 6.1.0 release.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 708.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since the s112_nrf52_6.1.0 release.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible to the s112_nrf52_6.1.0 and memory requirements have not) Tj T* (changed. Applications are therefore not required to be recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 656.0236 cm
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice Properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice is production tested for nRF52810 and nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice variant is production tested for nRF52811.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 578.0236 cm
+Q
+q
+1 0 0 1 57.02362 544.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.4.1 \(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This MBR version is compatible with previous MBR versions.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 538.0236 cm
+Q
+q
+1 0 0 1 57.02362 444.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 79 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are the same as for the) Tj T* (s112_nrf52_6.1.0:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.86 kB) Tj /F1 10 Tf ( \(0xF70 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00B8.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 440.0236 cm
+Q
+q
+1 0 0 1 57.02362 410.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 398.0236 cm
+Q
+q
+1 0 0 1 57.02362 398.0236 cm
+Q
+q
+1 0 0 1 57.02362 298.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 85 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The MBR 2.4.1 is a minor backward compatible configuration update of the MBR for this release.) Tj T* (There were no bugs resolved in this update, only minor build configuration option changes) Tj T* (\(DRGN-10680\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Applications can improve the radio utilization for multiprotocol applications by enabling the) Tj T* (improved advertiser role scheduling configuration through the BLE Option API. The time reserved) Tj T* (for an advertising event will then be decreased by up to 1.3 ms \(DRGN-10398\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 294.0236 cm
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 252.0236 cm
+Q
+q
+1 0 0 1 57.02362 252.0236 cm
+Q
+q
+1 0 0 1 57.02362 206.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where NRF_TIMER0 may not be reset at the start of a radio timeslot) Tj T* (\(DRGN-10650\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 202.0236 cm
+Q
+q
+1 0 0 1 57.02362 172.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 160.0236 cm
+Q
+q
+1 0 0 1 57.02362 160.0236 cm
+Q
+q
+1 0 0 1 57.02362 90.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MBR) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (When copying the Bootloader on the nRF52811 using the MBR command,) Tj T* (SD_MBR_COMMAND_COPY_BL, flash is not protected using the BPROT peripheral. This does) Tj T* (not change the behavior of the MBR or DFU process as the MBR cannot be configured to) Tj T* (overwrite itself. \(DRGN-11287\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 84.02362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 31) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+348 0 obj
+<<
+/Length 5803
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 659.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 653.0236 cm
+Q
+q
+1 0 0 1 57.02362 607.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 603.0236 cm
+Q
+q
+1 0 0 1 57.02362 573.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 561.0236 cm
+Q
+q
+1 0 0 1 57.02362 561.0236 cm
+Q
+q
+1 0 0 1 57.02362 329.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 217 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 217 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 211 cm
+Q
+q
+1 0 0 1 23 211 cm
+Q
+q
+1 0 0 1 23 163 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate enough space for the device name before calling ) Tj /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf  T* (\(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 157 cm
+Q
+q
+1 0 0 1 23 109 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (If the application requests an earliest possible Radio Timeslot and the timeslot is blocked, the) Tj T* (SoftDevice will repeat the same request until it times out, thereby blocking the main context and) Tj T* (the lower application interrupt priority levels. A workaround is to increase the timeout of the Radio) Tj T* (Timeslot request to make it able to fit after the event that is blocking the request \(DRGN-10402\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 103 cm
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The application should not enable MWU if the SoftDevice is run on nRF52832 as this leads to) Tj T* (undefined behavior \(DRGN-10917\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 57 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 62 Tm /F1 10 Tf 12 TL (The SoftDevice will generate a resolvable address for the TargetA field in directed advertisements) Tj T* (if the target device address is in the device identity list with a non-zero IRK, even if privacy is not) Tj T* -0.128921 Tw (enabled and the local device address is set to a public address. This can make devices certified for) Tj T* 0 Tw (Bluetooth versions older than 4.2 ignore the advertising packets. This issue is present in) Tj T* -0.060092 Tw (SoftDevice versions 3.0.0 and later. A workaround is to set the IRK to zero or to remove the device) Tj T* 0 Tw (address from the device identity list \(DRGN-10659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 325.0236 cm
+Q
+q
+1 0 0 1 57.02362 325.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 32) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+349 0 obj
+<<
+/Length 8610
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_6.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 726.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The s112_nrf52_6.1.0 is the first S112 SoftDevice to support both nRF52810 and nRF52832.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 708.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 702.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since the s112_nrf52_6.0.0 release.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 684.0236 cm
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice is binary compatible to the s112_nrf52_6.0.0. Applications are therefore not required to) Tj T* (be recompiled and memory requirements have not changed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 656.0236 cm
+Q
+q
+1 0 0 1 57.02362 626.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice Properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+Q
+q
+1 0 0 1 57.02362 614.0236 cm
+Q
+q
+1 0 0 1 57.02362 602.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice is production tested for nRF52810 and nRF52832.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+Q
+q
+1 0 0 1 57.02362 584.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice contains the Master Boot Record \(MBR\) version 2.2.2 \(DRGN-9537\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 578.0236 cm
+Q
+q
+1 0 0 1 57.02362 502.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are the same as for the) Tj T* (s112_nrf52_6.0.0:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.86 kB) Tj /F1 10 Tf ( \(0xF70 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 496.0236 cm
+Q
+q
+1 0 0 1 57.02362 484.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00B0.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 480.0236 cm
+Q
+q
+1 0 0 1 57.02362 450.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New Functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 438.0236 cm
+Q
+q
+1 0 0 1 57.02362 438.0236 cm
+Q
+q
+1 0 0 1 57.02362 362.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The SoftDevice variant, flash usage, reserved PPIs, and reserved interrupt priorities are now) Tj T* (available at compile time to the application through new APIs \(DRGN-9627\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (An API is added to enable the application to remove an unused UUID entry from the UUID table) Tj T* (\(DRGN-10389\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 356.0236 cm
+Q
+q
+1 0 0 1 57.02362 310.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (With the new ) Tj /F5 10 Tf (sd_ble_gap_adv_addr_get\(\)) Tj /F1 10 Tf ( API, the application can now get the Bluetooth) Tj T* (device address that is being used by the advertiser \(DRGN-10470\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 306.0236 cm
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+Q
+q
+1 0 0 1 57.02362 264.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 174.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 174.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 168.3307 cm
+Q
+q
+1 0 0 1 23 168.3307 cm
+Q
+q
+1 0 0 1 23 132.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (On nRF52810, the time reserved by the SoftDevice is reduced by 297 \265s when performing a flash) Tj T* (word write, and by 4.7 ms when performing a flash page erase. This increases the probability of) Tj T* (successfully scheduled flash operations \(DRGN-9048\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 126.3307 cm
+Q
+q
+1 0 0 1 23 114.3307 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Improved documentation for the ) Tj /F5 10 Tf (NRF_ERROR_INVALID_STATE) Tj /F1 10 Tf ( error code \(DRGN-9693\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 108.3307 cm
+Q
+q
+1 0 0 1 23 60.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (When the SoftDevice is acting as a peripheral, and the RC oscillator is used as the LFCLK source,) Tj T* (the configured RC calibration period can now be increased. By default, the SoftDevice will now) Tj T* (increase the receive window if two consecutive packets are missed and will then perform RC) Tj T* (calibration if necessary \(DRGN-9852\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 54.33071 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 36.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 12.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (SoftDevice 112_nrf52_6.0.0 accepted an advertising interval larger than) Tj T* (BLE_GAP_ADV_INTERVAL_MAX as an experimental feature. However, this configuration could) Tj T* (make the SoftDevice assert. Now, the SoftDevice will return NRF_ERROR_INVALID_PARAM if) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 33) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+350 0 obj
+<<
+/Length 8881
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 707.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 45 Tm  T* ET
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 11 Tm  T* ET
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (the application configures an advertising interval larger than BLE_GAP_ADV_INTERVAL_MAX) Tj T* (\(DRGN-10322\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.080127 Tw (Radio utilization for multi-protocol applications are improved significantly as the time allocated for a) Tj T* 0 Tw (normal Radio Timeslot request session has decreased by up to 1 ms \(DRGN-10405\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 701.0236 cm
+Q
+q
+1 0 0 1 57.02362 643.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gatts_rw_authorize_reply\(\)) Tj /F1 10 Tf ( now allows sending the 0xFC \(Write Request) Tj T* (Rejected\) profile error code which was introduced in the Bluetooth Core Specification Supplement) Tj T* (CSSv7 \(DRGN-10373\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 637.0236 cm
+Q
+q
+1 0 0 1 57.02362 591.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Instead of disconnecting, the SoftDevice will now respond with LL_UNKNOWN_RSP when) Tj T* (receiving control procedure PDUs with invalid lengths \(DRGN-9997\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 587.0236 cm
+Q
+q
+1 0 0 1 57.02362 557.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug Fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 545.0236 cm
+Q
+q
+1 0 0 1 57.02362 545.0236 cm
+Q
+q
+1 0 0 1 57.02362 307.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 223 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 223 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 217 cm
+Q
+q
+1 0 0 1 23 217 cm
+Q
+q
+1 0 0 1 23 193 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where a HardFault could generate a new HardFault if the application called a NULL) Tj T* (pointer \(DRGN-9607\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 187 cm
+Q
+q
+1 0 0 1 23 163 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice HardFault handler could hang if the application wrote to) Tj T* (protected memory \(DRGN-9694\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 157 cm
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Fixed an issue where the HFXO would sometimes not be released properly after RC calibration.) Tj T* (This is in addition to the bug fix for a similar condition resolved in s112_nrf52_6.0.0 \(DRGN-9920,) Tj T* (DRGN-10166\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Fixed an issue where the PA/LNA GPIOs could be triggered too late. Furthermore, the PA pin is) Tj T* (now set active 23 \265s before RADIO TX start, instead of 5 \265s before RADIO TX start. The LNA pin) Tj T* (is set active 5 \265s before RADIO RX start, as before \(DRGN-9928\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed documentation for ) Tj /F5 10 Tf (SD_EVT_IRQHandler) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (RADIO_NOTIFICATION_IRQHandler) Tj /F1 10 Tf (,) Tj T* (where the default interrupt priority was documented incorrectly \(DRGN-10174\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue where LFRC oscillator calibration could fail \(DRGN-10255\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue that could make the SoftDevice assert when scheduling events close together) Tj T* (\(DRGN-10316\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 301.0236 cm
+Q
+q
+1 0 0 1 57.02362 183.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the advertiser would not update its address type if) Tj T* /F5 10 Tf (sd_ble_gap_addr_set\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gap_privacy_set\(\)) Tj /F1 10 Tf ( was called after) Tj T* /F5 10 Tf (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf ( and before ) Tj /F5 10 Tf (sd_ble_gap_adv_start\(\)) Tj /F1 10 Tf  T* (\(DRGN-10025\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue that could cause an assert when an advertiser configured with invalid parameters) Tj T* (connected to a peer \(DRGN-10355\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue that could cause an assert when the advertiser was stopped \(DRGN-10364\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 177.0236 cm
+Q
+q
+1 0 0 1 57.02362 113.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue that could cause links to disconnect \(DRGN-9844\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the slave might not listen during the entire connection parameter update) Tj T* (\(DRGN-10086\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 109.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 34) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+351 0 obj
+<<
+/Length 4731
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 747.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 629.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 623.0236 cm
+Q
+q
+1 0 0 1 57.02362 577.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 573.0236 cm
+Q
+q
+1 0 0 1 57.02362 543.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 531.0236 cm
+Q
+q
+1 0 0 1 57.02362 531.0236 cm
+Q
+q
+1 0 0 1 57.02362 395.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 121 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( may return ) Tj /F5 10 Tf (NRF_ERROR_INTERNAL) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (NRF_ERROR_NO_MEM) Tj /F1 10 Tf ( if the allocated space for the device name is too small. A workaround is to) Tj T* (allocate large enough space for the device name before calling) Tj T* /F5 10 Tf (sd_ble_gap_device_name_set\(\)) Tj /F1 10 Tf ( \(DRGN-10195\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 50 Tm /F1 10 Tf 12 TL (If the application requests an earliest possible Radio Timeslot and the timeslot is blocked, the) Tj T* (SoftDevice will repeat the same request until it times out, thereby blocking the main context and) Tj T* (the lower application interrupt priority levels. A possible workaround is to increase the timeout of) Tj T* (the Radio Timeslot request to make it able to fit after the event that is blocking the request) Tj T* (\(DRGN-10402\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 391.0236 cm
+Q
+q
+1 0 0 1 57.02362 391.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 35) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+352 0 obj
+<<
+/Length 9041
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52_6.0.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 714.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The main new feature of s112_nrf52_6.0.0 compared to s112_nrf52810_5.1.0 is channel information in the) Tj T* (Received Signal Strength Indication \(RSSI\) reports.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 696.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+Q
+q
+1 0 0 1 57.02362 666.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This release has changed the Application Programmer Interface \(API\). This requires applications to be) Tj T* (recompiled.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The memory requirements of the S112 SoftDevice have changed.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+Q
+q
+1 0 0 1 57.02362 630.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The release notes list changes since s112_nrf52810_5.1.0.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 624.0236 cm
+Q
+q
+1 0 0 1 57.02362 600.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The SoftDevice release naming convention has changed: Instead of specifying the platform supported) Tj T* (by the SoftDevice in the release name, the release notes will have this information.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 554.0236 cm
+Q
+q
+1 0 0 1 57.02362 554.0236 cm
+Q
+q
+1 0 0 1 57.02362 530.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This SoftDevice variant is production tested for nRF52810. It can be used on nRF52832 for) Tj T* (development purposes.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 524.0236 cm
+Q
+q
+1 0 0 1 57.02362 512.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This version of the SoftDevice contains the Master Boot Record \(MBR\) version 2.2.2 \(DRGN-9537\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 506.0236 cm
+Q
+q
+1 0 0 1 57.02362 442.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100.0 kB) Tj /F1 10 Tf ( \(0x19000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.86 kB) Tj /F1 10 Tf ( \(0xF70 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 436.0236 cm
+Q
+q
+1 0 0 1 57.02362 424.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The Firmware ID of this SoftDevice is 0x00A7.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 420.0236 cm
+Q
+q
+1 0 0 1 57.02362 390.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 378.0236 cm
+Q
+q
+1 0 0 1 57.02362 378.0236 cm
+Q
+q
+1 0 0 1 57.02362 332.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The SoftDevice API for advertising and scanning is updated and prepared to support future) Tj T* (features. For more information, see the migration document \(DRGN-9712\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 326.0236 cm
+Q
+q
+1 0 0 1 57.02362 256.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Channel number for RSSI measurement is now available in advertising reports \(DRGN-9473\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Channel number for RSSI measurement is now available for connections \(DRGN-9667\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The SoftDevice now supports the configuration of TX power per link and per role \(DRGN-6659\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 252.0236 cm
+Q
+q
+1 0 0 1 57.02362 222.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 210.0236 cm
+Q
+q
+1 0 0 1 57.02362 210.0236 cm
+Q
+q
+1 0 0 1 57.02362 92.02362 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 73 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice now returns ) Tj /F5 10 Tf (NRF_ERROR_BUSY) Tj /F1 10 Tf ( from flash API functions until the event generated) Tj T* (after a previous flash operation has been pulled \(DRGN-9565\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice now has an additional API for write-protecting memory. This can now be achieved) Tj T* (by accessing the BPROT peripheral configuration registers through) Tj T* /F5 10 Tf (sd_protected_register_write\(\)) Tj /F1 10 Tf ( \(DRGN-9337\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (A message sequence chart for Unexpected Security Packet Reception has been added to) Tj T* (Peripheral Security Procedures in the API documentation \(DRGN-9479\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 86.02362 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 36) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+353 0 obj
+<<
+/Length 8994
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 689.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice will now return ) Tj /F5 10 Tf (NRF_ERROR_TIMEOUT) Tj /F1 10 Tf ( instead of ) Tj /F5 10 Tf (NRF_ERROR_BUSY) Tj /F1 10 Tf ( from GATT) Tj T* (API functions if a GATT procedure is blocked due to a previous procedure timeout \(DRGN-9545\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Clarified API documentation: The length field in the parameter struct passed to) Tj T* /F5 10 Tf (sd_ble_gatts_hvx\(\)) Tj /F1 10 Tf ( may be written to by the SoftDevice \(DRGN-9620\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 683.0236 cm
+Q
+q
+1 0 0 1 57.02362 619.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The documentation of the PHY Update procedure is improved \(DRGN-9678\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Bluetooth Core Specification Erratum #7408 is incorporated, meaning that it is now accepted to) Tj T* (receive an LL_UNKNOWN_RSP during encryption procedure \(DRGN-8414\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 615.0236 cm
+Q
+q
+1 0 0 1 57.02362 585.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 573.0236 cm
+Q
+q
+1 0 0 1 57.02362 573.0236 cm
+Q
+q
+1 0 0 1 57.02362 497.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where ) Tj /F5 10 Tf (sd_ble_gap_rssi_get\(\)) Tj /F1 10 Tf ( could sometimes return ) Tj /F5 10 Tf (NRF_ERROR_SUCCESS) Tj /F1 10 Tf  T* (with an invalid RSSI \(DRGN-9746\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the HFXO would sometimes not be released properly after RC calibration) Tj T* (\(DRGN-9920\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 491.0236 cm
+Q
+q
+1 0 0 1 57.02362 445.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice could drop a write request if it was received at the same time) Tj T* (as a write command \(DRGN-9709\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 439.0236 cm
+Q
+q
+1 0 0 1 57.02362 309.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 115 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 115 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 73 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the slave could disconnect with status code) Tj T* /F5 10 Tf (BLE_HCI_DIFFERENT_TRANSACTION_COLLISION) Tj /F1 10 Tf ( if master sent an ) Tj /F5 10 Tf (LL_UNKNOWN_RSP) Tj /F1 10 Tf ( after a) Tj T* (PHY procedure collision \(DRGN-9870\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice might advertise with the RxAdd bit set to 1 for undirected) Tj T* (advertisements. According to the Bluetooth Core Specification v 5.0, the RxAdd bit is reserved for) Tj T* (future use for these PDU types \(DRGN-9739\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice could assert if the identity list was used while advertising) Tj T* (\(DRGN-9723\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 305.0236 cm
+Q
+q
+1 0 0 1 57.02362 275.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 263.0236 cm
+Q
+q
+1 0 0 1 57.02362 263.0236 cm
+Q
+q
+1 0 0 1 57.02362 157.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 91 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 85 cm
+Q
+q
+1 0 0 1 23 61 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 55 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 151.0236 cm
+Q
+q
+1 0 0 1 57.02362 105.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 101.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 37) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+354 0 obj
+<<
+/Length 1717
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 747.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 735.0236 cm
+Q
+q
+1 0 0 1 57.02362 647.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 73 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 73 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 67 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If the application calls a NULL pointer, there will be a HardFault inside the SoftDevice HardFault) Tj T* (handler \(DRGN-9607\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (If ) Tj /F5 10 Tf (sd_ble_gap_addr_set\(\)) Tj /F1 10 Tf ( or ) Tj /F5 10 Tf (sd_ble_gap_privacy_set\(\)) Tj /F1 10 Tf ( is called after) Tj T* /F5 10 Tf (sd_ble_gap_adv_set_configure\(\)) Tj /F1 10 Tf ( and before ) Tj /F5 10 Tf (sd_ble_gap_adv_start\(\)) Tj /F1 10 Tf (, the advertiser) Tj T* (will not update its address type \(DRGN-10025\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 643.0236 cm
+Q
+q
+1 0 0 1 57.02362 643.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 38) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+355 0 obj
+<<
+/Length 8043
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52810_5.1.0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (This release is the first production version of the S112. The S112 is a size-optimized peripheral-only BLE) Tj T* (SoftDevice for Nordic Semiconductor's nRF52810 chip. The S112 API is a compatible subset of the S132) Tj T* (SoftDevice API. For features that are common to S112 and S132, the API is the same. To show the API) Tj T* (compatibility, the S112 follows the same version numbering as S132.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The main change relative to the s112_nrf52810_5.1.0-2.alpha is that the observer role functionality is) Tj T* (removed from the SoftDevice. The SoftDevice also has some minor updates and bug fixes.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 642.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Notes:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+Q
+q
+1 0 0 1 57.02362 636.0236 cm
+Q
+q
+1 0 0 1 57.02362 612.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (The priority of SoftDevice interrupts SD_EVT_IRQn \(SWI2_IRQn\) and RADIO_NOTIFICATION_IRQn) Tj T* (\(SWI3_IRQn\) is 6. This is different from S132 4.x and previous SoftDevices \(DRGN-9245\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 608.0236 cm
+Q
+q
+1 0 0 1 57.02362 578.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 566.0236 cm
+Q
+q
+1 0 0 1 57.02362 554.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The S112 SoftDevice Specification document will be available at ) Tj 0 .4 .6 rg (http://infocenter.nordicsemi.com/) Tj 0 0 0 rg ( .) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 548.0236 cm
+Q
+q
+1 0 0 1 57.02362 536.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This version of the SoftDevice contains the Master Boot Record \(MBR\) version 2.2.2 \(DRGN-9537\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 530.0236 cm
+Q
+q
+1 0 0 1 57.02362 466.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (96 kB) Tj /F1 10 Tf ( \(0x18000 bytes\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.68 kB) Tj /F1 10 Tf ( \(0xeb8 bytes\). This is the minimum required memory. The actual requirements) Tj T* (depend on the configuration chosen at ) Tj /F5 10 Tf (sd_ble_enable\(\)) Tj /F1 10 Tf ( time.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 462.0236 cm
+Q
+q
+1 0 0 1 57.02362 432.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Device Compatibility) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 414.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The SoftDevice is built, production tested, and qualified for use with nRF52810.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 372.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The SoftDevice is not production tested and qualified for use with nRF52832. However, the SoftDevice can) Tj T* (be used for development purposes on the nRF52832 if minor performance and stability issues are accepted) Tj T* (during development.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 342.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 324.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This release has no new features compared to the s112_nrf52810_5.1.0-2.alpha.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 294.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Relative to the s112_nrf52810_5.1.0-2.alpha:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 270.0236 cm
+Q
+q
+1 0 0 1 57.02362 270.0236 cm
+Q
+q
+1 0 0 1 57.02362 74.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 180.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 180.3307 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 174.3307 cm
+Q
+q
+1 0 0 1 23 174.3307 cm
+Q
+q
+1 0 0 1 23 18.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 141 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 129 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Observer role is no longer supported, and the following functions, structures, defines, and events) Tj T* (have been removed \(DRGN-9298\):) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 123 cm
+Q
+q
+1 0 0 1 23 123 cm
+Q
+q
+1 0 0 1 23 111 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (BLE_GAP_EVT_ADV_REPORT) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 105 cm
+Q
+q
+1 0 0 1 23 93 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (BLE_GAP_TIMEOUT_SRC_SCAN) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 87 cm
+Q
+q
+1 0 0 1 23 75 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_GAP_SCAN_INTERVAL_MIN) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_GAP_SCAN_INTERVAL_MAX) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 69 cm
+Q
+q
+1 0 0 1 23 57 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_GAP_SCAN_WINDOW_MIN,) Tj ( ) Tj (BLE_GAP_SCAN_WINDOW_MAX) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 51 cm
+Q
+q
+1 0 0 1 23 39 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_GAP_SCAN_TIMEOUT_MIN,) Tj ( ) Tj (BLE_GAP_SCAN_TIMEOUT_MAX) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 33 cm
+Q
+q
+1 0 0 1 23 21 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (ble_gap_scan_params_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 15 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (ble_gap_evt_adv_report_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 39) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+356 0 obj
+<<
+/Length 9465
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 727.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 25 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 21 Tm  T* ET
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (sd_ble_gap_scan_start\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (sd_ble_gap_scan_stop\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 721.0236 cm
+Q
+q
+1 0 0 1 57.02362 675.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SoftDevice now sends ) Tj /F5 10 Tf (LL_REJECT_EXT_IND) Tj /F1 10 Tf ( instead of ) Tj /F5 10 Tf (LL_REJECT_IND) Tj /F1 10 Tf ( if the peer has) Tj T* (indicated support for ) Tj /F5 10 Tf (LL_REJECT_EXT_IND) Tj /F1 10 Tf ( \(DRGN-9539\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 671.0236 cm
+Q
+q
+1 0 0 1 57.02362 653.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Relative to the s132_nrf52_5.0.0:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 647.0236 cm
+Q
+q
+1 0 0 1 57.02362 647.0236 cm
+Q
+q
+1 0 0 1 57.02362 547.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 85 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_flash_protect\(\)) Tj /F1 10 Tf ( will now return ) Tj /F5 10 Tf (NRF_ERROR_NOT_SUPPORTED) Tj /F1 10 Tf ( if a non-zero value is) Tj T* (given for a BPROT configuration register that is not available on the platform \(DRGN-9336\). \(This) Tj T* (was also part of the s112_nrf52810_5.1.0-2.alpha release.\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (References to ) Tj /F5 10 Tf (EGU*) Tj /F1 10 Tf ( have been removed from nrf_soc.h and nrf_nvic.h as the SoftDevice is using) Tj T* (SWI and not EGU to generate interrupts \(DRGN-9257\). \(This was also part of the) Tj T* (s112_nrf52810_5.1.0-2.alpha release.\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 543.0236 cm
+Q
+q
+1 0 0 1 57.02362 525.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (See the release notes for the s112_nrf52810_5.1.0-2.alpha for the rest of the changes.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 495.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 477.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Compared to the s112_nrf52810_5.1.0-2.alpha, the following bugs have been fixed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+Q
+q
+1 0 0 1 57.02362 471.0236 cm
+Q
+q
+1 0 0 1 57.02362 377.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 79 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 79 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 73 cm
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where ) Tj /F5 10 Tf (sd_ble_gatts_attr_get\(\)) Tj /F1 10 Tf ( and ) Tj /F5 10 Tf (sd_ble_gatts_value_get\(\)) Tj /F1 10 Tf ( could) Tj T* (return undocumented ) Tj /F5 10 Tf (BLE_ERROR_INVALID_ATTR_HANDLE) Tj /F1 10 Tf ( error code in a situation where they) Tj T* (should have returned ) Tj /F5 10 Tf (NRF_ERROR_NOT_FOUND) Tj /F1 10 Tf ( \(DRGN-9216\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue where the API documentation was referencing removed APIs \(DRGN-9484\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue where some include directives were missing in ble_gatts.h \(DRGN-9467\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 371.0236 cm
+Q
+q
+1 0 0 1 57.02362 325.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATT) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice could assert if ATT packets longer than the LL packet size) Tj T* (were sent and received at the same time \(DRGN-9328\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 319.0236 cm
+Q
+q
+1 0 0 1 57.02362 189.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 115 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 115 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (LL) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 97 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice could assert while doing radio or flash activity \(DRGN-9463\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 91 cm
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the SoftDevice could send ) Tj /F5 10 Tf (LL_FEATURE_RSP) Tj /F1 10 Tf ( with incorrect ) Tj /F5 10 Tf (FeatureSet) Tj /F1 10 Tf  T* (\(DRGN-9551\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 45 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 50 Tm 12 TL /F1 10 Tf 0 0 0 rg (Fixed an issue where the slave disconnect event reason code was set to) Tj T* /F5 10 Tf (HCI_LOCAL_HOST_TERMINATED_CONNECTION) Tj /F1 10 Tf ( instead of) Tj T* /F5 10 Tf (HCI_STATUS_CODE_PIN_OR_KEY_MISSING) Tj /F1 10 Tf (. This occurred if the LTK \(Long Term Key\) was) Tj T* (missing during the re-encryption of the link \(DRGN-9190\). \(This was also fixed in the) Tj T* (s112_nrf52810_5.1.0-2.alpha release.\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 185.0236 cm
+Q
+q
+1 0 0 1 57.02362 155.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 143.0236 cm
+Q
+q
+1 0 0 1 57.02362 143.0236 cm
+Q
+q
+1 0 0 1 57.02362 80.69291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 47.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 47.33071 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 41.33071 cm
+Q
+q
+1 0 0 1 23 41.33071 cm
+Q
+q
+1 0 0 1 23 17.33071 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 11.33071 cm
+Q
+q
+1 0 0 1 23 -0.669291 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 40) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+357 0 obj
+<<
+/Length 2666
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 719.0236 cm
+Q
+q
+1 0 0 1 57.02362 673.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 669.0236 cm
+Q
+q
+1 0 0 1 57.02362 639.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 627.0236 cm
+Q
+q
+1 0 0 1 57.02362 569.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 43 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 37 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL (The SoftDevice can assert if the whitelist and identity list is set at the same time with matching) Tj T* (addresses. A workaround for this issue is to clear the whitelist before setting the identity list) Tj T* (\(DRGN-9535\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 565.0236 cm
+Q
+q
+1 0 0 1 57.02362 565.0236 cm
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 41) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+358 0 obj
+<<
+/Length 7831
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf .133333 .133333 .133333 rg (s112_nrf52810_5.1.0-2.alpha) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 690.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL (The S112 is a size-optimized peripheral only BLE SoftDevice for Nordic Semiconductor's nRF52810 chip.) Tj T* -0.036403 Tw (The S112 API is a compatible subset of the S132 SoftDevice API. For features that are common to S112 and) Tj T* 0 Tw (S132, the API is the same. To show the API compatibility, the S112 follows the same version numbering as) Tj T* -0.094536 Tw (S132. See the section "Changes" below for features that are not available in the S112 compared to the S132.) Tj T* 0 Tw ET
+Q
+Q
+q
+1 0 0 1 57.02362 660.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (SoftDevice properties) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+Q
+q
+1 0 0 1 57.02362 648.0236 cm
+Q
+q
+1 0 0 1 57.02362 596.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The combined MBR and SoftDevice memory requirements for this version are as follows:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Flash: ) Tj /F4 10 Tf (100 kB) Tj /F1 10 Tf ( \(0x19000 bytes\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (RAM: ) Tj /F4 10 Tf (3.65 kB) Tj /F1 10 Tf ( \(0xe98 bytes\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 592.0236 cm
+Q
+q
+1 0 0 1 57.02362 562.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Device Compatibility) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 544.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This SoftDevice is built and tested for nRF52810.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 502.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL -0.111353 Tw (For development purposes this SoftDevice can be run on the nRF52832, but some of the Errata workarounds) Tj T* 0 Tw (for that device are not present in this version of the alpha SoftDevice. This may result in minor performance) Tj T* (and stability issues on nRF52832.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 472.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (New functionality) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 442.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (This release is the first version of the S112. It is based upon the s132_nrf52_5.0.0, and has no new) Tj T* (functionality compared to that version.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 412.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Changes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 394.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Compared to the s132_nrf52_5.0.0, the following features have been removed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 388.0236 cm
+Q
+q
+1 0 0 1 57.02362 388.0236 cm
+Q
+q
+1 0 0 1 57.02362 336.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 37 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 31 cm
+Q
+q
+1 0 0 1 23 19 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (MWU is not supported, as the nrf52810 does not have MWU \(DRGN-9341\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 13 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Cache is not supported, as the nrf52810 does not have Cache \(DRGN-9256\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 330.0236 cm
+Q
+q
+1 0 0 1 57.02362 110.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 205 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 199 cm
+Q
+q
+1 0 0 1 23 175 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Observer role is still present in this alpha version of the SoftDevice, but might be removed for the) Tj T* (production version.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 169 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 151 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 139 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Central Role is no longer supported and the following functions, structures, defines and events) Tj T* (have been removed \(DRGN-9145\):) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 133 cm
+Q
+q
+1 0 0 1 23 121 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_gap_connect\(\)) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ble_gap_connect_cancel\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 115 cm
+Q
+q
+1 0 0 1 23 103 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (sd_ble_gap_encrypt\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 97 cm
+Q
+q
+1 0 0 1 23 85 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 79 cm
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (ble_gap_evt_conn_param_update_request_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (BLE_GAP_OPT_COMPAT_MODE_1) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (ble_gap_opt_compat_mode_1_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_GAP_ROLE_CENTRAL) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_GAP_ROLE_COUNT_CENTRAL_DEFAULT) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (BLE_GAP_ROLE_COUNT_CENTRAL_SEC_DEFAULT) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 42) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+359 0 obj
+<<
+/Length 8913
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 619.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 133 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 127 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 115 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (LE Data Length Extension is no longer supported and the following structures, defines and events) Tj T* (have been removed \(DRGN-9242\):) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 109 cm
+Q
+q
+1 0 0 1 23 97 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (sd_ble_gap_data_length_update\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 91 cm
+Q
+q
+1 0 0 1 23 67 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST) Tj /F1 10 Tf ( ,) Tj T* /F5 10 Tf (BLE_GAP_EVT_DATA_LENGTH_UPDATE) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 61 cm
+Q
+q
+1 0 0 1 23 49 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL (BLE_GAP_DATA_LENGTH_AUTO) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 43 cm
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_data_length_params_t) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (ble_gap_data_length_limitation_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_gap_evt_data_length_update_request_t) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (ble_gap_evt_data_length_update_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 613.0236 cm
+Q
+q
+1 0 0 1 57.02362 380.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 218 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 218 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (L2CAP:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 212 cm
+Q
+q
+1 0 0 1 23 212 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 196 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 184 cm
+q
+BT 1 0 0 1 0 14 Tm 12 TL /F1 10 Tf 0 0 0 rg (L2CAP Connection Oriented Channels is no longer supported and the header file ) Tj /F3 10 Tf (ble_l2cap.h) Tj /F1 10 Tf ( with) Tj T* (it's functions, structures, defines and events has been removed \(DRGN-923 8\):) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 178 cm
+Q
+q
+1 0 0 1 23 178 cm
+Q
+q
+1 0 0 1 23 142 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (sd_ble_l2cap_ch_setup\(\)) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ble_l2cap_ch_release\(\)) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (sd_ble_l2cap_ch_rx\(\)) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (sd_ble_l2cap_ch_tx\(\)) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (sd_ble_l2cap_ch_flow_control\(\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 136 cm
+Q
+q
+1 0 0 1 23 109 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 12 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 12 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_l2cap_ch_rx_params_t) Tj /F4 10 Tf (, ) Tj /F5 10 Tf (ble_l2cap_ch_setup_params_t) Tj /F4 10 Tf (,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 0 2 Tm  T* ET
+q
+1 0 0 1 20 0 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_l2cap_ch_tx_params_t) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (ble_l2cap_conn_cfg_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 103 cm
+Q
+q
+1 0 0 1 23 55 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (BLE_L2CAP_EVT_CH_SETUP_REQUEST) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_L2CAP_EVT_CH_SETUP_REFUSED) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (BLE_L2CAP_EVT_CH_SETUP) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_L2CAP_EVT_CH_RELEASED) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_L2CAP_EVT_CH_CREDIT) Tj /F1 10 Tf (,) Tj T* /F5 10 Tf (BLE_L2CAP_EVT_CH_RX) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (BLE_L2CAP_EVT_CH_TX) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 49 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 33 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (ble_l2cap_evt_t,) Tj ( ) Tj (ble_l2cap_evt_ch_tx_t) Tj /F1 10 Tf ( , ) Tj /F5 10 Tf (ble_l2cap_evt_ch_rx_t) Tj /F1 10 Tf ( ,) Tj T* /F5 10 Tf (ble_l2cap_evt_ch_credit_t) Tj /F1 10 Tf (, ) Tj /F5 10 Tf (ble_l2cap_evt_ch_sdu_buf_released_t) Tj /F1 10 Tf ( ,) Tj T* /F5 10 Tf (ble_l2cap_evt_ch_setup_request_t) Tj /F1 10 Tf ( , ) Tj /F5 10 Tf (ble_l2cap_evt_ch_setup_refused_t) Tj /F1 10 Tf ( ,) Tj T* /F5 10 Tf (ble_l2cap_evt_ch_setup_t) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 376.0236 cm
+Q
+q
+1 0 0 1 57.02362 346.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Bug fixes) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 328.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Compared to the s132_nrf52_5.0.0, the following bugs have been fixed:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 322.0236 cm
+Q
+q
+1 0 0 1 57.02362 322.0236 cm
+Q
+q
+1 0 0 1 57.02362 276.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where Radio Notification could be suppressed between connection events when) Tj T* (Connection Event Length Extension was enabled \(DRGN-7687\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 270.0236 cm
+Q
+q
+1 0 0 1 57.02362 224.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GAP) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (Fixed an issue where the SoftDevice could assert if the white list and identity list were set at the) Tj T* (same time with matching addresses \(DRGN-9535\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 220.0236 cm
+Q
+q
+1 0 0 1 57.02362 190.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Limitations) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 178.0236 cm
+Q
+q
+1 0 0 1 57.02362 178.0236 cm
+Q
+q
+1 0 0 1 57.02362 112.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 51 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 51 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SoftDevice) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 45 cm
+Q
+q
+1 0 0 1 23 45 cm
+Q
+q
+1 0 0 1 23 21 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (If Radio Notifications are enabled, flash write and flash erase operations initiated through the) Tj T* (SoftDevice API will be notified to the application as Radio Events \(FORT-809\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 15 cm
+Q
+q
+1 0 0 1 23 3 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Synthesized low frequency clock source is not tested or intended for use with the BLE stack.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 43) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+360 0 obj
+<<
+/Length 1861
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 57.02362 725.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 27 Tm  T* ET
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+BT 1 0 0 1 0 26 Tm 12 TL /F1 10 Tf 0 0 0 rg (Applications must not modify the ) Tj /F5 10 Tf (SEVONPEND) Tj /F1 10 Tf ( flag in the ) Tj /F5 10 Tf (SCR) Tj /F1 10 Tf ( register when running in priority) Tj T* (levels higher than 6 \(priority level numerical values lower than 6\) as this can lead to undefined) Tj T* (behavior.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 719.0236 cm
+Q
+q
+1 0 0 1 57.02362 673.0236 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 31 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (GATTS) Tj T* ET
+Q
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 25 cm
+Q
+q
+1 0 0 1 23 1 cm
+q
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 9 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F5 10 Tf 12 TL 8 0 Td (\177) Tj T* -8 0 Td ET
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (To conform to the Bluetooth Core Specification v 5.0, there shall be no secondary service that is) Tj T* (not referenced somehow by a primary service. The SoftDevice does not enforce this \(DRGN-906\).) Tj T* ET
+Q
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 23 -3 cm
+Q
+q
+Q
+Q
+Q
+q
+1 0 0 1 57.02362 669.0236 cm
+Q
+q
+1 0 0 1 57.02362 639.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf .133333 .133333 .133333 rg (Known Issues) Tj T* ET
+Q
+Q
+q
+1 0 0 1 57.02362 621.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (No known issues.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 51.02362 42.51969 cm
+q
+BT 1 0 0 1 0 2 Tm 227.9892 0 Td 12 TL /F3 10 Tf 0 0 0 rg (Page 44) Tj T* -227.9892 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+361 0 obj
+<<
+/Nums [ 0 362 0 R 1 363 0 R 2 364 0 R 3 365 0 R 4 366 0 R 
+  5 367 0 R 6 368 0 R 7 369 0 R 8 370 0 R 9 371 0 R 
+  10 372 0 R 11 373 0 R 12 374 0 R 13 375 0 R 14 376 0 R 
+  15 377 0 R 16 378 0 R 17 379 0 R 18 380 0 R 19 381 0 R 
+  20 382 0 R 21 383 0 R 22 384 0 R 23 385 0 R 24 386 0 R 
+  25 387 0 R 26 388 0 R 27 389 0 R 28 390 0 R 29 391 0 R 
+  30 392 0 R 31 393 0 R 32 394 0 R 33 395 0 R 34 396 0 R 
+  35 397 0 R 36 398 0 R 37 399 0 R 38 400 0 R 39 401 0 R 
+  40 402 0 R 41 403 0 R 42 404 0 R 43 405 0 R ]
+>>
+endobj
+362 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+363 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+364 0 obj
+<<
+/S /D /St 3
+>>
+endobj
+365 0 obj
+<<
+/S /D /St 4
+>>
+endobj
+366 0 obj
+<<
+/S /D /St 5
+>>
+endobj
+367 0 obj
+<<
+/S /D /St 6
+>>
+endobj
+368 0 obj
+<<
+/S /D /St 7
+>>
+endobj
+369 0 obj
+<<
+/S /D /St 8
+>>
+endobj
+370 0 obj
+<<
+/S /D /St 9
+>>
+endobj
+371 0 obj
+<<
+/S /D /St 10
+>>
+endobj
+372 0 obj
+<<
+/S /D /St 11
+>>
+endobj
+373 0 obj
+<<
+/S /D /St 12
+>>
+endobj
+374 0 obj
+<<
+/S /D /St 13
+>>
+endobj
+375 0 obj
+<<
+/S /D /St 14
+>>
+endobj
+376 0 obj
+<<
+/S /D /St 15
+>>
+endobj
+377 0 obj
+<<
+/S /D /St 16
+>>
+endobj
+378 0 obj
+<<
+/S /D /St 17
+>>
+endobj
+379 0 obj
+<<
+/S /D /St 18
+>>
+endobj
+380 0 obj
+<<
+/S /D /St 19
+>>
+endobj
+381 0 obj
+<<
+/S /D /St 20
+>>
+endobj
+382 0 obj
+<<
+/S /D /St 21
+>>
+endobj
+383 0 obj
+<<
+/S /D /St 22
+>>
+endobj
+384 0 obj
+<<
+/S /D /St 23
+>>
+endobj
+385 0 obj
+<<
+/S /D /St 24
+>>
+endobj
+386 0 obj
+<<
+/S /D /St 25
+>>
+endobj
+387 0 obj
+<<
+/S /D /St 26
+>>
+endobj
+388 0 obj
+<<
+/S /D /St 27
+>>
+endobj
+389 0 obj
+<<
+/S /D /St 28
+>>
+endobj
+390 0 obj
+<<
+/S /D /St 29
+>>
+endobj
+391 0 obj
+<<
+/S /D /St 30
+>>
+endobj
+392 0 obj
+<<
+/S /D /St 31
+>>
+endobj
+393 0 obj
+<<
+/S /D /St 32
+>>
+endobj
+394 0 obj
+<<
+/S /D /St 33
+>>
+endobj
+395 0 obj
+<<
+/S /D /St 34
+>>
+endobj
+396 0 obj
+<<
+/S /D /St 35
+>>
+endobj
+397 0 obj
+<<
+/S /D /St 36
+>>
+endobj
+398 0 obj
+<<
+/S /D /St 37
+>>
+endobj
+399 0 obj
+<<
+/S /D /St 38
+>>
+endobj
+400 0 obj
+<<
+/S /D /St 39
+>>
+endobj
+401 0 obj
+<<
+/S /D /St 40
+>>
+endobj
+402 0 obj
+<<
+/S /D /St 41
+>>
+endobj
+403 0 obj
+<<
+/S /D /St 42
+>>
+endobj
+404 0 obj
+<<
+/S /D /St 43
+>>
+endobj
+405 0 obj
+<<
+/S /D /St 44
+>>
+endobj
+xref
+0 406
+0000000000 65535 f 
+0000000073 00000 n 
+0000000158 00000 n 
+0000000265 00000 n 
+0000000374 00000 n 
+0000000489 00000 n 
+0000000696 00000 n 
+0000000808 00000 n 
+0000000975 00000 n 
+0000001140 00000 n 
+0000001307 00000 n 
+0000001473 00000 n 
+0000001643 00000 n 
+0000001811 00000 n 
+0000001981 00000 n 
+0000002149 00000 n 
+0000002319 00000 n 
+0000002487 00000 n 
+0000002657 00000 n 
+0000002825 00000 n 
+0000002995 00000 n 
+0000003163 00000 n 
+0000003333 00000 n 
+0000003501 00000 n 
+0000003671 00000 n 
+0000003839 00000 n 
+0000004009 00000 n 
+0000004177 00000 n 
+0000004347 00000 n 
+0000004515 00000 n 
+0000004685 00000 n 
+0000004853 00000 n 
+0000005023 00000 n 
+0000005189 00000 n 
+0000005359 00000 n 
+0000005525 00000 n 
+0000005695 00000 n 
+0000005861 00000 n 
+0000006031 00000 n 
+0000006197 00000 n 
+0000006367 00000 n 
+0000006533 00000 n 
+0000006703 00000 n 
+0000006869 00000 n 
+0000007039 00000 n 
+0000007205 00000 n 
+0000007375 00000 n 
+0000007541 00000 n 
+0000007711 00000 n 
+0000007877 00000 n 
+0000008047 00000 n 
+0000008213 00000 n 
+0000008383 00000 n 
+0000008549 00000 n 
+0000008719 00000 n 
+0000008885 00000 n 
+0000009055 00000 n 
+0000009221 00000 n 
+0000009391 00000 n 
+0000009557 00000 n 
+0000009727 00000 n 
+0000009893 00000 n 
+0000010063 00000 n 
+0000010229 00000 n 
+0000010399 00000 n 
+0000010565 00000 n 
+0000010735 00000 n 
+0000010901 00000 n 
+0000011071 00000 n 
+0000011237 00000 n 
+0000011407 00000 n 
+0000011573 00000 n 
+0000011743 00000 n 
+0000011909 00000 n 
+0000012079 00000 n 
+0000012245 00000 n 
+0000012415 00000 n 
+0000012581 00000 n 
+0000012751 00000 n 
+0000012917 00000 n 
+0000013087 00000 n 
+0000013253 00000 n 
+0000013423 00000 n 
+0000013589 00000 n 
+0000013759 00000 n 
+0000013925 00000 n 
+0000014095 00000 n 
+0000014261 00000 n 
+0000015059 00000 n 
+0000015229 00000 n 
+0000015395 00000 n 
+0000015565 00000 n 
+0000015731 00000 n 
+0000015901 00000 n 
+0000016067 00000 n 
+0000016237 00000 n 
+0000016403 00000 n 
+0000016573 00000 n 
+0000016739 00000 n 
+0000016909 00000 n 
+0000017075 00000 n 
+0000017246 00000 n 
+0000017413 00000 n 
+0000017584 00000 n 
+0000017751 00000 n 
+0000017922 00000 n 
+0000018089 00000 n 
+0000018260 00000 n 
+0000018427 00000 n 
+0000018598 00000 n 
+0000018765 00000 n 
+0000018936 00000 n 
+0000019103 00000 n 
+0000019274 00000 n 
+0000019441 00000 n 
+0000019612 00000 n 
+0000019779 00000 n 
+0000019950 00000 n 
+0000020117 00000 n 
+0000020288 00000 n 
+0000020455 00000 n 
+0000020626 00000 n 
+0000020793 00000 n 
+0000020964 00000 n 
+0000021131 00000 n 
+0000021302 00000 n 
+0000021469 00000 n 
+0000021640 00000 n 
+0000021807 00000 n 
+0000021978 00000 n 
+0000022145 00000 n 
+0000022316 00000 n 
+0000022483 00000 n 
+0000022654 00000 n 
+0000022821 00000 n 
+0000022992 00000 n 
+0000023159 00000 n 
+0000023330 00000 n 
+0000023497 00000 n 
+0000023668 00000 n 
+0000023835 00000 n 
+0000024006 00000 n 
+0000024173 00000 n 
+0000024344 00000 n 
+0000024511 00000 n 
+0000024682 00000 n 
+0000024849 00000 n 
+0000025020 00000 n 
+0000025187 00000 n 
+0000025358 00000 n 
+0000025525 00000 n 
+0000025696 00000 n 
+0000025863 00000 n 
+0000026034 00000 n 
+0000026201 00000 n 
+0000026372 00000 n 
+0000026539 00000 n 
+0000026710 00000 n 
+0000026877 00000 n 
+0000027048 00000 n 
+0000027215 00000 n 
+0000027386 00000 n 
+0000027553 00000 n 
+0000027724 00000 n 
+0000027891 00000 n 
+0000028062 00000 n 
+0000028229 00000 n 
+0000028400 00000 n 
+0000028567 00000 n 
+0000028738 00000 n 
+0000028905 00000 n 
+0000029076 00000 n 
+0000029243 00000 n 
+0000030148 00000 n 
+0000030319 00000 n 
+0000030486 00000 n 
+0000030657 00000 n 
+0000030824 00000 n 
+0000030995 00000 n 
+0000031162 00000 n 
+0000031431 00000 n 
+0000031538 00000 n 
+0000031747 00000 n 
+0000031956 00000 n 
+0000032165 00000 n 
+0000032374 00000 n 
+0000032486 00000 n 
+0000032695 00000 n 
+0000032904 00000 n 
+0000033113 00000 n 
+0000033322 00000 n 
+0000033531 00000 n 
+0000033740 00000 n 
+0000033949 00000 n 
+0000034158 00000 n 
+0000034367 00000 n 
+0000034576 00000 n 
+0000034785 00000 n 
+0000034994 00000 n 
+0000035203 00000 n 
+0000035412 00000 n 
+0000035621 00000 n 
+0000035830 00000 n 
+0000036039 00000 n 
+0000036248 00000 n 
+0000036457 00000 n 
+0000036666 00000 n 
+0000036875 00000 n 
+0000037084 00000 n 
+0000037293 00000 n 
+0000037502 00000 n 
+0000037711 00000 n 
+0000037920 00000 n 
+0000038129 00000 n 
+0000038338 00000 n 
+0000038547 00000 n 
+0000038756 00000 n 
+0000038943 00000 n 
+0000039172 00000 n 
+0000039381 00000 n 
+0000039590 00000 n 
+0000039799 00000 n 
+0000040008 00000 n 
+0000040217 00000 n 
+0000040327 00000 n 
+0000040604 00000 n 
+0000040683 00000 n 
+0000040866 00000 n 
+0000040974 00000 n 
+0000041157 00000 n 
+0000041284 00000 n 
+0000041411 00000 n 
+0000041542 00000 n 
+0000041660 00000 n 
+0000041837 00000 n 
+0000041964 00000 n 
+0000042093 00000 n 
+0000042224 00000 n 
+0000042342 00000 n 
+0000042519 00000 n 
+0000042646 00000 n 
+0000042775 00000 n 
+0000042906 00000 n 
+0000043024 00000 n 
+0000043201 00000 n 
+0000043328 00000 n 
+0000043460 00000 n 
+0000043589 00000 n 
+0000043720 00000 n 
+0000043838 00000 n 
+0000044015 00000 n 
+0000044142 00000 n 
+0000044274 00000 n 
+0000044403 00000 n 
+0000044534 00000 n 
+0000044652 00000 n 
+0000044829 00000 n 
+0000044956 00000 n 
+0000045088 00000 n 
+0000045215 00000 n 
+0000045344 00000 n 
+0000045475 00000 n 
+0000045593 00000 n 
+0000045770 00000 n 
+0000045897 00000 n 
+0000046034 00000 n 
+0000046165 00000 n 
+0000046283 00000 n 
+0000046460 00000 n 
+0000046587 00000 n 
+0000046714 00000 n 
+0000046843 00000 n 
+0000046974 00000 n 
+0000047092 00000 n 
+0000047284 00000 n 
+0000047436 00000 n 
+0000047559 00000 n 
+0000047686 00000 n 
+0000047815 00000 n 
+0000047946 00000 n 
+0000048064 00000 n 
+0000048241 00000 n 
+0000048368 00000 n 
+0000048495 00000 n 
+0000048624 00000 n 
+0000048755 00000 n 
+0000048873 00000 n 
+0000049050 00000 n 
+0000049177 00000 n 
+0000049314 00000 n 
+0000049441 00000 n 
+0000049570 00000 n 
+0000049701 00000 n 
+0000049819 00000 n 
+0000049996 00000 n 
+0000050123 00000 n 
+0000050260 00000 n 
+0000050387 00000 n 
+0000050516 00000 n 
+0000050647 00000 n 
+0000050765 00000 n 
+0000050945 00000 n 
+0000051072 00000 n 
+0000051212 00000 n 
+0000051349 00000 n 
+0000051476 00000 n 
+0000051605 00000 n 
+0000051736 00000 n 
+0000051854 00000 n 
+0000052028 00000 n 
+0000052155 00000 n 
+0000052295 00000 n 
+0000052432 00000 n 
+0000052559 00000 n 
+0000052688 00000 n 
+0000052819 00000 n 
+0000052937 00000 n 
+0000053354 00000 n 
+0000055215 00000 n 
+0000064667 00000 n 
+0000074460 00000 n 
+0000075445 00000 n 
+0000084384 00000 n 
+0000093554 00000 n 
+0000096023 00000 n 
+0000104507 00000 n 
+0000113074 00000 n 
+0000115077 00000 n 
+0000123618 00000 n 
+0000132186 00000 n 
+0000134189 00000 n 
+0000142584 00000 n 
+0000151140 00000 n 
+0000154910 00000 n 
+0000163604 00000 n 
+0000172153 00000 n 
+0000175928 00000 n 
+0000184197 00000 n 
+0000192130 00000 n 
+0000197709 00000 n 
+0000206389 00000 n 
+0000212211 00000 n 
+0000220611 00000 n 
+0000229101 00000 n 
+0000232305 00000 n 
+0000241395 00000 n 
+0000250168 00000 n 
+0000252353 00000 n 
+0000260508 00000 n 
+0000266364 00000 n 
+0000275027 00000 n 
+0000283961 00000 n 
+0000288745 00000 n 
+0000297839 00000 n 
+0000306886 00000 n 
+0000308656 00000 n 
+0000316752 00000 n 
+0000326270 00000 n 
+0000328989 00000 n 
+0000336873 00000 n 
+0000345839 00000 n 
+0000347753 00000 n 
+0000348284 00000 n 
+0000348319 00000 n 
+0000348354 00000 n 
+0000348389 00000 n 
+0000348424 00000 n 
+0000348459 00000 n 
+0000348494 00000 n 
+0000348529 00000 n 
+0000348564 00000 n 
+0000348599 00000 n 
+0000348635 00000 n 
+0000348671 00000 n 
+0000348707 00000 n 
+0000348743 00000 n 
+0000348779 00000 n 
+0000348815 00000 n 
+0000348851 00000 n 
+0000348887 00000 n 
+0000348923 00000 n 
+0000348959 00000 n 
+0000348995 00000 n 
+0000349031 00000 n 
+0000349067 00000 n 
+0000349103 00000 n 
+0000349139 00000 n 
+0000349175 00000 n 
+0000349211 00000 n 
+0000349247 00000 n 
+0000349283 00000 n 
+0000349319 00000 n 
+0000349355 00000 n 
+0000349391 00000 n 
+0000349427 00000 n 
+0000349463 00000 n 
+0000349499 00000 n 
+0000349535 00000 n 
+0000349571 00000 n 
+0000349607 00000 n 
+0000349643 00000 n 
+0000349679 00000 n 
+0000349715 00000 n 
+0000349751 00000 n 
+0000349787 00000 n 
+0000349823 00000 n 
+trailer
+<<
+/ID 
+[<6892f59cf8d361ccda52807a97e34228><6892f59cf8d361ccda52807a97e34228>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 224 0 R
+/Root 223 0 R
+/Size 406
+>>
+startxref
+349859
+%%EOF


### PR DESCRIPTION
Keep the built pdfs here for now until they can be better integrated into the rest of the sdk documentation.

Taken from dragoon build 2057, sha 988c64d2fad47585fe7dd9acc6b1a57faace20ad.