### PR TITLE
workflows: build_samples: upload logs on failure only

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: upload-logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      if: ${{ failure() && !contains(github.event.pull_request.user.login, 'dependabot[bot]') }}
       with:
         name: build-logs
         path: nrf-bm/twister-out/**/*.log


### PR DESCRIPTION
Upload logs on failure only.
This operation takes a long time on runners with a high number of cores, so execute only when necessary (during failures).

Example here https://github.com/nrfconnect/sdk-nrf-bm/actions/runs/16922618239/job/47951960362 where sample build took ~5 minutes while uploading logs took ~8 minutes.