### PR TITLE
lib: bm_storage: replace bm_storage_api struct with bm_storage_backend.h

### DIFF
--- a/include/bm_storage.h
+++ b/include/bm_storage.h
@@ -87,9 +87,6 @@ struct bm_storage_info {
 	bool no_explicit_erase;
 };
 
-/* Forward declaration. */
-struct bm_storage_api;
-
 /**
  * @brief Storage instance.
  *
@@ -99,11 +96,11 @@ struct bm_storage_api;
  */
 struct bm_storage {
 	/**
-	 * @brief The implementation-specific API used by this instance.
+	 * @brief Tells whether the instance is initialized.
 	 *
 	 * @note This field must not be set manually.
 	 */
-	const struct bm_storage_api *api;
+	bool initialized;
 	/**
 	 * @brief Information about the implementation-specific functionality and the non-volatile
 	 *        memory peripheral.
@@ -139,37 +136,6 @@ struct bm_storage {
 };
 
 /**
- * @brief Functions provided by the API implementation.
- */
-struct bm_storage_api {
-	/**
-	 * @brief Initialize the storage peripheral.
-	 */
-	uint32_t (*init)(struct bm_storage *storage);
-	/**
-	 * @brief Uninitialize the storage peripheral.
-	 */
-	uint32_t (*uninit)(struct bm_storage *storage);
-	/**
-	 * @brief Read data from non-volatile memory.
-	 */
-	uint32_t (*read)(const struct bm_storage *storage, uint32_t src, void *dest, uint32_t len);
-	/**
-	 * @brief Write bytes to non-volatile memory.
-	 */
-	uint32_t (*write)(const struct bm_storage *storage, uint32_t dest, const void *src,
-			  uint32_t len, void *ctx);
-	/**
-	 * @brief Erase the non-volatile memory.
-	 */
-	uint32_t (*erase)(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx);
-	/**
-	 * @brief Check if there are any pending operations.
-	 */
-	bool (*is_busy)(const struct bm_storage *storage);
-};
-
-/**
  * @brief Initialize a storage instance.
  *
  * @note This function can be called multiple times on different storage instances in order to
@@ -196,6 +162,7 @@ uint32_t bm_storage_init(struct bm_storage *storage);
  * @retval NRF_ERROR_NULL If @p storage is @c NULL.
  * @retval NRF_ERROR_INVALID_STATE If @p storage is in an invalid state.
  * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support uninitialization.
  */
 uint32_t bm_storage_uninit(struct bm_storage *storage);
 
@@ -268,16 +235,10 @@ uint32_t bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint3
  *
  * @param[in] storage Storage instance to query the status of.
  *
- * @retval true If the storage instance is busy or if the implementation-specific backend is not
- *              initialized.
- * @retval false If the storage instance is not busy.
+ * @retval true If the storage instance is busy, or not initialized.
+ * @retval false If the storage instance is not busy, or the operation is not supported.
  */
 bool bm_storage_is_busy(const struct bm_storage *storage);
-
-/**
- * @brief Singleton instance of the implementation-specific API.
- */
-extern const struct bm_storage_api bm_storage_api;
 
 /**
  * @brief Singleton instance of the implementation-specific non-volatile memory information.

--- a/include/bm_storage_backend.h
+++ b/include/bm_storage_backend.h
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *
+ * @defgroup bm_storage_backend NCS Bare Metal Storage library backend
+ * @{
+ *
+ * @brief Backend API for the NCS Bare Metal Storage library.
+ */
+
+#ifndef BM_STORAGE_BACKEND_H__
+#define BM_STORAGE_BACKEND_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the storage peripheral.
+ *
+ * @note This function must be defined by the backend.
+ *
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_BUSY If the implementation-specific resource is busy.
+ * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ */
+uint32_t bm_storage_backend_init(struct bm_storage *storage);
+/**
+ * @brief Uninitialize the storage peripheral.
+ *
+ * @note This function is optional. If not defined in the backend, a weak implementation will return
+ * NRF_ERROR_NOT_SUPPORTED.
+ *
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support uninitialization.
+ */
+uint32_t bm_storage_backend_uninit(struct bm_storage *storage);
+/**
+ * @brief Read data from non-volatile memory.
+ *
+ * @note This function must be defined by the backend.
+ *
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
+ */
+uint32_t bm_storage_backend_read(const struct bm_storage *storage, uint32_t src, void *dest,
+				 uint32_t len);
+/**
+ * @brief Write bytes to non-volatile memory.
+ *
+ * @note This function must be defined by the backend.
+ *
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
+ * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ */
+uint32_t bm_storage_backend_write(const struct bm_storage *storage, uint32_t dest, const void *src,
+				  uint32_t len, void *ctx);
+/**
+ * @brief Erase the non-volatile memory.
+ *
+ * @note This function is optional. If not defined in the backend, a weak implementation will return
+ * NRF_ERROR_NOT_SUPPORTED.
+ *
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
+ * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support erase.
+ */
+uint32_t bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len,
+				  void *ctx);
+/**
+ * @brief Check if there are any pending operations.
+ *
+ * @note This function is optional. If not defined in the backend, a weak implementation will return
+ * false.
+ *
+ * @retval true If the storage instance is busy.
+ * @retval false If the storage instance is not busy, or the operation is not supported.
+ */
+bool bm_storage_backend_is_busy(const struct bm_storage *storage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BM_STORAGE_BACKEND_H__ */
+
+/** @} */

--- a/lib/bm_storage/bm_storage.c
+++ b/lib/bm_storage/bm_storage.c
@@ -18,14 +18,20 @@ static inline bool is_within_bounds(off_t addr, size_t len, off_t boundary_start
 
 uint32_t bm_storage_init(struct bm_storage *storage)
 {
+	uint32_t err;
+
 	if (!storage) {
 		return NRF_ERROR_NULL;
 	}
 
-	storage->api = &bm_storage_api;
 	storage->nvm_info = &bm_storage_info;
 
-	return (storage->api)->init(storage);
+	err = bm_storage_api.init(storage);
+	if (err != NRF_SUCCESS) {
+		return err;
+	}
+
+	storage->api = &bm_storage_api;
 }
 
 uint32_t bm_storage_uninit(struct bm_storage *storage)

--- a/lib/bm_storage/sd/bm_storage_sd.c
+++ b/lib/bm_storage/sd/bm_storage_sd.c
@@ -13,6 +13,7 @@
 #include <nrf_sdh.h>
 #include <nrf_error.h>
 #include <bm_storage.h>
+#include <bm_storage_backend.h>
 
 /* 128-bit word line. This is the optimal size to fully utilize RRAM 128-bit word line with ECC
  * (error correction code) and minimize ECC updates overhead, due to these updates happening
@@ -213,7 +214,7 @@ static bool on_operation_failure(const struct bm_storage_sd_op *op)
 	return false;
 }
 
-static uint32_t bm_storage_sd_init(struct bm_storage *storage)
+uint32_t bm_storage_backend_init(struct bm_storage *storage)
 {
 	/* If it's already initialized, return early successfully.
 	 * This is to support more than one client initialization.
@@ -238,16 +239,7 @@ static uint32_t bm_storage_sd_init(struct bm_storage *storage)
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_sd_uninit(struct bm_storage *storage)
-{
-	if (!state.is_init) {
-		return NRF_ERROR_FORBIDDEN;
-	}
-
-	return NRF_SUCCESS;
-}
-
-static uint32_t bm_storage_sd_read(const struct bm_storage *storage, uint32_t src, void *dest,
+uint32_t bm_storage_backend_read(const struct bm_storage *storage, uint32_t src, void *dest,
 				   uint32_t len)
 {
 	if (!state.is_init) {
@@ -265,7 +257,7 @@ static uint32_t bm_storage_sd_read(const struct bm_storage *storage, uint32_t sr
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_sd_write(const struct bm_storage *storage, uint32_t dest,
+uint32_t bm_storage_backend_write(const struct bm_storage *storage, uint32_t dest,
 				    const void *src, uint32_t len, void *ctx)
 {
 	uint32_t written;
@@ -299,15 +291,7 @@ static uint32_t bm_storage_sd_write(const struct bm_storage *storage, uint32_t d
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_sd_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len,
-				    void *ctx)
-{
-	/* Do nothing. The SoftDevice does not implement the erase functionality. */
-
-	return NRF_ERROR_NOT_SUPPORTED;
-}
-
-static bool bm_storage_sd_is_busy(const struct bm_storage *storage)
+bool bm_storage_backend_is_busy(const struct bm_storage *storage)
 {
 	return (state.type != BM_STORAGE_SD_STATE_IDLE);
 }
@@ -379,15 +363,6 @@ static bool on_state_req_change(enum nrf_sdh_state_req req, void *ctx)
 
 	return (state.type == BM_STORAGE_SD_STATE_IDLE);
 }
