### PR TITLE
CI: src-mirror workflow stores entire project workspace in Files.nordicsemi.com

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -1,0 +1,25 @@
+name: src-mirror
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  zip-and-upload:
+    runs-on: ubuntu-24.04-16cores
+
+    steps:
+      - name: Upload source to Artifactory
+        uses: nrfconnect/action-src-mirror@main
+        with:
+          git-ref: ${{ github.ref_name }}
+          git-fetch-depth: '0'
+          path: 'workspace/sdk-nrf-bm'
+          west-update-args: ''
+          artifactory-url: 'https://eu.files.nordicsemi.com/artifactory'
+          artifactory-repository: 'ncs-src-mirror'
+          artifactory-target-prefix: 'external/sdk-nrf-bm'
+          artifactory-target-file-name: 'src.tar.gz'
+          artifactory-user: ${{ secrets.COM_NORDICSEMI_FILES_USERNAME }}
+          artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}


### PR DESCRIPTION
Use new public action to mirror files with Artifactory