### PR TITLE
samples: bluetooth: ble_cgms: correct bas return type

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -86,6 +86,10 @@ Bluetooth samples
 
   * Added support for bonding and pairing.
 
+* :ref:`ble_cgms_sample` sample:
+
+  * Corrected the return type for the :c:func:`ble_bas_battery_level_update` function.
+
 Peripheral samples
 ------------------
 


### PR DESCRIPTION
ble_bas_battery_level_update return errno.