### PR TITLE
samples: peripherals: add mcuboot board targets to peripheral samples

### DIFF
--- a/samples/peripherals/buttons/sample.yaml
+++ b/samples/peripherals/buttons/sample.yaml
@@ -8,8 +8,14 @@ tests:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     tags: ci_build

--- a/samples/peripherals/leds/sample.yaml
+++ b/samples/peripherals/leds/sample.yaml
@@ -8,8 +8,14 @@ tests:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     tags: ci_build

--- a/samples/peripherals/timer/sample.yaml
+++ b/samples/peripherals/timer/sample.yaml
@@ -11,7 +11,13 @@ tests:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot

--- a/samples/peripherals/uarte/sample.yaml
+++ b/samples/peripherals/uarte/sample.yaml
@@ -8,8 +8,14 @@ tests:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+      - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
     tags: ci_build


### PR DESCRIPTION
Add mcuboot board targets to peripheral samples.