### PR TITLE
sysbuild: Add firmware loader entrance mode Kconfigs

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -48,6 +48,22 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       )
 
       set(bm_install_images 2)
+
+      # MCUboot firmware loader entrance mode selection
+      if(SB_CONFIG_BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_BOOT_MODE)
+        set_config_bool(mcuboot CONFIG_BOOT_FIRMWARE_LOADER_BOOT_MODE y)
+      endif()
+
+      if(SB_CONFIG_BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_PIN_RESET)
+        set_config_bool(mcuboot CONFIG_BOOT_FIRMWARE_LOADER_PIN_RESET y)
+      endif()
+
+      if(SB_CONFIG_BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_GPIO)
+        set_config_bool(mcuboot CONFIG_GPIO y)
+        set_config_bool(mcuboot CONFIG_BM_TIMER y)
+        set_config_bool(mcuboot CONFIG_BM_BUTTONS y)
+        set_config_bool(mcuboot CONFIG_BOOT_FIRMWARE_LOADER_ENTRANCE_GPIO y)
+      endif()
     endif()
 
     # Use BM-supplied bootloader image configuration file

--- a/sysbuild/Kconfig.bm
+++ b/sysbuild/Kconfig.bm
@@ -50,6 +50,22 @@ config BM_BOOTLOADER_MCUBOOT_SIGNATURE_KEY_FILE
 	help
 	  Absolute path to signing key file to use with MCUBoot.
 
+menu "Firmware loader entrance modes"
+	depends on !BM_FIRMWARE_LOADER_NONE
+
+config BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_GPIO
+	bool "GPIO"
+	default y
+
+config BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_PIN_RESET
+	bool "Check for device reset by pin"
+
+config BM_BOOTLOADER_MCUBOOT_FIRMWARE_LOADER_ENTRANCE_BOOT_MODE
+	bool "Check boot mode via retention subsystem"
+	default y
+
+endmenu
+
 endmenu
 
 endif # BM_BOOTLOADER_MCUBOOT


### PR DESCRIPTION
Configures the mode for firmware loader entrance in MCUboot