### PR TITLE
drivers: console: add carriage return before linefeed

### DIFF
--- a/drivers/console/Kconfig.lite_uarte
+++ b/drivers/console/Kconfig.lite_uarte
@@ -26,4 +26,26 @@ config LITE_UARTE_CONSOLE_UARTE_USE_HWFC
 config LITE_UARTE_CONSOLE_UARTE_PARITY_INCLUDED
 	bool "Use parity"
 
+
+config LITE_UARTE_CONSOLE_ADD_CR_BEFORE_LF
+	bool "Add carriage return before linefeed"
+	default y
+
+#
+# Console termination
+#
+choice
+	prompt "Termination mode"
+	default LITE_UARTE_CONSOLE_CR_LF_TERMINATION
+	help
+		Sets the command terminator used by the serial terminal.
+		Available options are:
+		-  LF termination
+		-  CR+LF termination
+	config LITE_UARTE_CONSOLE_LF_TERMINATION
+		bool "LF termination"
+	config LITE_UARTE_CONSOLE_CR_LF_TERMINATION
+		bool "CR+LF termination"
+endchoice
+
 endif # LITE_UARTE_CONSOLE

--- a/drivers/console/console_lite_uarte.c
+++ b/drivers/console/console_lite_uarte.c
@@ -52,6 +52,14 @@ static int console_out(int c)
 {
 	const char c2 = c;
 
+#if defined(CONFIG_LITE_UARTE_CONSOLE_CR_LF_TERMINATION)
+	const char r = '\r';
+
+	if ('\n' == c) {
+		nrfx_uarte_tx(&uarte_inst, &r, 1, NRFX_UARTE_TX_BLOCKING);
+	}
+#endif
+
 	nrfx_uarte_tx(&uarte_inst, &c2, 1, NRFX_UARTE_TX_BLOCKING);
 
 	/* Return the character passed as input. */


### PR DESCRIPTION
Add carriage return before linefeed. This is done in zephyr and needed by some termnials to avoid adding \r to all prints.