### PR TITLE
workflows: pin GitHub Actions to explicit SHAs

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         path: nrf-lite
         fetch-depth: 0
 
     - name: restore-cache-sdk
       id: cache-sdk
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: |
           nrf
@@ -51,7 +51,7 @@ jobs:
         west twister -T samples --build-only -v --inline-logs --integration
 
     - name: upload-logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:
         name: build-logs
@@ -59,7 +59,7 @@ jobs:
         retention-days: 5
 
     - name: upload-artifacts-dispatch
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true &&
           github.event_name == 'workflow_dispatch'
       with:
@@ -69,7 +69,7 @@ jobs:
 
     - name: save-cache-sdk
       if: always() && steps.cache-sdk.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: |
           nrf

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: .
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: cache-pip
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         path: nrf-lite
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip
@@ -83,7 +83,7 @@ jobs:
         fi
 
     - name: upload-results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       continue-on-error: True
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Build
         run: |
@@ -18,7 +18,7 @@ jobs:
           python3 build_docs.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs
           path: doc/ncs-lite/_build/html

--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         path: nrf-lite
         fetch-depth: 0
 
     - name: restore-cache-sdk
       id: cache-sdk
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: |
           nrf
@@ -56,7 +56,7 @@ jobs:
         west twister -vc -p native_sim -T tests --enable-asan --enable-lsan --enable-ubsan
 
     - name: upload-logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: ${{ !cancelled() }}
       with:
         name: twister-logs
@@ -65,7 +65,7 @@ jobs:
 
     - name: save-cache-sdk
       if: always() && steps.cache-sdk.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: |
           nrf


### PR DESCRIPTION
Mitigates GitHub Actions supply chain attack
vulnerabilities by pinning actions to explicit
and safe commits.
More info: NCSDK-32440