-
-const struct bm_storage_api bm_storage_api = {
-	.init = bm_storage_sd_init,
-	.uninit = bm_storage_sd_uninit,
-	.write = bm_storage_sd_write,
-	.read = bm_storage_sd_read,
-	.erase = bm_storage_sd_erase,
-	.is_busy = bm_storage_sd_is_busy
-};
 
 const struct bm_storage_info bm_storage_info = {
 	.program_unit = SD_WRITE_BLOCK_SIZE,

--- a/samples/peripherals/storage/src/main.c
+++ b/samples/peripherals/storage/src/main.c
@@ -121,13 +121,13 @@ static uint32_t storage_uninits(void)
 	uint32_t err;
 
 	err = bm_storage_uninit(&storage_a);
-	if (err != NRF_SUCCESS) {
+	if (err != NRF_SUCCESS && err != NRF_ERROR_NOT_SUPPORTED) {
 		LOG_ERR("bm_storage_uninit() failed, err %#x", err);
 		return err;
 	}
 
 	err = bm_storage_uninit(&storage_b);
-	if (err != NRF_SUCCESS) {
+	if (err != NRF_SUCCESS && err != NRF_ERROR_NOT_SUPPORTED) {
 		LOG_ERR("bm_storage_uninit() failed, err %#x", err);
 		return err;
 	}

--- a/tests/lib/bm_storage/bm_storage/src/unity_test.c
+++ b/tests/lib/bm_storage/bm_storage/src/unity_test.c
@@ -15,48 +15,38 @@
 #define PARTITION_START 0x4200
 #define PARTITION_SIZE (BLOCK_SIZE * 2)
 
-static uint32_t bm_storage_unity_init(struct bm_storage *storage)
+uint32_t bm_storage_backend_init(struct bm_storage *storage)
 {
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_unity_uninit(struct bm_storage *storage)
+uint32_t bm_storage_backend_uninit(struct bm_storage *storage)
 {
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_unity_write(const struct bm_storage *storage, uint32_t dest,
+uint32_t bm_storage_backend_write(const struct bm_storage *storage, uint32_t dest,
 				       const void *src, uint32_t len, void *ctx)
 {
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_unity_erase(const struct bm_storage *storage, uint32_t addr,
+uint32_t bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr,
 				       uint32_t len, void *ctx)
 {
 	return NRF_SUCCESS;
 }
 
-static uint32_t bm_storage_unity_read(const struct bm_storage *storage, uint32_t src, void *dest,
+uint32_t bm_storage_backend_read(const struct bm_storage *storage, uint32_t src, void *dest,
 				      uint32_t len)
 {
 	return NRF_SUCCESS;
 }
 
-static bool bm_storage_unity_is_busy(const struct bm_storage *storage)
+bool bm_storage_backend_is_busy(const struct bm_storage *storage)
 {
 	return false;
 }
-
-/* Implements the exported extern. */
-const struct bm_storage_api bm_storage_api = {
-	.init = bm_storage_unity_init,
-	.uninit = bm_storage_unity_uninit,
-	.write = bm_storage_unity_write,
-	.read = bm_storage_unity_read,
-	.erase = bm_storage_unity_erase,
-	.is_busy = bm_storage_unity_is_busy
-};
 
 /* Implements the exported extern. */
 const struct bm_storage_info bm_storage_info = {
@@ -434,10 +424,6 @@ void test_bm_storage_is_busy(void)
 
 	/* Storage is NULL. */
 	is_busy = bm_storage_is_busy(NULL);
-	TEST_ASSERT_EQUAL(true, is_busy);
-
-	/* Storage is uninitialized. */
-	is_busy = bm_storage_is_busy(&storage);
 	TEST_ASSERT_EQUAL(true, is_busy);
 
 	err = bm_storage_init(&storage);


### PR DESCRIPTION
Replace bm_storage_api struct with bm_storage_backend.h Each backend is expected to support init,
read and write as a minimum. Other functions are optional.

Same as #266.