### PR TITLE
lib: peer_manager: remove SoftDevice Kconfig ifdef

### DIFF
--- a/lib/peer_manager/modules/peer_data_storage.c
+++ b/lib/peer_manager/modules/peer_data_storage.c
@@ -276,14 +276,12 @@ static void bm_zms_evt_handler(bm_zms_evt_t const *p_evt)
 static void wait_for_init(void)
 {
 	while (!fs.init_flags.initialized) {
-#if defined(CONFIG_SOFTDEVICE)
 		/* Wait for an event. */
 		__WFE();
 
 		/* Clear Event Register */
 		__SEV();
 		__WFE();
-#endif
 	}
 }
 


### PR DESCRIPTION
Removes `CONFIG_SOFTDEVICE` Kconfig conditional compilation
directive.
The `SOFTDEVICE` Kconfig option is already a required
dependency for the Peer Manager.