### PR TITLE
cmake: Add overwrite only flag to imgtool calls

### DIFF
--- a/cmake/image_signing_softdevice.cmake
+++ b/cmake/image_signing_softdevice.cmake
@@ -46,7 +46,7 @@ function(softdevice_tasks output_hex output_bin)
   dt_nodelabel(softdevice_partition_node_full_path NODELABEL "softdevice_partition")
   dt_reg_size(softdevice_partition_node_size PATH "${softdevice_partition_node_full_path}")
 
-  set(imgtool_sign ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version ${CONFIG_SOFTDEVICE_VERSION} --align ${write_block_size} --slot-size ${softdevice_partition_node_size} --header-size ${CONFIG_SOFTDEVICE_START_OFFSET} ${pad_header})
+  set(imgtool_sign ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version ${CONFIG_SOFTDEVICE_VERSION} --align ${write_block_size} --slot-size ${softdevice_partition_node_size} --header-size ${CONFIG_SOFTDEVICE_START_OFFSET} ${pad_header} --overwrite-only)
 
 #  if(CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
 #    set(imgtool_args --security-counter ${CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE})

--- a/cmake/sysbuild/image_signing_installer.cmake
+++ b/cmake/sysbuild/image_signing_installer.cmake
@@ -62,7 +62,7 @@ function(bm_install_tasks output_hex output_bin)
 #  sysbuild_get(CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION IMAGE ${DEFAULT_IMAGE} VAR CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION KCONFIG)
 
   # Custom TLV 0x0a is set to 0x01 to indicate that this is an installer image
-  set(imgtool_sign ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION} --align ${write_block_size} --slot-size ${CONFIG_FLASH_LOAD_SIZE} --header-size ${CONFIG_ROM_START_OFFSET} --custom-tlv 0xa0 0x01)
+  set(imgtool_sign ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION} --align ${write_block_size} --slot-size ${CONFIG_FLASH_LOAD_SIZE} --header-size ${CONFIG_ROM_START_OFFSET} --overwrite-only --custom-tlv 0xa0 0x01)
 
 #  if(CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
 #    set(imgtool_args --security-counter ${CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE})


### PR DESCRIPTION
The default mode imgtool assumes is swap mode, and it adds trailer overhead to size calculations. Since BM uses firmware loader which does not do swapping, the overwrite only flag has to be used which disables this (though overwrite only mode is not used in BM, it is the only flag for disabling the swap overhead check)