### PR TITLE
samples: fix configuration of buttons and leds in samples

### DIFF
--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -18,15 +18,6 @@
 
 #include <bm_buttons.h>
 
-#if defined(CONFIG_SOC_SERIES_NRF52X)
-#define LED_ACTIVE_STATE 0 /* GPIO_ACTIVE_LOW */
-#elif defined(CONFIG_SOC_SERIES_NRF54LX)
-#define LED_ACTIVE_STATE 1 /* GPIO_ACTIVE_HIGH */
-#endif
-
-#define PIN_BTN_0 BOARD_PIN_BTN_0
-#define PIN_LED_0 BOARD_PIN_LED_0
-
 BLE_ADV_DEF(ble_adv); /* BLE advertising instance */
 BLE_LBS_DEF(ble_lbs); /* BLE LED Button Service instance */
 
@@ -100,17 +91,17 @@ static void button_handler(uint8_t pin, enum bm_buttons_evt_type action)
 
 static void led_on(void)
 {
-	nrf_gpio_pin_write(PIN_LED_0, LED_ACTIVE_STATE ? 1 : 0);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 }
 
 static void led_off(void)
 {
-	nrf_gpio_pin_write(PIN_LED_0, LED_ACTIVE_STATE ? 0 : 1);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, !BOARD_LED_ACTIVE_STATE);
 }
 
 static void led_init(void)
 {
-	nrf_gpio_cfg_output(PIN_LED_0);
+	nrf_gpio_cfg_output(BOARD_PIN_LED_0);
 	led_off();
 }
 
@@ -168,7 +159,7 @@ int main(void)
 
 	err = bm_buttons_init(
 		&(struct bm_buttons_config){
-			.pin_number = PIN_BTN_0,
+			.pin_number = BOARD_PIN_BTN_0,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler,

--- a/samples/peripherals/buttons/src/main.c
+++ b/samples/peripherals/buttons/src/main.c
@@ -10,18 +10,13 @@
 #include <board-config.h>
 #include <zephyr/logging/log_ctrl.h>
 
-#define PIN_BTN_0 BOARD_PIN_BTN_0
-#define PIN_BTN_1 BOARD_PIN_BTN_1
-#define PIN_BTN_2 BOARD_PIN_BTN_2
-#define PIN_BTN_3 BOARD_PIN_BTN_3
-
 static volatile bool running;
 
 static void button_handler(uint8_t pin, uint8_t action)
 {
 	printk("Button event callback: %d, %d\n", pin, action);
 
-	if (pin == PIN_BTN_3) {
+	if (pin == BOARD_PIN_BTN_3) {
 		running = false;
 	}
 }
@@ -36,25 +31,25 @@ int main(void)
 
 	struct bm_buttons_config configs[4] = {
 		{
-			.pin_number = PIN_BTN_0,
+			.pin_number = BOARD_PIN_BTN_0,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler,
 		},
 		{
-			.pin_number = PIN_BTN_1,
+			.pin_number = BOARD_PIN_BTN_1,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler,
 		},
 		{
-			.pin_number = PIN_BTN_2,
+			.pin_number = BOARD_PIN_BTN_2,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler,
 		},
 		{
-			.pin_number = PIN_BTN_3,
+			.pin_number = BOARD_PIN_BTN_3,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler,

--- a/samples/peripherals/leds/src/main.c
+++ b/samples/peripherals/leds/src/main.c
@@ -20,12 +20,12 @@ static void led_init(void)
 
 static void led_on(void)
 {
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE ? 1 : 0);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 }
 
 static void led_off(void)
 {
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE ? 0 : 1);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, !BOARD_LED_ACTIVE_STATE);
 }
 
 int main(void)


### PR DESCRIPTION
Use defines from board-config.h directly in sample main file. Set initial LED pin states to off and write LED pins based on the configured LED_ACTIVE_STATE in ble_cgms sample.