### PR TITLE
bluetooth: services: handle sys attr missing err when calling notify

### DIFF
--- a/subsys/bluetooth/services/ble_bas/bas.c
+++ b/subsys/bluetooth/services/ble_bas/bas.c
@@ -216,6 +216,7 @@ int ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle, uint
 	case BLE_ERROR_INVALID_CONN_HANDLE:
 		return -ENOTCONN;
 	case NRF_ERROR_INVALID_STATE:
+	case BLE_ERROR_GATTS_SYS_ATTR_MISSING:
 		return -EPIPE;
 	default:
 		LOG_ERR("Failed to notify battery level, nrf_error %#x", err);

--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -292,6 +292,7 @@ int ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart_rate
 	case BLE_ERROR_INVALID_CONN_HANDLE:
 		return -ENOTCONN;
 	case NRF_ERROR_INVALID_STATE:
+	case BLE_ERROR_GATTS_SYS_ATTR_MISSING:
 		return -EPIPE;
 	default:
 		LOG_ERR("Failed to notify heart rate measurement, nrf_error %#x", err);

--- a/subsys/bluetooth/services/ble_nus/nus.c
+++ b/subsys/bluetooth/services/ble_nus/nus.c
@@ -335,6 +335,7 @@ int ble_nus_data_send(struct ble_nus *nus, uint8_t *data,
 	case BLE_ERROR_INVALID_CONN_HANDLE:
 		return -ENOTCONN;
 	case NRF_ERROR_INVALID_STATE:
+	case BLE_ERROR_GATTS_SYS_ATTR_MISSING:
 		return -EPIPE;
 	case NRF_ERROR_RESOURCES:
 		return -EAGAIN;


### PR DESCRIPTION
The BLE_ERROR_GATTS_SYS_ATTR_MISSING error will be returned if sd_ble_gatts_sys_attr_set() have not been called yet as a response to BLE_GATTS_EVT_SYS_ATTR_MISSING. Handle it by returning -EPIPE.

Removes some mostly irrelevant error prints for sample applications when using peer_manager.