### PR TITLE
ble_conn_params: some Kconfigs fixes

### DIFF
--- a/doc/nrf-bm/libraries/ble_conn_params.rst
+++ b/doc/nrf-bm/libraries/ble_conn_params.rst
@@ -62,9 +62,9 @@ You can specify the connection parameters using Kconfig options:
 * :kconfig:option:`CONFIG_BLE_CONN_PARAMS_MAX_SUP_TIMEOUT_DEVIATION` - Allowed deviation from the specified supervision timeout.
 
 If the device has the peripheral role in a connection and the connection parameters are not within the specified range, then the library will request a renegotiation.
-The number of renegotiation attempts is configured by the :kconfig:option:`CONFIG_CONFIG_BLE_CONN_PARAMS_NEGOTIATION_RETRIES` Kconfig option.
+The number of renegotiation attempts is configured by the :kconfig:option:`CONFIG_BLE_CONN_PARAMS_NEGOTIATION_RETRIES` Kconfig option.
 
-If the peripheral and central device cannot agree on a set of connection parameters after the given number of negotiation attempts, and the :kconfig:option:`CONFIG_CONFIG_BLE_CONN_PARAMS_DISCONNECT_ON_FAILURE` Kconfig option is set, the device disconnects automatically.
+If the peripheral and central device cannot agree on a set of connection parameters after the given number of negotiation attempts, and the :kconfig:option:`CONFIG_BLE_CONN_PARAMS_DISCONNECT_ON_FAILURE` Kconfig option is set, the device disconnects automatically.
 
 A connection parameter update procedure can be started using the :c:func:`ble_conn_params_override` function.
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -56,6 +56,10 @@ Libraries
 
    * Updated the :c:func:`bm_zms_register` function to return ``-EINVAL`` when passing ``NULL`` input parameters.
 
+* :ref:`lib_ble_conn_params` library:
+
+   * Fixed an issue that caused the :kconfig:option:`CONFIG_BLE_CONN_PARAMS_INITIATE_DATA_LENGTH_UPDATE` Kconfig option to always be hidden.
+
 Samples
 =======
 

--- a/lib/ble_conn_params/Kconfig
+++ b/lib/ble_conn_params/Kconfig
@@ -120,7 +120,8 @@ config BLE_CONN_PARAMS_DATA_LENGTH_RX
 	  definitive max data length of 251, the ATT MTU needs to be configured to at least 247.
 
 config BLE_CONN_PARAMS_INITIATE_DATA_LENGTH_UPDATE
-	bool "Initiate data length update on connection" if BLE_CONN_PARAMS_DATA_LENGTH != 27
+	bool "Initiate data length update on connection" if BLE_CONN_PARAMS_DATA_LENGTH_TX != 27 || \
+							    BLE_CONN_PARAMS_DATA_LENGTH_RX != 27
 
 endif # BLE_CONN_PARAMS_AUTO_DATA_LENGTH
 


### PR DESCRIPTION
Fixes:
* One instance of a wrong Kconfig option name in a prompt conditional.
* Two instances of duplicate CONFIG_ in the docs. 