### PR TITLE
manifest: use NCS v3.0.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
   projects:
     - name: sdk-nrf
       path: nrf
-      revision: 42f0799cf00546256b2e8f079361be3b821b0c4f
+      revision: v3.0.1
       import:
         name-allowlist:
           - cmsis


### PR DESCRIPTION
Set manifest to use NCS v3.0.1 tag for the 0.7.0 release.

This will break support for internal nRF52 use until after the release. 