### PR TITLE
samples: bluetooth: ble_pwr_profiling: Turn off led as default and update adv data

### DIFF
--- a/samples/bluetooth/ble_pwr_profiling/Kconfig
+++ b/samples/bluetooth/ble_pwr_profiling/Kconfig
@@ -42,7 +42,6 @@ config BLE_PWR_PROFILING_CHAR_VALUE_LEN
 
 config BLE_PWR_PROFILING_LED
 	bool "Power profiling LED"
-	default y
 
 module=BLE_PWR_PROFILING_SAMPLE
 module-dep=LOG

--- a/samples/bluetooth/ble_pwr_profiling/Kconfig
+++ b/samples/bluetooth/ble_pwr_profiling/Kconfig
@@ -8,7 +8,7 @@ menu "BLE Power Profiling sample"
 
 config BLE_PWR_PROFILING_ADV_NAME
 	string "Advertising name"
-	default "nRF_BM_PWR"
+	default "Nordic_Power_Profiling"
 
 config BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT
 	int "Connectable advertising timeout (10 ms units)"

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -122,6 +122,11 @@ LED 0:
    This causes a delay between the SoC wake up and button press processing.
    If you want to start advertising on system start, you must keep pressing the button until you see a log message confirming the advertising start on the terminal.
 
+.. note::
+   The LED is disabled by default.
+   You can enable the LED by setting the :kconfig:option:`CONFIG_BLE_PWR_PROFILING_LED` Kconfig option.
+   Enabling the LED will increase the power consumption in active and low power mode by ~1.8 uA.
+
 Configuration
 *************
 


### PR DESCRIPTION
When on, LED0 draws 1.8uA due to the 1M pulldown. This increases the current by 50% in CPU idle state from ~4uA to ~5.8uA. This commit turns the LED off by default to match the behaviour in NCS.

* Change default advertisement name to Nordic_Power_Profiling
* Remove service from advertising data.

This aligns the advertising data with NCS samples, which gives a better
comparison between the two.