### PR TITLE
boards: nordic: bm_nrf54l15dk: update rram size nRF54L10 emulation target

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -22,7 +22,7 @@
 
 /* Override NCS default to use entire RRAM for application CPU. */
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1022)>;
+	reg = <0x0 DT_SIZE_K(1012)>;
 };
 
 &gpregret1 {


### PR DESCRIPTION
Correct the maximum rram size for the nRF54L10 emulation board target on the bm_nrf54l15dk board.