### PR TITLE
samples: boot: Throw error if not using correct board targets

### DIFF
--- a/samples/boot/mcuboot_recovery_entry/CMakeLists.txt
+++ b/samples/boot/mcuboot_recovery_entry/CMakeLists.txt
@@ -12,4 +12,8 @@ if(NOT (DEFINED SYSBUILD))
   message(FATAL_ERROR "This must be built with sysbuild.")
 endif()
 
+if(NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
+  message(FATAL_ERROR "Invalid MCUboot mode selected.")
+endif()
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/boot/mcuboot_recovery_retention/CMakeLists.txt
+++ b/samples/boot/mcuboot_recovery_retention/CMakeLists.txt
@@ -12,4 +12,8 @@ if(NOT (DEFINED SYSBUILD))
   message(FATAL_ERROR "This must be built with sysbuild.")
 endif()
 
+if(NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
+  message(FATAL_ERROR "Invalid MCUboot mode selected.")
+endif()
+
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
Throws a CMake error if the wrong board targets have been used, these samples are only valid when built using the MCUboot board targets which select the MCUboot operating mode