### PR TITLE
manifest: Remove cmsis

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,6 @@ manifest:
       revision: 3c221e6bbced4c117195a47076ea7ba9b2108ba5
       import:
         name-allowlist:
-          - cmsis
           - cmsis_6
           - dragoon
           - hal_nordic


### PR DESCRIPTION
Updates revision of sdk-nrf and removed cmsis from allow list, since this is not used with the modules in this repo