### PR TITLE
boards: nordic: bm_nrf54l15dk: add CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/Kconfig
+++ b/boards/nordic/bm_nrf54l15dk/Kconfig
@@ -6,3 +6,8 @@
 
 config BOARD_BM_NRF54L15DK
 	select BOARD_LATE_INIT_HOOK
+
+# Temporary fix to remove a build warning in MCUboot.
+config NRF_RTC_TIMER_USER_CHAN_COUNT
+	int "Unused"
+	default 0


### PR DESCRIPTION
Add CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT to remove a compile warning.