### PR TITLE
boards: nordic: bm_nrf54l15dk: remove grtc clkout pinctrl node

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
@@ -41,20 +41,3 @@
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
 };
-
-&pinctrl {
-	/omit-if-no-ref/ grtc_default: grtc_default {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-		};
-	};
-
-	/omit-if-no-ref/ grtc_sleep: grtc_sleep {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-			low-power-enable;
-		};
-	};
-};

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -41,20 +41,3 @@
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
 };
-
-&pinctrl {
-	/omit-if-no-ref/ grtc_default: grtc_default {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-		};
-	};
-
-	/omit-if-no-ref/ grtc_sleep: grtc_sleep {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-			low-power-enable;
-		};
-	};
-};

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -41,20 +41,3 @@
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
 };
-
-&pinctrl {
-	/omit-if-no-ref/ grtc_default: grtc_default {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-		};
-	};
-
-	/omit-if-no-ref/ grtc_sleep: grtc_sleep {
-		group1 {
-			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
-				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
-			low-power-enable;
-		};
-	};
-};


### PR DESCRIPTION
Remove the grtc clkout pinctrl nodes. They are not planned to be used in bm. If the clkout functionality is to be used, nrfx drivers should be used directly.