### PR TITLE
samples: bluetooth: Add power profiling sample.

### DIFF
--- a/doc/nrf-bm/links.txt
+++ b/doc/nrf-bm/links.txt
@@ -47,6 +47,9 @@
 .. _`Bluetooth Low Energy app`: https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html
 .. _`Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
 .. _`Configuring Kconfig`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/config_and_build/kconfig/index.html
+.. _`Power Profiler app`: https://docs.nordicsemi.com/bundle/nrf-connect-ppk/page/index.html
+.. _`Power Profiler Kit II (PPK2)`: https://docs.nordicsemi.com/bundle/ug_ppk2/page/UG/ppk/PPK_user_guide_Intro.html
+.. _`nRF Connect for Mobile`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-mobile
 
 .. ### DFU
 

--- a/samples/bluetooth/ble_pwr_profiling/CMakeLists.txt
+++ b/samples/bluetooth/ble_pwr_profiling/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ble_pwr_profiling)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/ble_pwr_profiling/Kconfig
+++ b/samples/bluetooth/ble_pwr_profiling/Kconfig
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "BLE Power Profiling sample"
+
+config BLE_PWR_PROFILING_ADV_NAME
+	string "Advertising name"
+	default "nRF_BM_PWR"
+
+config BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT
+	int "Connectable advertising timeout (10 ms units)"
+	range 0 18000
+	default 3000
+
+config BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL
+	int "Connectable advertising interval (0.625 ms units)"
+	range 32 16384
+	default 160
+
+config BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT
+	int "Non-connectable advertising timeout (10 ms units)"
+	range 0 18000
+	default 6000
+
+config BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL
+	int "Non-connectable advertising interval (0.625 ms units)"
+	range 32 16384
+	default 1600
+
+config BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT
+	int "Notification connection timeout"
+	default 10000
+	help
+	  The time before the application disconnects after notifications are enabled.
+
+config BLE_PWR_PROFILING_CHAR_VALUE_LEN
+	int "Size of characteristic value"
+	default 20
+
+config BLE_PWR_PROFILING_LED
+	bool "Power profiling LED"
+	default y
+
+module=BLE_PWR_PROFILING_SAMPLE
+module-dep=LOG
+module-str=BLE Power Profiling Sample
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endmenu # "BLE Power Profiling sample"
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -1,0 +1,227 @@
+.. _ble_pwr_profiling_sample:
+
+Bluetooth: Power Profiling
+##########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This sample can be used to measure power consumption when Bluetooth® Low Energy is used for communication.
+You can measure power consumption during advertising and data transmission.
+For this purpose, the sample demonstrates advertising in a connectable and non-connectable mode.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Hardware platform
+     - PCA
+     - SoftDevice
+     - Board target
+   * - `nRF54L15 DK`_
+     - PCA10156
+     - S115
+     - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+   * - `nRF54L15 DK`_ (emulating nRF54L10)
+     - PCA10156
+     - S115
+     - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+   * - `nRF54L15 DK`_ (emulating nRF54L05)
+     - PCA10156
+     - S115
+     - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+
+Optionally, you can use the `Power Profiler Kit II (PPK2)`_ for power profiling and optimizing your configuration.
+You can also use your proprietary solution for measuring the power consumption.
+
+Overview
+********
+
+This sample implements the low power mode and the system off mode.
+
+**Low power mode**
+
+The application enters CPU sleep mode when in idle state, which means it has nothing to schedule.
+Wake-up events are interrupts triggered by one of the SoC peripheral modules, such as RTC or SystemTick.
+
+**System off mode**
+
+The system is put in system off mode 5 seconds after power up, unless advertising is started, and when the device disconnects from the central device.
+This is the deepest power saving mode the system can enter.
+In this mode, all core functionalities are powered down, and most peripherals are non-functional or non-responsive.
+The only mechanisms that are functional in this mode are reset and wake-up.
+
+To wake up your development kit from the system off state, you have the following options:
+
+* Press the **RESET** button on your development kit.
+* Press **Button 0** to start connectable advertising.
+* Press **Button 1** to start non-connectable advertising.
+
+The development kit starts advertising automatically when pressing **Button 0** or **Button 1** and goes to **System off mode** when pressing **RESET**.
+
+When you establish a connection with a central device, you can test different connection parameters to optimize the power consumption.
+When the central device enables the notification characteristic, your development kit starts sending notifications until the timeout set by the :kconfig:option:`CONFIG_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT` Kconfig option expires.
+The device then disconnects from the central and enters the system off mode.
+You can press a button to wake up the device and continue testing.
+
+Power profiling
+===============
+
+You can use the `Power Profiler Kit II (PPK2)`_ for power profiling with this sample.
+See the device documentation for details about preparing your development kit for measurements.
+
+The following parameters have an impact on power consumption:
+
+   * Connection interval
+   * Advertising duration
+   * Latency
+   * Notifications data size and interval
+
+You can configure these parameters with the Kconfig options.
+If your central device is the `Bluetooth Low Energy app`_ from `nRF Connect for Desktop`_, you can use it to change the current connection parameters.
+
+Service UUID
+============
+
+This sample implements a custom service.
+
+The 128-bit service UUID is ``00001630-1212-EFDE-1523-785FEABCD123``.
+
+Characteristics
+===============
+
+The 128-bit characteristic UUID is ``00001631-1212-EFDE-1523-785FEABCD123``.
+This characteristic value can be read or sent by the notification mechanism.
+The value is an array filled with zeroes, where upon enabling notifications the value of the last byte will increase per notification.
+You can configure the length of data using the :kconfig:option:`CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN` Kconfig option.
+
+This characteristic has a client characteristic configuration descriptor (CCCD) associated with it.
+
+User interface
+**************
+
+The sample uses buttons and LEDs to provide a simple user interface.
+
+Button 0:
+    Starts connectable advertising and wakes up the SoC from the system off state.
+
+Button 1:
+    Starts non-connectable advertising and wakes up the SoC from the system off state.
+
+LED 0:
+    Lit when the main loop is running.
+    Off when the device is in system off state.
+
+.. note::
+   When you use buttons to wake up the SoC from the system off state, the button state is read in the main thread.
+   This causes a delay between the SoC wake up and button press processing.
+   If you want to start advertising on system start, you must keep pressing the button until you see a log message confirming the advertising start on the terminal.
+
+Configuration
+*************
+
+The Peripheral Power Profiling sample allows configuring some of its settings using Kconfig.
+You can set different options to monitor the power consumption of your development kit.
+You can modify the following options (available in the Kconfig file at :file:`samples/bluetooth/ble_pwr_profiling`):
+
+.. _CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN:
+
+CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN - Notification data length
+   Sets the length of the data sent through notification mechanism.
+
+.. _CONFIG_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT:
+
+CONFIG_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT - Notification timeout
+   Sets the notification timeout in milliseconds.
+   When this timeout fires the device will stop sending notifications.
+   After that, the sample disconnects and enters the system off mode.
+
+.. _CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT:
+
+CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT - Connectable advertising timeout
+   Sets the connectable advertising duration in N*10 milliseconds unit.
+   If the connection is not established during advertising, the device enters the system off state.
+
+.. _CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL:
+
+CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL - Connectable advertising interval
+   Sets the connectable advertising interval in 0.625 milliseconds unit.
+
+.. _CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT:
+
+CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT - Non-connectable advertising timeout
+   Sets the non-connectable advertising duration in N*10 milliseconds unit.
+   When the advertising ends, the device enters the system off state if there is no outgoing connection.
+
+.. _CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL:
+
+CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL - Non-connectable advertising interval
+   Sets the non-connectable advertising interval in 0.625 milliseconds unit.
+
+.. _CONFIG_BLE_PWR_PROFILING_LED:
+
+CONFIG_BLE_PWR_PROFILING_LED - Enable LEDs
+   Enabled by default. The LEDs can be disabled to reduce power consumption.
+
+Programming the S115 SoftDevice
+*******************************
+
+.. include:: /includes/softdevice_flash.txt
+
+.. _ble_pwr_profiling_sample_testing:
+
+Building and running
+********************
+
+This sample can be found under :file:`samples/bluetooth/ble_pwr_profiling/` in the |BMshort| folder structure.
+
+.. include:: /includes/create_sample.txt
+
+.. include:: /includes/configure_and_build_sample.txt
+
+.. note::
+   To remove terminal messages (at the benefit of a very small decrease in power consumption), disable the following Kconfig options:
+   * :kconfig:option:`CONFIG_LOG`
+   * :kconfig:option:`CONFIG_CONSOLE`
+   * :kconfig:option:`CONFIG_LOG_BACKEND_BM_UARTE`
+
+.. include:: /includes/program_sample.txt
+
+Testing
+=======
+
+This testing procedure assumes that you are using `nRF Connect for Mobile`_ or `nRF Connect for Desktop`_.
+After programming the sample to your development kit, you need another device for measuring the power consumption.
+`Power Profiler Kit II (PPK2)`_ is the recommended device for the measurement.
+
+Testing with Bluetooth Low Energy app and Power Profiler Kit II (PPK2)
+----------------------------------------------------------------------
+
+1. Set up `Power Profiler Kit II (PPK2)`_ and prepare your development kit for current measurement.
+#. Run the `Power Profiler app`_ from nRF Connect for Desktop.
+#. Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_).
+#. Reset your development kit.
+#. Observe that the sample starts.
+   The device enters the system off state after five seconds if advertising is not started.
+   Observe a significant power consumption drop when the device enters the system off state.
+#. Use the device buttons to wake up your device and start advertising.
+   You can measure power consumption during advertising with different intervals.
+   Use the Kconfig options to change the interval or other parameters.
+#. Connect to the device through the `Bluetooth Low Energy app`_.
+#. Set different connection parameters:
+
+   a. Click :guilabel:`Settings` for the connected device in the Bluetooth Low Energy app.
+   #. Select :guilabel:`Update connection`.
+   #. Set new connection parameters.
+   #. Click :guilabel:`Update` to negotiate new parameters with your device.
+
+#. Observe the power consumption with the new connection parameters.
+#. In service with UUID :guilabel:`000016301212EFDE1523785FEABCD123`, click :guilabel:`Notify` for the characteristic.
+#. Observe that notifications are received.
+#. After the timeout set by the :kconfig:option:`CONFIG_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT` option, your development kit disconnects and enters the system off mode.
+#. Repeat this test using different wake-up methods and different parameters, and monitor the power consumption for your new setup.

--- a/samples/bluetooth/ble_pwr_profiling/prj.conf
+++ b/samples/bluetooth/ble_pwr_profiling/prj.conf
@@ -1,0 +1,31 @@
+# Logging
+CONFIG_LOG=y
+CONFIG_LOG_BACKEND_BM_UARTE=y
+CONFIG_CONSOLE=y
+
+# SoftDevice and SoftDevice handler library
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
+# Require storage of a vendor UUID
+CONFIG_NRF_SDH_BLE_VS_UUID_COUNT=1
+
+# Connection parameter configurations
+CONFIG_BLE_CONN_PARAMS_MAX_CONN_INTERVAL=800
+CONFIG_BLE_CONN_PARAMS_SUP_TIMEOUT=1000
+CONFIG_BLE_CONN_PARAMS_MAX_SLAVE_LATENCY_DEVIATION=4
+
+# BLE connection parameter
+CONFIG_BLE_CONN_PARAMS=y
+
+# QWR
+CONFIG_BLE_QWR=y
+
+# Advertising library, needed for ble_adv_data
+CONFIG_BLE_ADV=y
+
+# Timer library
+CONFIG_BM_TIMER=y
+
+# Button library
+CONFIG_BM_BUTTONS=y

--- a/samples/bluetooth/ble_pwr_profiling/sample.yaml
+++ b/samples/bluetooth/ble_pwr_profiling/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: BLE Power Profiling Sample
+tests:
+  sample.ble_pwr_profiling:
+    build_only: true
+    integration_platforms:
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+    platform_allow:
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+    tags: ci_build

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -1,0 +1,740 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include <stdint.h>
+#include <errno.h>
+#include <string.h>
+#include <bluetooth/services/common.h>
+#include <bm_timer.h>
+#include <bm_buttons.h>
+#include <ble_adv_data.h>
+#include <ble_conn_params.h>
+#include <ble_gap.h>
+#include <ble_qwr.h>
+#include <nrf_sdh.h>
+#include <nrf_sdh_ble.h>
+#include <nrf_soc.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/util.h>
+#include <board-config.h>
+
+#include <zephyr/toolchain.h>
+#include <zephyr/drivers/retained_mem/nrf_retained_mem.h>
+
+#include <hal/nrf_regulators.h>
+#include <helpers/nrfx_reset_reason.h>
+
+#include <hal/nrf_gpio.h>
+
+#if defined(CONFIG_HAS_NORDIC_RAM_CTRL)
+#include <helpers/nrfx_ram_ctrl.h>
+#endif
+
+LOG_MODULE_REGISTER(app, CONFIG_BLE_PWR_PROFILING_SAMPLE_LOG_LEVEL);
+
+/** Custom UUID base for the Service. */
+#define BLE_UUID_BASE { 0x23, 0xD1, 0xBC, 0xEA, 0x5F, 0x78, 0x23, 0x15, \
+			0xDE, 0xEF, 0x12, 0x12, 0x30, 0x16, 0x00, 0x00 }
+
+/** Byte 12 and 13 of the  Service UUID. */
+#define BLE_UUID_PWR_SERVICE 0x1630
+/** Byte 12 and 13 of the Characteristic UUID. */
+#define BLE_UUID_PWR_CHARACTERISTIC 0x1631
+
+/* Notification connection timeout. */
+#define NOTIF_CONN_TIMEOUT CONFIG_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT
+
+/** Characteristic notification timer. */
+static struct bm_timer char_notif_timer;
+/** Connection timer. */
+static struct bm_timer connection_timer;
+/** Poweroff timer. */
+static struct bm_timer poweroff_timer;
+
+/** BLE QWR instance. */
+BLE_QWR_DEF(ble_qwr);
+/** Characteristic value. */
+static uint8_t char_value[CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN];
+/** Handle of the current connection. */
+static uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
+/** Connection interval. */
+static uint16_t conn_interval_ms = (CONFIG_BLE_CONN_PARAMS_MIN_CONN_INTERVAL * 5) / 4;
+/** Attribute handles related to power profiling characteristic. */
+static ble_gatts_char_handles_t char_handles;
+/** UUID type. */
+static uint8_t uuid_type;
+
+/** Advertising modes. */
+enum adv_mode {
+	ADV_MODE_IDLE,
+	ADV_MODE_CONN,
+	ADV_MODE_NONCONN,
+};
+
+/** Current advertising mode. */
+static enum adv_mode adv_mode_current;
+/** Advertising parameters. */
+static ble_gap_adv_params_t adv_params;
+/* Advertising handle. */
+static uint8_t adv_handle;
+/* Advertising data. */
+static ble_gap_adv_data_t gap_adv_data;
+/* Encoded advertising data. */
+static uint8_t enc_adv_data[2][BLE_GAP_ADV_SET_DATA_SIZE_MAX];
+/* Encoded scan response data. */
+static uint8_t enc_scan_rsp_data[2][BLE_GAP_ADV_SET_DATA_SIZE_MAX];
+
+/** Power of the SoC. */
+static void poweroff(void)
+{
+	LOG_INF("Power off");
+	while (LOG_PROCESS()) {
+	}
+
+#if defined(CONFIG_BLE_PWR_PROFILING_LED)
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, !BOARD_LED_ACTIVE_STATE);
+#endif
+
+#if defined(CONFIG_HAS_NORDIC_RAM_CTRL)
+	uint8_t *ram_start;
+	size_t ram_size;
+
+#if defined(NRF_MEMORY_RAM_BASE)
+	ram_start = (uint8_t *)NRF_MEMORY_RAM_BASE;
+#else
+	ram_start = (uint8_t *)NRF_MEMORY_RAM0_BASE;
+#endif
+
+	ram_size = 0;
+#if defined(NRF_MEMORY_RAM_SIZE)
+	ram_size += NRF_MEMORY_RAM_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM0_SIZE)
+	ram_size += NRF_MEMORY_RAM0_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM1_SIZE)
+	ram_size += NRF_MEMORY_RAM1_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM2_SIZE)
+	ram_size += NRF_MEMORY_RAM2_SIZE;
+#endif
+
+	/* Disable retention for all memory blocks */
+	nrfx_ram_ctrl_retention_enable_set(ram_start, ram_size, false);
+
+#endif /* defined(CONFIG_HAS_NORDIC_RAM_CTRL) */
+
+#if defined(CONFIG_RETAINED_MEM_NRF_RAM_CTRL)
+	/* Restore retention for retained_mem driver regions defined in devicetree */
+	(void)z_nrf_retained_mem_retention_apply();
+#endif
+
+#if defined(CONFIG_SOC_SERIES_NRF54LX)
+	nrfx_reset_reason_clear(UINT32_MAX);
+#endif
+
+	nrf_regulators_system_off(NRF_REGULATORS);
+
+	CODE_UNREACHABLE;
+}
+
+static uint32_t ble_pwr_profiling_char_add(const uint8_t uuid_type, uint16_t service_handle,
+					   ble_gatts_char_handles_t *char_handles)
+{
+	ble_uuid_t char_uuid = {
+		.type = uuid_type,
+		.uuid = BLE_UUID_PWR_CHARACTERISTIC,
+	};
+	ble_gatts_attr_md_t cccd_md = {
+		.vloc = BLE_GATTS_VLOC_STACK
+	};
+	ble_gatts_char_md_t char_md = {
+		.char_props = {
+			.read = true,
+			.notify = true,
+		},
+		.p_cccd_md = &cccd_md,
+	};
+	ble_gatts_attr_md_t attr_md = {
+		.vloc = BLE_GATTS_VLOC_STACK,
+	};
+	ble_gatts_attr_t attr_char_value = {
+		.p_uuid = &char_uuid,
+		.p_attr_md = &attr_md,
+		.p_value = char_value,
+		.init_len = CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN,
+		.max_len = CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN,
+	};
+
+	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+	BLE_GAP_CONN_SEC_MODE_SET_NO_ACCESS(&attr_md.write_perm);
+
+	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.read_perm);
+	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
+
+	/* Add characteristic declaration and value attributes. */
+	return sd_ble_gatts_characteristic_add(service_handle, &char_md, &attr_char_value,
+					       char_handles);
+}
+
+/* Send characteristic notification to peer if in a connected state and notification is enabled. */
+static void notification_send(void)
+{
+	uint32_t err;
+	uint16_t len = CONFIG_BLE_PWR_PROFILING_CHAR_VALUE_LEN;
+
+	/* Increase last byte of characteristic value to have different values on each update*/
+	char_value[0]++;
+
+	/* Send value if connected and notifying. */
+	if (conn_handle != BLE_CONN_HANDLE_INVALID) {
+		ble_gatts_hvx_params_t hvx_params = {
+			.handle = char_handles.value_handle,
+			.type   = BLE_GATT_HVX_NOTIFICATION,
+			.offset = 0,
+			.p_len  = &len,
+			.p_data = char_value,
+		};
+
+		err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
+		if ((err != NRF_SUCCESS) &&
+		    (err != NRF_ERROR_INVALID_STATE) &&
+		    (err != NRF_ERROR_RESOURCES) &&
+		    (err != BLE_ERROR_GATTS_SYS_ATTR_MISSING)) {
+			LOG_ERR("sd_ble_gatts_hvx failed, nrf_error %#x", err);
+		}
+	}
+}
+
+/* Connection interval timeout.
+ * This function will be called when the connection interval timer expires. This will
+ * trigger another characteristic notification to the peer.
+ */
+static void char_notif_timeout_handler(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	/*  Send one notification. */
+	notification_send();
+}
+
+
+/* Connection timeout.
+ * This function will be called when the connection timer expires. This will stop the
+ * timer for characteristic notification and disconnect from the peer.
+ */
+static void connection_timeout_handler(void *ctx)
+{
+	int err;
+
+	ARG_UNUSED(ctx);
+
+	/* Stop all notifications (by stopping the timer for connection interval that triggers
+	 * notifications and disconnecting from peer).
+	 */
+	err = bm_timer_stop(&char_notif_timer);
+	if (err) {
+		LOG_ERR("Failed to stop timer, err %d", err);
+	}
+
+	err = sd_ble_gap_disconnect(conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to disconnect, nrf_error %#x", err);
+	}
+}
+
+/* Poweroff timeout.
+ * This function will be called when the poweroff timer triggers.
+ */
+static void poweroff_timeout_handler(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	poweroff();
+}
+
+/* Handle gatt write event.
+ * If notifications are enabled, this will start a timer to send a notification on each connection
+ * interval. In addition a connection timer is started, that disconnects the peripheral on timeout.
+ */
+static void on_write(ble_evt_t const *ble_evt)
+{
+	uint32_t err;
+	bool notif_enabled;
+	ble_gatts_evt_write_t const *evt_write = &ble_evt->evt.gatts_evt.params.write;
+
+	if ((evt_write->handle == char_handles.cccd_handle) && (evt_write->len == 2)) {
+		/* CCCD written. Start notifications */
+		notif_enabled = is_notification_enabled(evt_write->data);
+
+		if (notif_enabled) {
+			err = bm_timer_start(&char_notif_timer,
+					     BM_TIMER_MS_TO_TICKS(conn_interval_ms), NULL);
+			if (err) {
+				LOG_ERR("Failed to start conn interval timer, err %d", err);
+			}
+
+			err = bm_timer_start(&connection_timer,
+					     BM_TIMER_MS_TO_TICKS(NOTIF_CONN_TIMEOUT), NULL);
+			if (err) {
+				LOG_ERR("Failed to start notif timer, err %d", err);
+			}
+
+			notification_send();
+		} else {
+			err = bm_timer_stop(&char_notif_timer);
+			if (err) {
+				LOG_ERR("Failed to stop conn interval timer, err %d", err);
+			}
+
+			err = bm_timer_stop(&connection_timer);
+			if (err) {
+				LOG_ERR("Failed to stop notif timer, err %d", err);
+			}
+		}
+	}
+}
+
+static void on_ble_evt(const ble_evt_t *evt, void *ctx)
+{
+	int err;
+
+	switch (evt->header.evt_id) {
+	case BLE_GAP_EVT_CONNECTED:
+		LOG_INF("Peer connected");
+		conn_handle = evt->evt.gap_evt.conn_handle;
+		break;
+
+	case BLE_GAP_EVT_DISCONNECTED:
+		LOG_INF("Peer disconnected");
+		if (conn_handle == evt->evt.gap_evt.conn_handle) {
+			conn_handle = BLE_CONN_HANDLE_INVALID;
+			err = bm_timer_stop(&connection_timer);
+			if (err) {
+				LOG_ERR("Failed to stop timer, err %d", err);
+			}
+			poweroff();
+		}
+		break;
+
+	case BLE_GAP_EVT_AUTH_STATUS:
+		LOG_INF("Authentication status: %#x",
+			evt->evt.gap_evt.params.auth_status.auth_status);
+		break;
+
+	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
+		/* Pairing not supported */
+		err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
+						  BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL);
+		if (err != NRF_SUCCESS) {
+			LOG_ERR("Failed to reply with Security params, nrf_error %#x", err);
+		}
+		break;
+
+	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
+		/* No system attributes have been stored */
+		err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		if (err != NRF_SUCCESS) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		}
+		break;
+
+	case BLE_GATTS_EVT_WRITE:
+		on_write(evt);
+		break;
+
+	case BLE_GAP_EVT_ADV_SET_TERMINATED:
+		const uint8_t reason = evt->evt.gap_evt.params.adv_set_terminated.reason;
+
+		if (reason == BLE_GAP_EVT_ADV_SET_TERMINATED_REASON_TIMEOUT ||
+		    reason == BLE_GAP_EVT_ADV_SET_TERMINATED_REASON_LIMIT_REACHED) {
+			poweroff();
+		}
+		break;
+	default:
+		break;
+	}
+}
+NRF_SDH_BLE_OBSERVER(sdh_ble, on_ble_evt, NULL, 0);
+
+static void on_conn_params_evt(const struct ble_conn_params_evt *evt)
+{
+	int err;
+
+	switch (evt->id) {
+	case BLE_CONN_PARAMS_EVT_REJECTED:
+		err = sd_ble_gap_disconnect(evt->conn_handle, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE);
+		if (err) {
+			LOG_ERR("Disconnect failed on conn params update rejection, nrf_error %#x",
+				err);
+		} else {
+			LOG_INF("Disconnected from peer, unacceptable conn params");
+		}
+		break;
+
+	case BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED:
+		if (evt->conn_handle != conn_handle) {
+			LOG_DBG("Connection handle does not match, expected %d, was %d",
+				conn_handle, evt->conn_handle);
+			break;
+		}
+		break;
+
+	case BLE_CONN_PARAMS_EVT_UPDATED:
+		if (evt->conn_handle == conn_handle) {
+			conn_interval_ms = (evt->conn_params.max_conn_interval * 5) / 4;
+		}
+		break;
+
+	default:
+		break;
+	}
+}
+
+static uint16_t on_ble_qwr_evt(struct ble_qwr *qwr, const struct ble_qwr_evt *qwr_evt)
+{
+	switch (qwr_evt->evt_type) {
+	case BLE_QWR_EVT_ERROR:
+		LOG_ERR("QWR error event, nrf_error 0x%x", qwr_evt->error.reason);
+		break;
+	case BLE_QWR_EVT_EXECUTE_WRITE:
+		LOG_INF("QWR execute write event");
+		break;
+	case BLE_QWR_EVT_AUTH_REQUEST:
+		LOG_INF("QWR auth request event");
+		break;
+	}
+
+	return BLE_GATT_STATUS_SUCCESS;
+}
+
+/* Initialize BLE service */
+static uint32_t ble_service_init(uint16_t *service_handle, uint8_t *uuid_type,
+				 ble_gatts_char_handles_t *char_handles)
+{
+	uint32_t err;
+	ble_uuid_t ble_uuid;
+	ble_uuid128_t uuid_base = {
+		.uuid128 = BLE_UUID_BASE
+	};
+
+	if (!service_handle || !uuid_type) {
+		return NRF_ERROR_NULL;
+	}
+
+	/* Initialize the service structure. */
+	*service_handle = BLE_CONN_HANDLE_INVALID;
+
+	/* Add a custom base UUID. */
+	err = sd_ble_uuid_vs_add(&uuid_base, uuid_type);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to add base UUID, nrf_error %#x", err);
+		return err;
+	}
+
+	ble_uuid.type = *uuid_type;
+	ble_uuid.uuid = BLE_UUID_PWR_SERVICE;
+
+	/* Add the service. */
+	err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid, service_handle);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to add pwr profiling service, nrf_error %#x", err);
+		return err;
+	}
+
+	/* Add characteristic. */
+	err = ble_pwr_profiling_char_add(*uuid_type, *service_handle, char_handles);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to add pwr profiling characteristic, nrf_error %#x", err);
+		return err;
+	}
+
+	return NRF_SUCCESS;
+}
+
+/* Add optional advertising data and start advertising in the given mode */
+static void adv_data_update_and_start(enum adv_mode adv_mode, uint8_t uuid_type)
+{
+	uint32_t err;
+	/* Adding power profiling service UUID to the scan response data. */
+	ble_uuid_t adv_uuid_list[] = {
+		{
+			.uuid = BLE_UUID_PWR_SERVICE,
+			.type = uuid_type
+		},
+	};
+	ble_gap_adv_data_t new_adv_data = {0};
+
+	struct ble_adv_data adv_data = {
+		.name_type = BLE_ADV_DATA_FULL_NAME,
+		.flags = BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE,
+	};
+	struct ble_adv_data sr_data = {};
+
+	if (adv_mode_current != ADV_MODE_IDLE) {
+		err = sd_ble_gap_adv_stop(adv_handle);
+		if (err != NRF_SUCCESS) {
+			LOG_ERR("Failed to stop advertising, nrf_error %#x", err);
+			return;
+		}
+
+		LOG_INF("Advertising stopped. Reconfiguring...");
+	}
+
+	switch (adv_mode) {
+	case ADV_MODE_CONN:
+		sr_data.uuid_lists.complete.uuid = &adv_uuid_list[0];
+		sr_data.uuid_lists.complete.len = ARRAY_SIZE(adv_uuid_list);
+
+		memset(&adv_params, 0, sizeof(adv_params));
+		adv_params.properties.type = BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED;
+		adv_params.interval = CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL;
+		adv_params.duration = CONFIG_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT;
+		break;
+
+	case ADV_MODE_NONCONN:
+		sr_data.uuid_lists.complete.uuid = NULL;
+		sr_data.uuid_lists.complete.len = 0;
+
+		memset(&adv_params, 0, sizeof(adv_params));
+		adv_params.properties.type = BLE_GAP_ADV_TYPE_NONCONNECTABLE_SCANNABLE_UNDIRECTED;
+		adv_params.interval = CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL;
+		adv_params.duration = CONFIG_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT;
+		break;
+
+	default:
+		break;
+	}
+
+	new_adv_data.adv_data.p_data =
+		(new_adv_data.adv_data.p_data != enc_adv_data[0])
+			? enc_adv_data[0]
+			: enc_adv_data[1];
+
+	new_adv_data.adv_data.len = BLE_GAP_ADV_SET_DATA_SIZE_MAX;
+
+	err = ble_adv_data_encode(&adv_data, new_adv_data.adv_data.p_data,
+				  &new_adv_data.adv_data.len);
+	if (err) {
+		return;
+	}
+
+	new_adv_data.scan_rsp_data.p_data =
+		(new_adv_data.scan_rsp_data.p_data != enc_scan_rsp_data[0])
+			? enc_scan_rsp_data[0]
+			: enc_scan_rsp_data[1];
+
+	new_adv_data.scan_rsp_data.len = BLE_GAP_ADV_SET_DATA_SIZE_MAX;
+
+	err = ble_adv_data_encode(&sr_data, new_adv_data.scan_rsp_data.p_data,
+				  &new_adv_data.scan_rsp_data.len);
+	if (err) {
+		return;
+	}
+
+	memcpy(&gap_adv_data, &new_adv_data, sizeof(gap_adv_data));
+
+	err = sd_ble_gap_adv_set_configure(&adv_handle, &gap_adv_data, &adv_params);
+	if (err) {
+		LOG_ERR("Failed to set advertising data, nrf_error %#x", err);
+		return;
+	}
+
+	err = sd_ble_gap_adv_start(adv_handle, CONFIG_NRF_SDH_BLE_CONN_TAG);
+	if (err) {
+		LOG_ERR("Failed to start advertising, nrf_error %#x", err);
+		return;
+	}
+
+	adv_mode_current = adv_mode;
+
+	LOG_INF("Advertising as %s", CONFIG_BLE_PWR_PROFILING_ADV_NAME);
+}
+
+static void button_handler(uint8_t pin, uint8_t action)
+{
+	if (action != BM_BUTTONS_PRESS) {
+		return;
+	}
+
+	/* Cancel poweroff */
+	(void)bm_timer_stop(&poweroff_timer);
+
+	switch (pin) {
+	case BOARD_PIN_BTN_0:
+		adv_data_update_and_start(ADV_MODE_CONN, uuid_type);
+		break;
+
+	case BOARD_PIN_BTN_1:
+		adv_data_update_and_start(ADV_MODE_NONCONN, uuid_type);
+		break;
+
+	default:
+		break;
+	}
+}
+
+static uint32_t adv_init(void)
+{
+	uint32_t err;
+	ble_gap_conn_sec_mode_t sec_mode = {0};
+
+	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&sec_mode);
+	err = sd_ble_gap_device_name_set(&sec_mode, CONFIG_BLE_PWR_PROFILING_ADV_NAME,
+					 strlen(CONFIG_BLE_PWR_PROFILING_ADV_NAME));
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to set advertising name, nrf_error %#x", err);
+		return err;
+	}
+
+	gap_adv_data.adv_data.p_data = enc_adv_data[0];
+	gap_adv_data.adv_data.len = BLE_GAP_ADV_SET_DATA_SIZE_MAX;
+
+	adv_params.properties.type = BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED;
+	adv_params.duration = BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED;
+	adv_params.interval = BLE_GAP_ADV_INTERVAL_MAX;
+	adv_params.filter_policy = BLE_GAP_ADV_FP_ANY;
+	adv_params.primary_phy = BLE_GAP_PHY_AUTO;
+
+	err = sd_ble_gap_adv_set_configure(&adv_handle, NULL, &adv_params);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to set GAP advertising parameters, nrf_error %#x", err);
+		return err;
+	}
+
+	return NRF_SUCCESS;
+}
+
+int main(void)
+{
+	int err;
+	struct ble_qwr_config qwr_config = {
+		.evt_handler = on_ble_qwr_evt,
+	};
+
+	struct bm_buttons_config configs[2] = {
+		{
+			.pin_number = BOARD_PIN_BTN_0,
+			.active_state = BM_BUTTONS_ACTIVE_LOW,
+			.pull_config = BM_BUTTONS_PIN_PULLUP,
+			.handler = button_handler,
+		},
+		{
+			.pin_number = BOARD_PIN_BTN_1,
+			.active_state = BM_BUTTONS_ACTIVE_LOW,
+			.pull_config = BM_BUTTONS_PIN_PULLUP,
+			.handler = button_handler,
+		},
+	};
+
+	LOG_INF("BLE Power Profiling sample started");
+
+#if defined(CONFIG_BLE_PWR_PROFILING_LED)
+	nrf_gpio_cfg_output(BOARD_PIN_LED_0);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+#endif
+
+	err = ble_conn_params_evt_handler_set(on_conn_params_evt);
+	if (err) {
+		LOG_ERR("Failed to setup conn param event handler, err %d", err);
+		goto idle;
+	}
+
+	err = bm_timer_init(&char_notif_timer, BM_TIMER_MODE_REPEATED, char_notif_timeout_handler);
+	if (err) {
+		LOG_ERR("Failed to initialize characteristic notification timer, err %d", err);
+		goto idle;
+	}
+
+	err = bm_timer_init(&connection_timer, BM_TIMER_MODE_REPEATED, connection_timeout_handler);
+	if (err) {
+		LOG_ERR("Failed to initialize connection timer, err %d", err);
+		goto idle;
+	}
+
+	err = bm_timer_init(&poweroff_timer, BM_TIMER_MODE_SINGLE_SHOT, poweroff_timeout_handler);
+	if (err) {
+		LOG_ERR("Failed to initialize poweroff timer, err %d", err);
+		goto idle;
+	}
+
+	err = bm_buttons_init(configs, ARRAY_SIZE(configs), BM_BUTTONS_DETECTION_DELAY_MIN_US);
+	if (err) {
+		LOG_ERR("Failed to initialize buttons, err %d", err);
+		goto idle;
+	}
+
+	err = nrf_sdh_enable_request();
+	if (err) {
+		LOG_ERR("Failed to enable SoftDevice, err %d", err);
+		goto idle;
+	}
+
+	LOG_INF("SoftDevice enabled");
+
+	err = nrf_sdh_ble_enable(CONFIG_NRF_SDH_BLE_CONN_TAG);
+	if (err) {
+		LOG_ERR("Failed to enable BLE, err %d", err);
+		goto idle;
+	}
+
+	LOG_INF("Bluetooth enabled");
+
+	err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (err) {
+		LOG_ERR("Failed to initialize QWR, err %d", err);
+		goto idle;
+	}
+
+	err = adv_init();
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to initialize advertising, nrf_error %#x", err);
+		goto idle;
+	}
+
+	err = ble_service_init(&conn_handle, &uuid_type, &char_handles);
+	if (err != NRF_SUCCESS) {
+		LOG_ERR("Failed to initialize pwr profiling service, err %#x", err);
+		goto idle;
+	}
+
+	LOG_INF("Services initialized");
+
+	err = bm_buttons_enable();
+	if (err) {
+		LOG_ERR("Failed to enable buttons, err %d", err);
+		goto idle;
+	}
+
+	const bool connectable_adv = bm_buttons_is_pressed(BOARD_PIN_BTN_0);
+	const bool nonconnectable_adv = bm_buttons_is_pressed(BOARD_PIN_BTN_1);
+
+	if (connectable_adv) {
+		adv_data_update_and_start(ADV_MODE_CONN, uuid_type);
+	} else if (nonconnectable_adv) {
+		adv_data_update_and_start(ADV_MODE_NONCONN, uuid_type);
+	} else {
+		/* No advertising mode is selected at startup, power off */
+		LOG_INF("No advertising selected, schedule power off in 5 seconds");
+		err = bm_timer_start(&poweroff_timer, BM_TIMER_MS_TO_TICKS(5000), NULL);
+	}
+
+idle:
+	while (true) {
+		while (LOG_PROCESS()) {
+			/* Empty. */
+		}
+
+		/* Wait for an event. */
+		__WFE();
+
+		/* Clear Event Register */
+		__SEV();
+		__WFE();
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add power profiling sample.

Depends on other PRs for configuring nrf_regulators, updates to ble_adv libary and conn_params. 

Still missing some changes to achieve optimal power consumption. Currently an idle current of 4.5uA is achiavable, though it should go lower than that. This is to be investigated and will likely be taken outside of this PR. 

TODOs: 
- [x]  Documentation
- [x]  Sample cleanup
- [x] Investigation of power consumption

Sample goes to system off mode after 5 seconds after boot unless advertising, and when advertising stops. Current consumption in system off mode is ~1.4uA.  Power handling will be moved to its own module in a separate PR later. 

Depends on #236