### PR TITLE
workflows: src-mirror: use RunsOn 64cpu-linux-x64

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -14,7 +14,9 @@ jobs:
 
   # Tar entire project west workspace, prune, and upload to artifact service.
   generate-src-mirror-package:
-    runs-on: ubuntu-24.04-16cores
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=64cpu-linux-x64
     steps:
 
       - name: Set STABLE variable


### PR DESCRIPTION
Replace GitHub-hosted runner with RunsOn-hosted
runner.
This runner is 4x more powerful and 4x cheaper.

https://runs-on.com/runners/linux/#tab-panel-0

We are using these runners for other workflows already.