### PR TITLE
samples: peripheral: enable SoftDevice as default

### DIFF
--- a/samples/peripherals/buttons/prj.conf
+++ b/samples/peripherals/buttons/prj.conf
@@ -1,6 +1,10 @@
 CONFIG_LOG=y
 CONFIG_LOG_BACKEND_BM_UARTE=y
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
 CONFIG_BM_TIMER=y
 CONFIG_BM_BUTTONS=y
 

--- a/samples/peripherals/leds/prj.conf
+++ b/samples/peripherals/leds/prj.conf
@@ -1,4 +1,8 @@
 CONFIG_LOG=y
 CONFIG_LOG_BACKEND_BM_UARTE=y
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
 CONFIG_CLOCK_CONTROL=y

--- a/samples/peripherals/lpuarte/prj.conf
+++ b/samples/peripherals/lpuarte/prj.conf
@@ -4,6 +4,10 @@ CONFIG_LOG_BACKEND_BM_UARTE=n
 CONFIG_CONSOLE=n
 CONFIG_BM_UARTE_CONSOLE=n
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
 CONFIG_BM_TIMER=y
 CONFIG_CLOCK_CONTROL=y
 CONFIG_BM_SW_LPUARTE=y

--- a/samples/peripherals/timer/prj.conf
+++ b/samples/peripherals/timer/prj.conf
@@ -1,5 +1,9 @@
 CONFIG_LOG=y
 CONFIG_LOG_BACKEND_BM_UARTE=y
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
 CONFIG_BM_TIMER=y
 CONFIG_CLOCK_CONTROL=y

--- a/samples/peripherals/uarte/prj.conf
+++ b/samples/peripherals/uarte/prj.conf
@@ -1,6 +1,10 @@
 CONFIG_CONSOLE=y
 CONFIG_BM_UARTE_CONSOLE=y
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+CONFIG_NRF_SDH=y
+
 CONFIG_CLOCK_CONTROL=y
 
 CONFIG_UARTE_HWFC=y


### PR DESCRIPTION
Enable SoftDevice as default for all peripheral samples. This is not strictly required to compile and run the sample, though it will reduce noise by removing a Kconfig compiler warning when building the samples for the S115 board variants. Might revisit later by adding board variants without SoftDevice.