### PR TITLE
actions: manifest: Remove unnecessary cloning

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -27,11 +27,6 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           west init -l . || true
-          # We only import the NCS and zephyr manifests
-          west update nrf
-          west config manifest.path nrf
-          west update zephyr
-          west config manifest.path nrf-bm
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@ea38f222cddfbbb9debb5f0239f4139ae2677ebb # v1.8.0


### PR DESCRIPTION
As also described in https://github.com/nrfconnect/sdk-nrf/pull/23465, there's no need to run `west update` at all on the checked out sdk-nrf tree, because the manifest action will only parse the local manifests (i.e. the self: ones).