### PR TITLE
boards: nordic: bm_nrf54l15: Kconfig fixes and remove build warning

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+ /* Override NCS default. */
+/delete-node/ &cpuapp_sram;
+
 / {
 	compatible = "nordic,bm_nrf54l15dk_nrf54l05-cpuapp";
 	model = "Nordic Bare Metal nRF54L15 DK nRF54L05 Application MCU";
@@ -14,25 +17,28 @@
 	};
 
 	soc {
-		reserved-memory {
+		reserved-memory@20000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x20000000 0x80>;
 			ranges;
 
-			 nrf_kmu_reserved_push_area: memory@20000000 {
-				reg = <0x20000000 0x80>;
+			nrf_kmu_reserved_push_area: memory@20000000 {
 				compatible = "zephyr,memory-region", "mmio-sram";
+				reg = <0x20000000 0x80>;
 				zephyr,memory-region = "nrf_kmu_reserved_push_area";
 				status = "okay";
-			 };
+			};
+		};
+
+		cpuapp_sram: memory@20000080 {
+			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x20000080 (DT_SIZE_K(96) - 0x80)>;
+			ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x80)>;
 		};
 	};
-};
-
-/* Override NCS default to use entire SRAM for application CPU. */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
 };
 
 /* Override NCS default to use entire RRAM for application CPU. */

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/* Override NCS default. */
+/delete-node/ &cpuapp_sram;
+
 / {
 	compatible = "nordic,bm_nrf54l15dk_nrf54l10-cpuapp";
 	model = "Nordic Bare Metal nRF54L15 DK nRF54L10 Application MCU";
@@ -14,25 +17,28 @@
 	};
 
 	soc {
-		reserved-memory {
+		reserved-memory@20000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x20000000 0x80>;
 			ranges;
 
-			 nrf_kmu_reserved_push_area: memory@20000000 {
-				reg = <0x20000000 0x80>;
+			nrf_kmu_reserved_push_area: memory@20000000 {
 				compatible = "zephyr,memory-region", "mmio-sram";
+				reg = <0x20000000 0x80>;
 				zephyr,memory-region = "nrf_kmu_reserved_push_area";
 				status = "okay";
-			 };
+			};
+		};
+
+		cpuapp_sram: memory@20000080 {
+			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x20000080 (DT_SIZE_K(192) - 0x80)>;
+			ranges = <0x0 0x20000080 (DT_SIZE_K(192) - 0x80)>;
 		};
 	};
-};
-
-/* Override NCS default to use entire SRAM for application CPU. */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(192)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
 };
 
 /* Override NCS default to use entire RRAM for application CPU. */

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/* Override NCS default. */
+/delete-node/ &cpuapp_sram;
+
 / {
 	compatible = "nordic,bm_nrf54l15dk_nrf54l15-cpuapp";
 	model = "Nordic Bare Metal nRF54L15 DK nRF54L15 Application MCU";
@@ -14,25 +17,28 @@
 	};
 
 	soc {
-		reserved-memory {
+		reserved-memory@20000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x20000000 0x80>;
 			ranges;
 
-			 nrf_kmu_reserved_push_area: memory@20000000 {
-				reg = <0x20000000 0x80>;
+			nrf_kmu_reserved_push_area: memory@20000000 {
 				compatible = "zephyr,memory-region", "mmio-sram";
+				reg = <0x20000000 0x80>;
 				zephyr,memory-region = "nrf_kmu_reserved_push_area";
 				status = "okay";
-			 };
+			};
+		};
+
+		cpuapp_sram: memory@20000080 {
+			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x20000080 (DT_SIZE_K(256) - 0x80)>;
+			ranges = <0x0 0x20000080 (DT_SIZE_K(256) - 0x80)>;
 		};
 	};
-};
-
-/* Override NCS default to use entire SRAM for application CPU. */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(256)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 /* Override NCS default to use entire RRAM for application CPU. */


### PR DESCRIPTION
* Fixes SRAM misalignment
* Removes build warning of missing or empty reg/ranges property.