### PR TITLE
softdevice_handler: Fix maximum MTU Kconfig

### DIFF
--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -96,7 +96,7 @@ config NRF_SDH_BLE_GAP_EVENT_LENGTH
 
 config NRF_SDH_BLE_GATT_MAX_MTU_SIZE
 	int "Maximum MTU size"
-	range 23 247
+	range 23 65535
 	default 23
 
 config NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE


### PR DESCRIPTION
Fixes the maximum MTU Kconfig which was wrongly limited to a lesser value for an old Bluetooth specification