### PR TITLE
doc: fix issues from 0.1.0 testing

### DIFF
--- a/doc/ncs-lite/install_ncsl.rst
+++ b/doc/ncs-lite/install_ncsl.rst
@@ -22,6 +22,19 @@ Install the following software tools:
      After downloading the nRF Util executable, move it to a directory that is in the system :envvar:`PATH`.
      On macOS and Linux, the downloaded file also needs to be given execute permission by typing `chmod +x nrfutil` or by checking the checkbox in the file properties.
 
+* Install the nRF Util ``device`` command.
+  This command allows you to perform various operations on Nordic devices.
+
+   .. code-block:: console
+
+      nrfutil install device
+
+  For the complete list of functionalities offered by this command, type:
+
+   .. code-block:: console
+
+      nrfutil device --help
+
 *   The |jlink_ver| of SEGGER J-Link.
     Download it from the `J-Link Software and Documentation Pack`_ page.
 
@@ -74,7 +87,7 @@ Complete the following steps to clone the |NCSL| repositories.
 
    The SDK installation starts and it can take several minutes.
 #. Open command line and navigate to the SDK installation folder.
-   The default location to install the SDK is :file:`C:/ncs` on Windows, :file:`~/ncs/` on Linux, and :file:`/opt/nordic/ncs/` on macOS.
+   The default location to install the SDK is :file:`C:/ncs/2.9.1` on Windows, :file:`~/ncs/2.9.1` on Linux, and :file:`/opt/nordic/ncs/2.9.1` on macOS.
 #. Clone the `sdk-nrf-lite`_ repository:
 
    .. code-block:: console

--- a/doc/ncs-lite/links.txt
+++ b/doc/ncs-lite/links.txt
@@ -37,3 +37,5 @@
 .. _`How to connect to the terminal`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/get_started/quick_debug.html#how-to-connect-to-the-terminal
 .. _`nRF Connect for Desktop`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop
 .. _`nRF Toolbox`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox
+.. _`Bluetooth Low Energy app`: https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html
+.. _`Configuring Kconfig`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/config_and_build/kconfig/index.html

--- a/samples/ble_hrs/README.rst
+++ b/samples/ble_hrs/README.rst
@@ -67,7 +67,7 @@ Programming the S115 SoftDevice
 Testing
 =======
 
-You can test this sample with `nRF Connect for Desktop`_ by performing the following steps:
+You can test this sample using `nRF Connect for Desktop`_ with the `Bluetooth Low Energy app`_:
 
 1. Compile and program the application.
 #. Observe that the ``BLE HRS sample started`` message is printed.

--- a/samples/ble_lbs/README.rst
+++ b/samples/ble_lbs/README.rst
@@ -52,7 +52,7 @@ Programming the S115 SoftDevice
 Testing
 =======
 
-You can test this sample with `nRF Connect for Desktop`_ by performing the following steps:
+You can test this sample using `nRF Connect for Desktop`_ with the `Bluetooth Low Energy app`_:
 
 1. Compile and program the application.
 #. Observe that the ``BLE LBS sample started`` message is printed.

--- a/samples/ble_nus/README.rst
+++ b/samples/ble_nus/README.rst
@@ -59,6 +59,7 @@ Testing
 #. Reset the kit.
 #. Observe that LED 0 is blinking and the device is advertising under the default name ``NCS-Lite NUS``.
    You can configure this name using the ``CONFIG_BLE_ADV_NAME`` Kconfig option.
+   For information on how to do this, see `Configuring Kconfig`_.
 #. Observe that the text "BLE NUS sample started" is printed on the COM listener running on the computer.
 #. Connect to your device using the `nRF Toolbox`_ mobile application with the ``Universal Asynchronous Receiver/Transmitter (UART)`` service.
    You must choose ``All`` devices in the scanner to see the device.


### PR DESCRIPTION
Fix reported doc issues.

HTML: 
[nrf-lite-0.1.0-doc.zip](https://github.com/user-attachments/files/19488651/nrf-lite-0.1.0-doc.zip)
