### PR TITLE
samples: buttons: remove logging

### DIFF
--- a/samples/buttons/src/main.c
+++ b/samples/buttons/src/main.c
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/kernel.h>    /* k_busy_wait() */
-#include <zephyr/sys_clock.h> /* K_MSEC() */
+#include <zephyr/sys/printk.h>
 
 #include <lite_timer.h>
 #include <lite_buttons.h>


### PR DESCRIPTION
This sample has inconsistent use of logging
mixed with printks. Since logging is not really
needed here, remove it in favor of printk.
This makes it more aligned with the other samples.