### PR TITLE
workflows: docs: do not skip publish on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,11 +36,6 @@ jobs:
             echo "publish2 dev PR-${{ github.event.number }} ${ARCHIVE}" > "${MONITOR}"
             echo "${{ github.event.number }}" > pr.txt
           else
-            if [ -z "${VERSION}" ]; then
-              echo "Not a release or latest, skipping publish"
-              exit 0
-            fi
-
             ARCHIVE="legacy-ncs-${VERSION}.zip"
             echo "publish2 main ${VERSION} ${ARCHIVE}" > "${MONITOR}"
           fi


### PR DESCRIPTION
We want to publish also when merging to `main`.
This also fixes a failure in later steps because of `monitor_*.txt` not generated due to early exit.