### PR TITLE
lib: peer_manager: fix write_buffer record release

### DIFF
--- a/lib/peer_manager/modules/peer_data_storage.c
+++ b/lib/peer_manager/modules/peer_data_storage.c
@@ -427,6 +427,11 @@ uint32_t pds_peer_data_store(pm_peer_id_t peer_id, pm_peer_data_const_t const *p
 		return NRF_ERROR_INTERNAL;
 	}
 
+	if (p_store_token != NULL) {
+		/* Update the store token. */
+		*p_store_token = entry_id;
+	}
+
 	return NRF_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes a bug where the write_buffer records were not released properly.

After having bonded two different peers, there would be no available write_buffer records left and the third attempt would fail with a timeout.