### PR TITLE
samples: ble_mcumgr: Fix wrong NULL pointer check

### DIFF
--- a/samples/mcumgr/ble_mcumgr/src/main.c
+++ b/samples/mcumgr/ble_mcumgr/src/main.c
@@ -50,9 +50,8 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	int err;
 
 	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(ctx, "context is NULL");
 
-	if (ctx == NULL || evt == NULL) {
+	if (evt == NULL) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes a wrong check for a NULL pointer that is expected to be NULL, and prevented softdevice events being forwarded