### PR TITLE
include: bm_zms: clarify event results

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -63,6 +63,7 @@ Libraries
      * The :c:func:`bm_zms_register` function to return ``-EINVAL`` when passing ``NULL`` input parameters.
      * The name of the :c:struct:`bm_zms_evt_t` ``id`` field to :c:member:`bm_zms_evt_t.evt_id`.
      * The name of the :c:struct:`bm_zms_evt_t` ``ate_id`` field to :c:member:`bm_zms_evt_t.id`.
+     * The type of :c:member:`bm_zms_evt_t.result` from ``uint32_t`` to ``int``.
 
    * Added the :c:enumerator:`BM_ZMS_EVT_DELETE` event ID to distinguish :c:func:`bm_zms_delete` events.
 

--- a/include/bm_zms.h
+++ b/include/bm_zms.h
@@ -42,7 +42,7 @@ typedef enum {
 /**@brief A BM_ZMS event. */
 typedef struct {
 	bm_zms_evt_id_t evt_id; /* The event ID. See @ref bm_zms_evt_id_t. */
-	uint32_t result;        /* The result of the operation related to this event.
+	int result;		/* The result of the operation related to this event.
 				 * The operation might have failed for one of the following reasons:
 				 * -ENOSPC:  There is no free space in flash.
 				 * -EIO:     Internal BM_ZMS error.


### PR DESCRIPTION
* Clarifies the possible expected results
for BM_ZMS events.

* The result errors reported are negative errnos.
Change the type of `result` accordingly.
