### PR TITLE
boards: dts: Update memory layout for nRF54L

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
@@ -12,6 +12,21 @@
 		zephyr,flash-controller = &rram_controller;
 		zephyr,boot-mode = &boot_mode0;
 	};
+
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			 nrf_kmu_reserved_push_area: memory@20000000 {
+				reg = <0x20000000 0x80>;
+				compatible = "zephyr,memory-region", "mmio-sram";
+				zephyr,memory-region = "nrf_kmu_reserved_push_area";
+				status = "okay";
+			 };
+		};
+	};
 };
 
 /* Override NCS default to use entire SRAM for application CPU. */

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
@@ -63,9 +63,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001678 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
@@ -99,9 +99,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001400 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -12,6 +12,21 @@
 		zephyr,flash-controller = &rram_controller;
 		zephyr,boot-mode = &boot_mode0;
 	};
+
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			 nrf_kmu_reserved_push_area: memory@20000000 {
+				reg = <0x20000000 0x80>;
+				compatible = "zephyr,memory-region", "mmio-sram";
+				zephyr,memory-region = "nrf_kmu_reserved_push_area";
+				status = "okay";
+			 };
+		};
+	};
 };
 
 /* Override NCS default to use entire SRAM for application CPU. */

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
@@ -63,9 +63,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001678 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
@@ -99,9 +99,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001400 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -12,6 +12,21 @@
 		zephyr,flash-controller = &rram_controller;
 		zephyr,boot-mode = &boot_mode0;
 	};
+
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			 nrf_kmu_reserved_push_area: memory@20000000 {
+				reg = <0x20000000 0x80>;
+				compatible = "zephyr,memory-region", "mmio-sram";
+				zephyr,memory-region = "nrf_kmu_reserved_push_area";
+				status = "okay";
+			 };
+		};
+	};
 };
 
 /* Override NCS default to use entire SRAM for application CPU. */

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
@@ -63,9 +63,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001678 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
@@ -99,9 +99,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		softdevice_static_ram: partition@20000000 {
+		softdevice_static_ram: partition@20000080 {
 			label = "softdevice_static_ram";
-			reg = <0x20000000 DT_SIZE_K(5)>;
+			reg = <0x20000080 0x1380>;
 		};
 
 		softdevice_dynamic_ram: partition@20001400 {


### PR DESCRIPTION
    Adjust the memory layout of all the nRF54l variants
    to take into account that the top 64 bytes of RAM
    are reserved for the KMU. Here 128 bytes of memory are
    reserved for future proofness.
Depends on: https://github.com/nrfconnect/sdk-nrf/pull/23870