### PR TITLE
lib: bm_zms: fix writing when length is not a multiple of program unit

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -58,6 +58,8 @@ Libraries
 
 * :ref:`lib_bm_zms` library:
 
+   * Fixed an issue where some data would be written incorrectly to storage if the data size was not a multiple of the program unit of 16 bytes.
+
    * Updated:
 
      * The :c:func:`bm_zms_register` function to return ``-EINVAL`` when passing ``NULL`` input parameters.

--- a/lib/bm_zms/bm_zms.c
+++ b/lib/bm_zms/bm_zms.c
@@ -57,6 +57,9 @@ static bm_zms_cb_t zms_cb_table[CONFIG_BM_ZMS_MAX_USERS];
 /* Queue of bm_zms operations. */
 RING_BUF_DECLARE(zms_fifo, CONFIG_BM_ZMS_OP_QUEUE_SIZE * sizeof(zms_op_t));
 
+/* Internal write buffer for padding data that is not a multiple of the program unit. */
+static __ALIGN(4) uint8_t bm_zms_internal_buf[ZMS_BLOCK_SIZE];
+
 static int zms_prev_ate(struct bm_zms_fs *fs, uint64_t *addr, struct zms_ate *ate);
 static int zms_ate_valid(struct bm_zms_fs *fs, const struct zms_ate *entry);
 static int zms_get_sector_cycle(struct bm_zms_fs *fs, uint64_t addr, uint8_t *cycle_cnt);
@@ -723,7 +726,7 @@ static uint32_t zms_flash_al_wrt(struct bm_zms_fs *fs)
 	const uint8_t *data8;
 	uint32_t rc = 0;
 	off_t offset;
-	uint8_t buf[ZMS_BLOCK_SIZE];
+	size_t blen = 0;
 
 	if (!cur_op.len) {
 		zms_al_wrt_next_op(fs);
@@ -743,20 +746,23 @@ static uint32_t zms_flash_al_wrt(struct bm_zms_fs *fs)
 	}
 	offset = zms_addr_to_offset(fs, cur_op.addr);
 
-	cur_op.blen = zms_round_down_write_block_size(fs, cur_op.len);
-	if (cur_op.blen > 0) {
-		cur_op.len -= cur_op.blen;
+	blen = zms_round_down_write_block_size(fs, cur_op.len);
+	if (blen > 0) {
+		cur_op.len -= blen;
+		cur_op.blen = (cur_op.len) ? blen : 0;
 		zms_al_wrt_next_op(fs);
-		return bm_storage_write(&fs->zms_bm_storage, offset, data8, cur_op.blen,
+		return bm_storage_write(&fs->zms_bm_storage, offset, data8, blen,
 					(void *)&cur_op);
 	}
 	if (cur_op.len) {
-		memcpy(buf, data8 + cur_op.blen, cur_op.len);
-		(void)memset(buf + cur_op.len, fs->zms_bm_storage.nvm_info->erase_value,
+		memcpy(bm_zms_internal_buf, data8 + cur_op.blen, cur_op.len);
+		(void)memset(bm_zms_internal_buf + cur_op.len,
+			     fs->zms_bm_storage.nvm_info->erase_value,
 			     fs->zms_bm_storage.nvm_info->program_unit - cur_op.len);
 		cur_op.len = 0;
 		zms_al_wrt_next_op(fs);
-		return bm_storage_write(&fs->zms_bm_storage, offset + cur_op.blen, buf,
+		return bm_storage_write(&fs->zms_bm_storage, offset + cur_op.blen,
+					bm_zms_internal_buf,
 					fs->zms_bm_storage.nvm_info->program_unit,
 					(void *)&cur_op);
 	}


### PR DESCRIPTION
Fix writing when length is above the program unit and not a multiple of the program unit. Program unit is 16.

Data was not offset correctly when writing the last few bytes. Also, the temporary buffer used to pad the last few bytes went out of scope before the data could be asynchronously written.