### PR TITLE
workflows: twister: add coverage report support

### DIFF
--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -50,7 +50,12 @@ jobs:
     - name: Run Twister
       working-directory: nrf-bm
       run: |
-        west twister -vc -p native_sim -T tests --enable-asan --enable-lsan --enable-ubsan
+        if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          COVERAGE_OPTION="--coverage --coverage-basedir lib"
+        else
+          COVERAGE_OPTION=""
+        fi
+        west twister -vc $COVERAGE_OPTION -p native_sim -T tests --enable-asan --enable-lsan --enable-ubsan
 
     - name: upload-logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -59,6 +64,20 @@ jobs:
         name: twister-logs
         path: nrf-bm/twister-out/**/*.log
         retention-days: 5
+
+    - name: compress-twister-out-full
+      if: github.event_name == 'workflow_dispatch'
+      working-directory: nrf-bm
+      run: tar -zcvf twister-out.tar.gz twister-out
+
+    - name: upload-twister-out-full
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: github.event_name == 'workflow_dispatch' && !cancelled()
+      with:
+        name: twister-out-full
+        path: nrf-bm/twister-out.tar.gz
+        retention-days: 5
+        compression-level: 0 # Opt out of compression since already compressed previously
 
     - name: save-cache-sdk
       if: always() && steps.cache-sdk.outputs.cache-hit != 'true'


### PR DESCRIPTION
Adds coverage report support.

Example artifact here (`twister-out-full`): https://github.com/nrfconnect/sdk-nrf-bm/actions/runs/15610526720?pr=160