### PR TITLE
workflows: add labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+# https://github.com/actions/labeler/blob/main/README.md
+
+# When extending this, remember that in the PR, the labeler will run against
+# the labeler.yml in main, more info:
+# https://github.com/actions/labeler/issues/12
+# This means your changes won't be tested. To test your branch, make a second
+# branch with dummy changes, and open a PR on your own fork, against the
+# first branch.
+
+"manifest":
+- changed-files:
+  - any-glob-to-any-file:
+    - "west.yml"
+
+"doc-required":
+- changed-files:
+  - any-glob-to-any-file:
+    - "doc/**/*"
+    - "**/*.rst"
+
+"changelog-entry-required":
+- all:
+  - changed-files:
+    - all-globs-to-all-files:
+      - "!doc/nrf-bm/releases_notes/release_notes_changelog.rst"
+      - "!.github/*"
+      - "!CODEOWNERS"
+      - "!.*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
Add labeler to add changelog-entry-required and doc-required labels to PRs.

Files taken from NCS. 