### PR TITLE
lib: bm_buttons: use NRF_* errors

### DIFF
--- a/include/bm_buttons.h
+++ b/include/bm_buttons.h
@@ -106,41 +106,42 @@ struct bm_buttons_config {
  *                            is reported as pressed. Must be higher than
  *                            @ref BM_BUTTONS_DETECTION_DELAY_MIN_US.
  *
- * @retval 0 on success.
- * @retval -EPERM If the bm_buttons library is already initialized.
- * @retval -EINVAL If input data is invalid.
- * @retval -EIO If an error occurred.
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the bm_buttons library is already initialized.
+ * @retval NRF_ERROR_NULL If @p configs is NULL.
+ * @retval NRF_ERROR_INVALID_PARAM If input data is invalid.
+ * @retval NRF_ERROR_INTERNAL If an error occurred.
  */
-int bm_buttons_init(const struct bm_buttons_config *configs, uint8_t num_configs,
-		    uint32_t detection_delay);
+uint32_t bm_buttons_init(const struct bm_buttons_config *configs, uint8_t num_configs,
+			 uint32_t detection_delay);
 
 /**
  * @brief Deinitialize buttons.
  *
  * @details This function will deinitialize the buttons library.
  *
- * @retval 0 on success.
- * @retval -EPERM If the bm_buttons library is already initialized.
- * @retval -EIO If an error occurred.
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the bm_buttons library is already initialized.
+ * @retval NRF_ERROR_INTERNAL If an error occurred.
  */
-int bm_buttons_deinit(void);
+uint32_t bm_buttons_deinit(void);
 
 /**
  * @brief Enable button detection.
  *
- * @retval 0 on success.
- * @retval -EPERM If the bm_buttons library is not initialized.
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the bm_buttons library is not initialized.
  */
-int bm_buttons_enable(void);
+uint32_t bm_buttons_enable(void);
 
 /**
  * @brief Disable button detection.
  *
- * @retval 0 on success.
- * @retval -EPERM If the bm_buttons library is not initialized.
- * @retval -EIO If an error occurred.
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the bm_buttons library is not initialized.
+ * @retval NRF_ERROR_INTERNAL If an error occurred.
  */
-int bm_buttons_disable(void);
+uint32_t bm_buttons_disable(void);
 
 /**
  * @brief Check if a button is being pressed.

--- a/samples/peripherals/buttons/src/main.c
+++ b/samples/peripherals/buttons/src/main.c
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <stdint.h>
 #include <zephyr/sys/printk.h>
-#include <bm_buttons.h>
-
-#include <board-config.h>
 #include <zephyr/logging/log_ctrl.h>
+#include <s115/nrf_error.h>
+#include <board-config.h>
+
+#include <bm_buttons.h>
 
 static volatile bool running;
 
@@ -23,7 +25,7 @@ static void button_handler(uint8_t pin, uint8_t action)
 
 int main(void)
 {
-	int err;
+	uint32_t err;
 
 	printk("Buttons sample started\n");
 
@@ -58,14 +60,14 @@ int main(void)
 
 	err = bm_buttons_init(configs, ARRAY_SIZE(configs), BM_BUTTONS_DETECTION_DELAY_MIN_US);
 	if (err) {
-		printk("Failed to initialize buttons, err: %d\n", err);
-		return err;
+		printk("Failed to initialize buttons, err: 0x%x\n", err);
+		return -1;
 	}
 
 	err = bm_buttons_enable();
 	if (err) {
-		printk("Failed to enable buttons, err: %d\n", err);
-		return err;
+		printk("Failed to enable buttons, err: 0x%x\n", err);
+		return -1;
 	}
 
 	printk("Buttons initialized, press button 3 to terminate\n");
@@ -81,8 +83,8 @@ int main(void)
 
 	err = bm_buttons_deinit();
 	if (err) {
-		printk("Failed to deinitialize buttons, err: %d\n", err);
-		return err;
+		printk("Failed to deinitialize buttons, err: 0x%x\n", err);
+		return -1;
 	}
 
 	printk("Bye\n");


### PR DESCRIPTION
Refactors errnos into NRF_* errors.

Depends on:

- [ ] Unified `nrf_error.h` solution

TODOs:

- [ ] Update usage in other samples (e.g. CGMS)