### PR TITLE
logging: backends: uarte: Fix for log mode minimal

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -5,6 +5,10 @@
 #
 menu "Logging"
 
+if !LOG_MODE_MINIMAL
+
 rsource "backends/Kconfig"
+
+endif
 
 endmenu


### PR DESCRIPTION
Fixes for log mode minimal for bm UARTE log backend.