### PR TITLE
boards: nordic: bm_nrf54l15dk: update ram partitions

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
@@ -49,14 +49,14 @@
 			reg = <0x20000000 DT_SIZE_K(5)>;
 		};
 
-		softdevice_dynamic_ram: partition@20001678 {
+		softdevice_dynamic_ram: partition@20001400 {
 			label = "softdevice_dynamic_ram";
-			reg = <0x20001678 DT_SIZE_K(12)>;
+			reg = <0x20001400 DT_SIZE_K(12)>;
 		};
 
-		app_ram: partition@20004678 {
+		app_ram: partition@20004400 {
 			label = "app_ram";
-			reg = <0x20004678 DT_SIZE_K(78)>;
+			reg = <0x20004400 DT_SIZE_K(79)>;
 		};
 	};
 };

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.yaml
@@ -13,5 +13,5 @@ toolchain:
   - xtools
   - zephyr
 sysbuild: true
-ram: 78
+ram: 79
 flash: 372

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
@@ -49,14 +49,14 @@
 			reg = <0x20000000 DT_SIZE_K(5)>;
 		};
 
-		softdevice_dynamic_ram: partition@20001678 {
+		softdevice_dynamic_ram: partition@20001400 {
 			label = "softdevice_dynamic_ram";
-			reg = <0x20001678 DT_SIZE_K(12)>;
+			reg = <0x20001400 DT_SIZE_K(12)>;
 		};
 
-		app_ram: partition@20004678 {
+		app_ram: partition@20004400 {
 			label = "app_ram";
-			reg = <0x20004678 DT_SIZE_K(174)>;
+			reg = <0x20004400 DT_SIZE_K(175)>;
 		};
 	};
 };

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.yaml
@@ -13,5 +13,5 @@ toolchain:
   - xtools
   - zephyr
 sysbuild: true
-ram: 174
+ram: 175
 flash: 884

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
@@ -49,14 +49,14 @@
 			reg = <0x20000000 DT_SIZE_K(5)>;
 		};
 
-		softdevice_dynamic_ram: partition@20001678 {
+		softdevice_dynamic_ram: partition@20001400 {
 			label = "softdevice_dynamic_ram";
-			reg = <0x20001678 DT_SIZE_K(12)>;
+			reg = <0x20001400 DT_SIZE_K(12)>;
 		};
 
-		app_ram: partition@20004678 {
+		app_ram: partition@20004400 {
 			label = "app_ram";
-			reg = <0x20004678 DT_SIZE_K(238)>;
+			reg = <0x20004400 DT_SIZE_K(239)>;
 		};
 	};
 };

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.yaml
@@ -13,5 +13,5 @@ toolchain:
   - xtools
   - zephyr
 sysbuild: true
-ram: 238
+ram: 239
 flash: 1396


### PR DESCRIPTION
Update ram partitions for SoftDevice and application to default values that are fine for use with all samples.

In most cases SoftDevice is not using all the memory dedicated to it in devicetree (5KB + 12KB). If more application ram is needed, set CONFIG_NRF_SDH_LOG_LEVEL_DBG=y and see log messages from SoftDevice initialization/enabling telling how the app_ram partition can be adjusted. This adjustment is based on how much ram is needed by the SoftDevice given the current SoftDevice configuration (configured during initialization/enabling of SoftDevice).