### PR TITLE
errors: move nrfx error enum to bm

### DIFF
--- a/include/nrf_error.h
+++ b/include/nrf_error.h
@@ -82,6 +82,26 @@ extern "C" {
 /** Not enough resources for operation */
 #define NRF_ERROR_RESOURCES                   (NRF_ERROR_BASE_NUM + 19)
 
+#include <errno.h>
+
+/** @brief Enumerated type for nrfx error codes. */
+typedef enum {
+    NRFX_SUCCESS                   = 0,           ///< Operation performed successfully.
+    NRFX_ERROR_INTERNAL            = ECANCELED,   ///< Internal error.
+    NRFX_ERROR_NO_MEM              = ENOMEM,      ///< No memory for operation.
+    NRFX_ERROR_NOT_SUPPORTED       = ENOTSUP,     ///< Not supported.
+    NRFX_ERROR_INVALID_PARAM       = EINVAL,      ///< Invalid parameter.
+    NRFX_ERROR_INVALID_STATE       = EINPROGRESS, ///< Invalid state, operation disallowed in this state.
+    NRFX_ERROR_INVALID_LENGTH      = E2BIG,       ///< Invalid length.
+    NRFX_ERROR_TIMEOUT             = ETIMEDOUT,   ///< Operation timed out.
+    NRFX_ERROR_FORBIDDEN           = EPERM,       ///< Operation is forbidden.
+    NRFX_ERROR_NULL                = EFAULT,      ///< Null pointer.
+    NRFX_ERROR_INVALID_ADDR        = EACCES,      ///< Bad memory address.
+    NRFX_ERROR_BUSY                = EBUSY,       ///< Busy.
+    NRFX_ERROR_ALREADY             = EALREADY,    ///< Operation already done.
+    NRFX_ERROR_ALREADY_INITIALIZED = EALREADY,    ///< @deprecated Use @ref NRFX_ERROR_ALREADY instead.
+} nrfx_err_t;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Since nrfx is to remove its custom error codes with 4.0 release, error typedef enum has to be moved to bm if intended to still use the symbols.

With nrfx 4.0, we intend to completely remove `nrfx_err_t` enum and return errno values in the drivers in order to get rid of costly error translation in Zephyr drivers. I see two solutions

### 1. Moving the enum (done in this PR, very preferrable)
If nrf-bm is to still use `nrfx_err_t` enum, it would have to be defined here (I assume that `nrf_error.h` header is the appropriate location). With nrfx drivers returning errno values (0 or negative e.g. `-ECANCELED`), these would be mapped to the enum. The errors in nrfx would either be replaced 1:1 (e.g. every return of `NRFX_ERROR_INTERNAL` would be changed to `-ECANCELED`) or the specific error could get changed to better reflect meaning associated with errno value. Its drawbacks are imperfect value mapping and potenitally big effort to align the two projects.
 
###  2. Using conditional values in nrfx
In current form, nrfx supports usage of custom error codes with `NRFX_CUSTOM_ERROR_CODES`. If nrf-bm rejects the first variant, we could preserve the error code enum in nrfx which could take both errno values and legacy values to align with both Zephyr drivers and nrf-bm. The drawback would be keeping the layer of abstraction that we want to get rid of.

Also, I see that nrf-bm code uses three variants of error codes :
- `nrfx_err_t` in https://github.com/nrfconnect/sdk-nrf-bm/blob/60df6af05d22f61e4f48107f004d6f7fc269ca92/include/bm_lpuarte.h#L96-L110
- errno on https://github.com/nrfconnect/sdk-nrf-bm/blob/60df6af05d22f61e4f48107f004d6f7fc269ca92/lib/bm_timer/bm_timer.c#L76-L85
- nrf-bm specific in https://github.com/nrfconnect/sdk-nrf-bm/blob/60df6af05d22f61e4f48107f004d6f7fc269ca92/include/bm_storage.h#L138-L151

Is there a pattern to it? `nrfx_err_t` for drivers and errno for libs? 