### PR TITLE
lib: ble_conn_params: fix data length update procedure timeout and data_length_get

### DIFF
--- a/lib/ble_conn_params/Kconfig
+++ b/lib/ble_conn_params/Kconfig
@@ -101,6 +101,11 @@ config BLE_CONN_PARAMS_DATA_LENGTH
 	int "Data length"
 	range 27 251
 	default 27
+	help
+	  This option sets an application defined upper limit on the negotiated data length.
+	  Note that the SoftDevice ATT MTU configuration places limitations on the maximum
+	  negotiable data length. This is due to memory efficiency. For instance, to use the
+	  definitive max data length of 251, the ATT MTU needs to be configured to at least 247.
 
 config BLE_CONN_PARAMS_INITIATE_DATA_LENGTH_UPDATE
 	bool "Initiate data length update on connection" if BLE_CONN_PARAMS_DATA_LENGTH != 27


### PR DESCRIPTION
* Fix ble_conn_params_data_length_get returning the wrong value in some cases.
* Fix a data length update procedure related connection timeout issue.

~Depends partly on https://github.com/nrfconnect/sdk-nrf-bm/pull/193, which introduces DLE for S115.~ (Merged)
(Needed only for actually being able to test. The data_length part of the ble_conn_params library is not used unless the SoftDevice supports DLE.) Should be merged after the SoftDevice update.