### PR TITLE
ci: Use fixed version of toolchain bundle

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -39,3 +39,4 @@ jobs:
           artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
           stable: ${{ env.STABLE }}
           repository-type: 'nrf-bm'
+          toolchain-version: 'v3.1.0'


### PR DESCRIPTION
Use fixed version of toolchain bundle
in src.tar.gz package

Please remember to update bundle version when needed
It should also match toolchain version used in twister tests
https://github.com/nrfconnect/sdk-nrf-bm/blob/main/.github/workflows/twister.yml#L16

It is possible to extract bundle version to separate file, but it requires more changes in actions and is out of scope of my PR