### PR TITLE
manifest: update west module name of sdk-nrf repository to nrf

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,8 +12,8 @@ manifest:
     - -nrf-bm-internal
 
   projects:
-    - name: sdk-nrf
-      path: nrf
+    - name: nrf
+      repo-path: sdk-nrf
       revision: v3.0.1
       import:
         name-allowlist:


### PR DESCRIPTION
Update sdk-nrf -> nrf in west manifest to align with nrf-bm.