### PR TITLE
samples: boot: mcuboot_recovery_entry: add missing testing steps

### DIFF
--- a/samples/boot/mcuboot_recovery_entry/README.rst
+++ b/samples/boot/mcuboot_recovery_entry/README.rst
@@ -68,7 +68,21 @@ This sample can be found under :file:`samples/boot/mcuboot_recovery_entry` in th
 Testing
 =======
 
-TBD.
+1. Compile and program the application.
+#. Connect the device to the computer to access the UART.
+   If you use a development kit, the UART is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
+#. Connect to the DK with a terminal emulator (for example, the `Serial Terminal app`_) to VCOM1.
+#. Reset the DK.
+#. Observe in the terminal that the device boots into application mode and then advertises with the default name ``nRF_BM_Entry``.
+#. Connect to your device using the `nRF Connect Device Manager`_ mobile application.
+#. Under the :guilabel:`image` tab, tap :guilabel:`Advanced`.
+   Then, in the reset control pane, select :guilabel:`Switch to bootloader mode` and tap :guilabel:`Send Reset Command`.
+   Observe in the terminal that the device reboots into Firmware Loader mode and advertises with the default Firmware Loader name ``nRF_BM_MCUmgr``.
+#. Using the `nRF Connect Device Manager`_ mobile application, go back to the device list and refresh it by swiping down.
+   Connect to your device that now advertises with the default firmware loader name ``nRF_BM_MCUmgr``.
+#. Under the :guilabel:`image` tab, tap :guilabel:`Advanced`.
+   Then, in the image control pane, tap :guilabel:`Read`.
+   Observe that the details of the currently loaded application are displayed.
 
 Dependencies
 ************

--- a/samples/boot/mcuboot_recovery_entry/README.rst
+++ b/samples/boot/mcuboot_recovery_entry/README.rst
@@ -83,6 +83,23 @@ Testing
 #. Under the :guilabel:`image` tab, tap :guilabel:`Advanced`.
    Then, in the image control pane, tap :guilabel:`Read`.
    Observe that the details of the currently loaded application are displayed.
+#. Build an application with a modified image version by changing the :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` Kconfig option.
+   One way of changing the option is to add ``CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION="1.0.0+0"`` to the sample's :file:`prj.conf` file to override the default version string.
+#. Transfer the :file:`<build_dir>/installer_softdevice_firmware_loader.bin` and :file:`<build_dir>/<app_name>/zephyr/zephyr.signed.bin` files to your mobile device.
+#. In nRF Connect Device Manager application, tap the :guilabel:`Image` tab at the bottom to move to the image management tab.
+   If you only see the basic image tab view, tap :guilabel:`Advanced` to switch to the advanced image tab view.
+#. Under :guilabel:`Firmware Upload` select the update file to load:
+
+   * Choose :file:`installer_softdevice_firmware_loader.bin` to update the SoftDevice and Firmware Loader images.
+     This is only needed if the SoftDevice or Firmware Loader images have been updated.
+     This image must be loaded first if it is needed.
+   * Choose :file:`zephyr.signed.bin` to load the application update.
+
+#. Tap the :guilabel:`Upload` button, then select the :guilabel:`Image 0` option to begin the firmware update process.
+#. The mobile device will connect and load the firmware update to the device.
+#. Once completed, reboot the device.
+   If the Installer image was loaded, then it will apply the updates and reboot into Firmware Loader mode automatically and allow for loading the application firmware update using the same process.
+   If an application update was loaded, then the new application will begin executing.
 
 Dependencies
 ************

--- a/samples/boot/mcuboot_recovery_retention/README.rst
+++ b/samples/boot/mcuboot_recovery_retention/README.rst
@@ -66,13 +66,13 @@ Testing
 1. Compile and program the application.
 #. Connect the device to the computer to access UART 0.
    If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
-#. Connect to the DK with a terminal emulator (for example, the `Serial Terminal app`_) to both UART 0.
+#. Connect to the DK with a terminal emulator (for example, the `Serial Terminal app`_) to UART 0.
 #. Reset the DK.
 #. Observe that the device boots and reboots into firmware loader mode and then advertises with the default name ``nRF_BM_MCUmgr``.
 
    You can configure this name using the ``CONFIG_BLE_ADV_NAME`` Kconfig option of the ``firmware_loader`` image.
    For information on how to do this, see `Configuring Kconfig`_.
 #. Connect to your device using the `nRF Connect Device Manager`_ mobile application.
-#. Under the image tab, tap :guilabel:`Advanced`.
+#. Under the :guilabel:`image` tab, tap :guilabel:`Advanced`.
    Then, in the image control pane, tap :guilabel:`Read`.
    Observe that the details of the currently loaded application are displayed.


### PR DESCRIPTION
Add testing steps for the mcuboot_recovery_entry sample.

Testing steps have been written while using the Device Manager application on android to reset into the firmware loader.
Testing steps are inspired by the testing steps of the mcuboot_recovery_retention sample.