### PR TITLE
softdevice_handler: irq_connect: Add MCUboot overhead

### DIFF
--- a/subsys/softdevice_handler/irq_connect.c
+++ b/subsys/softdevice_handler/irq_connect.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
+#include <zephyr/storage/flash_map.h>
 
 #if CONFIG_SOC_SERIES_NRF52X
 #include <zephyr/linker/linker-defs.h>
@@ -56,7 +57,11 @@ uint32_t softdevice_vector_forward_address;
 
 static void sd_enable_irq_forwarding(void)
 {
-	softdevice_vector_forward_address = DT_REG_ADDR(DT_NODELABEL(softdevice_rom));
+	softdevice_vector_forward_address = FIXED_PARTITION_OFFSET(softdevice_partition);
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+	softdevice_vector_forward_address += CONFIG_ROM_START_OFFSET;
+#endif
+
 	CallSoftDeviceResetHandler();
 	irq_forwarding_enabled_magic_number_holder = IRQ_FORWARDING_ENABLED_MAGIC_NUMBER;
 }


### PR DESCRIPTION
Adds the MCUboot image header overhead when calculating the offset of the softdevice