### PR TITLE
workflows: docs: export VERSION to later steps & add guard for pull requests

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -25,6 +25,7 @@ jobs:
           unzip legacy-ncs*.zip -d $OUTDIR
 
       - name: Obtain PR number
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         working-directory: docs
         run: |
           echo "PR=$(cat pr.txt)" >> "$GITHUB_ENV"
@@ -37,6 +38,7 @@ jobs:
          azcopy cp $OUTDIR "${{ vars.NCS_DOC_STORAGE_URL }}?${{ secrets.NCS_DOC_SAS}}" --recursive=true
 
       - name: Find Comment
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
@@ -45,6 +47,7 @@ jobs:
           body-includes: documentation preview
 
       - name: Create or update comment
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             VERSION="pr-${{ github.event.number }}"
           fi
+          echo "VERSION=${VERSION}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Prepare Azure upload
         working-directory: doc/nrf-bm/_build/html


### PR DESCRIPTION
* Resolves a bug where `VERSION` would be read as
empty in the `Prepare Azure upload` step due
to the variable not being exported by the
`Check version` step.
This would cause builds generated from main branch
to not include "latest" in the build.

* Fixes a bug where some steps would be executed
unnecessarily when the event was not a pull
request (such as merging to main).