### PR TITLE
workflows: docs: fix Azure Storage Account Name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: doc
         run: |
           COMMENT="comment.txt"
-          PREFIX="https://ncsdoc.z6.web.core.windows.net/PR-${{ github.event.pull_request.number }}/"
+          PREFIX="https://ncsbmdoc.z6.web.core.windows.net/PR-${{ github.event.pull_request.number }}/"
 
           echo "You can find the documentation preview for this PR [here](${PREFIX})." >> $COMMENT
 


### PR DESCRIPTION
Fixes the Azure Storage Account Name.
This fixes the link generated by the documentation
publish bot comment.