### PR TITLE
lib: bm_zms: reword `bm_zms_evt_t` member names

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -54,7 +54,12 @@ Libraries
 
 * :ref:`lib_bm_zms` library:
 
-   * Updated the :c:func:`bm_zms_register` function to return ``-EINVAL`` when passing ``NULL`` input parameters.
+   * Updated:
+
+     * The :c:func:`bm_zms_register` function to return ``-EINVAL`` when passing ``NULL`` input parameters.
+     * The name of the :c:struct:`bm_zms_evt_t` ``id`` field to :c:member:`bm_zms_evt_t.evt_id`.
+     * The name of the :c:struct:`bm_zms_evt_t` ``ate_id`` field to :c:member:`bm_zms_evt_t.id`.
+
    * Added the :c:enumerator:`BM_ZMS_EVT_DELETE` event ID to distinguish :c:func:`bm_zms_delete` events.
 
 * :ref:`lib_ble_conn_params` library:

--- a/include/bm_zms.h
+++ b/include/bm_zms.h
@@ -41,9 +41,11 @@ typedef enum {
 
 /**@brief A BM_ZMS event. */
 typedef struct {
-	bm_zms_evt_id_t id; /* The event ID. See @ref bm_zms_evt_id_t. */
-	uint32_t result;    /* The result of the operation related to this event. */
-	uint32_t ate_id;    /* The ATE id in case of a write operation. */
+	bm_zms_evt_id_t evt_id; /* The event ID. See @ref bm_zms_evt_id_t. */
+	uint32_t result;        /* The result of the operation related to this event. */
+	uint32_t id;            /* The ID of the entry as specified in the corresponding
+				 * write/delete operation.
+				 */
 } bm_zms_evt_t;
 
 /* Init flags. */

--- a/lib/bm_zms/bm_zms.c
+++ b/lib/bm_zms/bm_zms.c
@@ -69,21 +69,21 @@ static void event_prepare(bm_zms_evt_t *p_evt)
 {
 	switch (cur_op.op_code) {
 	case ZMS_OP_INIT:
-		p_evt->id = BM_ZMS_EVT_INIT;
+		p_evt->evt_id = BM_ZMS_EVT_INIT;
 		break;
 
 	case ZMS_OP_WRITE:
 		atomic_sub(&cur_op.fs->ongoing_writes, 1);
-		p_evt->id = cur_op.len ? BM_ZMS_EVT_WRITE : BM_ZMS_EVT_DELETE;
-		p_evt->ate_id = cur_op.id;
+		p_evt->evt_id = cur_op.len ? BM_ZMS_EVT_WRITE : BM_ZMS_EVT_DELETE;
+		p_evt->id = cur_op.id;
 		break;
 
 	case ZMS_OP_CLEAR:
-		p_evt->id = BM_ZMS_EVT_CLEAR;
+		p_evt->evt_id = BM_ZMS_EVT_CLEAR;
 		break;
 
 	case ZMS_OP_NONE:
-		p_evt->id = BM_ZMS_EVT_NONE;
+		p_evt->evt_id = BM_ZMS_EVT_NONE;
 		break;
 	default:
 		/* Should not happen. */

--- a/samples/peripherals/bm_zms/src/main.c
+++ b/samples/peripherals/bm_zms/src/main.c
@@ -112,12 +112,12 @@ static int delete_basic_items(struct bm_zms_fs *fs)
 
 void bm_zms_sample_handler(bm_zms_evt_t const *p_evt)
 {
-	if (p_evt->id == BM_ZMS_EVT_INIT) {
+	if (p_evt->evt_id == BM_ZMS_EVT_INIT) {
 		if (p_evt->result) {
 			LOG_ERR("BM_ZMS initialization failed with error %d", p_evt->result);
 			return;
 		}
-	} else if ((p_evt->id == BM_ZMS_EVT_WRITE) || (p_evt->id == BM_ZMS_EVT_DELETE)) {
+	} else if ((p_evt->evt_id == BM_ZMS_EVT_WRITE) || (p_evt->evt_id == BM_ZMS_EVT_DELETE)) {
 		if (!p_evt->result) {
 			return;
 		}
@@ -127,7 +127,7 @@ void bm_zms_sample_handler(bm_zms_evt_t const *p_evt)
 		}
 		LOG_ERR("BM_ZMS Error received %d", p_evt->result);
 	} else {
-		LOG_WRN("Unhandled BM_ZMS event ID %u", p_evt->id);
+		LOG_WRN("Unhandled BM_ZMS event ID %u", p_evt->evt_id);
 	}
 }
 

--- a/tests/lib/bm_zms/src/main.c
+++ b/tests/lib/bm_zms/src/main.c
@@ -92,10 +92,10 @@ static void wait_for_init(struct bm_zms_fs *fs)
 
 void bm_zms_test_handler(bm_zms_evt_t const *p_evt)
 {
-	if (p_evt->id == BM_ZMS_EVT_INIT) {
+	if (p_evt->evt_id == BM_ZMS_EVT_INIT) {
 		zassert_true(p_evt->result == 0, "bm_zms_init call failure: %d",
 			     p_evt->result);
-	} else if ((p_evt->id == BM_ZMS_EVT_WRITE) || (p_evt->id == BM_ZMS_EVT_DELETE)) {
+	} else if ((p_evt->evt_id == BM_ZMS_EVT_WRITE) || (p_evt->evt_id == BM_ZMS_EVT_DELETE)) {
 		if (p_evt->result == 0) {
 			return;
 		}
@@ -104,7 +104,7 @@ void bm_zms_test_handler(bm_zms_evt_t const *p_evt)
 			return;
 		}
 		printf("BM_ZMS Error received %d\n", p_evt->result);
-	} else if (p_evt->id == BM_ZMS_EVT_CLEAR) {
+	} else if (p_evt->evt_id == BM_ZMS_EVT_CLEAR) {
 		zassert_true(p_evt->result == 0, "bm_zms_clear call failure: %d",
 			     p_evt->result);
 	}


### PR DESCRIPTION
* Rewords the event ID `id` to `evt_id`

* Rewords the entry ID `ate_id` to `id`

This aligns the `id` parameters for write/delete
operations with the name of the event struct member for the corresponding ID reported.