### PR TITLE
ci: Update sdk-manager index.json when tag is placed

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -1,21 +1,10 @@
-name: src-mirror
+name: Generate src mirror package
 
 on:
   workflow_dispatch:
-    inputs:
-      git-ref:
-        description: 'Branch, tag or SHA to checkout'
-        required: true
-        default: 'main'
   push:
     tags:
       - '*'
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    paths:
-      - .github/workflows/src-mirror.yml
 
 concurrency:
   group: src-mirror-${{ github.ref }}
@@ -24,34 +13,27 @@ concurrency:
 jobs:
 
   # Tar entire project west workspace, prune, and upload to artifact service.
-  standard:
+  generate-src-mirror-package:
     runs-on: ubuntu-24.04-16cores
     steps:
+
+      - name: Set STABLE variable
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]] && [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "STABLE=true" >> $GITHUB_ENV
+          else
+            echo "STABLE=false" >> $GITHUB_ENV
+          fi
+
       - name: Upload src.tar.gz
         uses: nrfconnect/action-src-mirror@main
         with:
+          git-ref: ${{ github.ref_name }}
           path: 'nrf-bm'
           west-update-args: ''
-          artifactory-path: >-
-            ${{ (github.ref_type != 'tag') &&
-              format('ncs-src-mirror/internal/{0}/{1}/src.tar.gz', github.event.repository.name, github.ref_name) ||
-              format('ncs-src-mirror/external/{0}/{1}/src.tar.gz', github.event.repository.name, github.ref_name) }}
+          sdk-manager-api-version: '2'
+          artifactory-base-folder-path: ${{ (github.ref_type == 'tag') && 'ncs-src-mirror/external/' || 'ncs-src-mirror/internal/' }}
           artifactory-user: ${{ secrets.COM_NORDICSEMI_FILES_USERNAME }}
           artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
-
-  # west update with --narrow & --shallow gives smaller size but no git history.
-  # narrow:
-  #   runs-on: ubuntu-24.04-16cores
-  #   steps:
-  #     - name: Upload src.tar.gz
-  #       uses: nrfconnect/action-src-mirror@main
-  #       with:
-  #         path: 'nrf-bm'
-  #         west-update-args: '--narrow'
-  #         git-fetch-depth: 1
-  #         artifactory-path: >-
-  #           ${{ (github.ref_type != 'tag') &&
-  #             format('ncs-src-mirror/internal/{0}/{1}/src-narrow.tar.gz', github.event.repository.name, github.ref_name) ||
-  #             format('ncs-src-mirror/external/{0}/{1}/src-narrow.tar.gz', github.event.repository.name, github.ref_name) }}
-  #         artifactory-user: ${{ secrets.COM_NORDICSEMI_FILES_USERNAME }}
-  #         artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
+          stable: ${{ env.STABLE }}
+          repository-type: 'nrf-bm'


### PR DESCRIPTION
Update sdk-manager index.json to reduce manual steps after tag is placed. Align with new API of action-src-mirror action