### PR TITLE
boards: nordic: bm_nrf54l15dk: allocate unused rram for application

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
@@ -27,14 +27,14 @@
 
 		slot0_partition: partition@0 {
 			label = "slot0";
-			reg = <0x00000000 DT_SIZE_K(364)>;
+			reg = <0x00000000 DT_SIZE_K(384)>;
 		};
 
-		storage_partition: partition@5b000 {
+		storage_partition: partition@60000 {
 			compatible = "fixed-subpartitions";
 			label = "storage";
-			reg = <0x0005b000 DT_SIZE_K(8)>;
-			ranges = <0x0 0x5b000 DT_SIZE_K(8)>;
+			reg = <0x00060000 DT_SIZE_K(8)>;
+			ranges = <0x0 0x60000 DT_SIZE_K(8)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 78
-flash: 364
+flash: 384

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
@@ -72,12 +72,12 @@
 
 		slot0_partition: partition@b000 {
 			label = "slot0";
-			reg = <0x0000b000 DT_SIZE_K(262)>;
+			reg = <0x0000b000 DT_SIZE_K(282)>;
 		};
 
-		slot1_partition: partition@4c800 {
+		slot1_partition: partition@51800 {
 			label = "slot1";
-			reg = <0x0004c800 DT_SIZE_K(64)>;
+			reg = <0x00051800 DT_SIZE_K(64)>;
 		};
 
 		softdevice_partition: partition@61800 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 78
-flash: 262
+flash: 282

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
@@ -27,14 +27,14 @@
 
 		slot0_partition: partition@0 {
 			label = "slot0";
-			reg = <0x00000000 DT_SIZE_K(876)>;
+			reg = <0x00000000 DT_SIZE_K(896)>;
 		};
 
-		storage_partition: partition@db000 {
+		storage_partition: partition@e0000 {
 			compatible = "fixed-subpartitions";
 			label = "storage";
-			reg = <0x000db000 DT_SIZE_K(8)>;
-			ranges = <0x0 0xdb000 DT_SIZE_K(8)>;
+			reg = <0x000e0000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xe0000 DT_SIZE_K(8)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 174
-flash: 876
+flash: 896

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
@@ -72,12 +72,12 @@
 
 		slot0_partition: partition@b000 {
 			label = "slot0";
-			reg = <0x0000b000 DT_SIZE_K(774)>;
+			reg = <0x0000b000 DT_SIZE_K(794)>;
 		};
 
-		slot1_partition: partition@cc800 {
+		slot1_partition: partition@d1800 {
 			label = "slot1";
-			reg = <0x000cc800 DT_SIZE_K(64)>;
+			reg = <0x000d1800 DT_SIZE_K(64)>;
 		};
 
 		softdevice_partition: partition@e1800 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 174
-flash: 774
+flash: 794

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
@@ -27,14 +27,14 @@
 
 		slot0_partition: partition@0 {
 			label = "slot0";
-			reg = <0x00000000 DT_SIZE_K(1388)>;
+			reg = <0x00000000 DT_SIZE_K(1408)>;
 		};
 
-		storage_partition: partition@15b000 {
+		storage_partition: partition@160000 {
 			compatible = "fixed-subpartitions";
 			label = "storage";
-			reg = <0x0015b000 DT_SIZE_K(8)>;
-			ranges = <0x0 0x15b000 DT_SIZE_K(8)>;
+			reg = <0x00160000 DT_SIZE_K(8)>;
+			ranges = <0x0 0x160000 DT_SIZE_K(8)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 238
-flash: 1388
+flash: 1408

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
@@ -72,12 +72,12 @@
 
 		slot0_partition: partition@b000 {
 			label = "slot0";
-			reg = <0x0000b000 DT_SIZE_K(1286)>;
+			reg = <0x0000b000 DT_SIZE_K(1306)>;
 		};
 
-		slot1_partition: partition@14c800 {
+		slot1_partition: partition@151800 {
 			label = "slot1";
-			reg = <0x0014c800 DT_SIZE_K(64)>;
+			reg = <0x00151800 DT_SIZE_K(64)>;
 		};
 
 		softdevice_partition: partition@161800 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.yaml
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.yaml
@@ -14,4 +14,4 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 238
-flash: 1286
+flash: 1306


### PR DESCRIPTION
After reducing the SoftDevice size, 20KiB was left unused. Allocate the unused read-only memory for application.