### PR TITLE
lib: ble_conn_params: Do not use LE coded if requested for S115

### DIFF
--- a/lib/ble_conn_params/phy_mode.c
+++ b/lib/ble_conn_params/phy_mode.c
@@ -29,7 +29,16 @@ BUILD_ASSERT(CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO ||
 static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 {
 	int err;
-	const ble_gap_phys_t phys = links[idx].phy_mode;
+	ble_gap_phys_t phys = links[idx].phy_mode;
+
+
+	if (phys.tx_phys != BLE_GAP_PHY_NOT_SET) {
+		phys.tx_phys &= BLE_GAP_PHYS_SUPPORTED;
+	}
+
+	if (phys.rx_phys != BLE_GAP_PHY_NOT_SET) {
+		phys.rx_phys &= BLE_GAP_PHYS_SUPPORTED;
+	}
 
 	err = sd_ble_gap_phy_update(conn_handle, &phys);
 	if (!err) {


### PR DESCRIPTION
Removes trying to use the unsupported LE coded PHY if a remote device requests it