### PR TITLE
logging: backends: improve log backend Kconfig dependencies

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -5,10 +5,18 @@
 #
 menu "Logging"
 
+if LOG
+
 if !LOG_MODE_MINIMAL
+
+if !LOG_FRONTEND_ONLY
 
 rsource "backends/Kconfig"
 
-endif
+endif # !LOG_FRONTEND_ONLY
+
+endif # !LOG_MODE_MINIMAL
+
+endif # LOG
 
 endmenu

--- a/subsys/logging/backends/Kconfig
+++ b/subsys/logging/backends/Kconfig
@@ -8,4 +8,9 @@ menu "Backends"
 
 rsource "Kconfig.bm_uarte"
 
+# Disable the zephyr UART backend by default when the Bare Metal UARTE log backend is used.
+config LOG_BACKEND_UART
+	depends on UART_CONSOLE
+	default n if LOG_BACKEND_BM_UARTE
+
 endmenu

--- a/subsys/logging/backends/Kconfig.bm_uarte
+++ b/subsys/logging/backends/Kconfig.bm_uarte
@@ -5,7 +5,7 @@
 #
 
 menuconfig LOG_BACKEND_BM_UARTE
-	bool "UARTE log backend"
+	bool "Bare Metal UARTE backend"
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  When enabled, the backend uses the nrfx UARTE driver to output logs and printk.

--- a/subsys/logging/backends/Kconfig.bm_uarte
+++ b/subsys/logging/backends/Kconfig.bm_uarte
@@ -16,12 +16,6 @@ if LOG_BACKEND_BM_UARTE
 config LOG_BACKEND_UART
 	default n
 
-# This is required to output printk immediately when we have the console.
-# If not, we wait on log_process, which can be problematic if we add a print right before exiting the
-# application.
-config LOG_PRINTK
-	default n if CONSOLE
-
 # Disable deprecated symbol
 config DEPRECATED_UART_NRFX_UARTE_LEGACY_SHIM
 	bool


### PR DESCRIPTION
Disabling CONFIG_LOG while having CONFIG_LOG_BACKEND_BM_UARTE enabled in the samples caused a build error. Rework the Bare Metal logging backend dependencies to better align with the zephyr logging Kconfigs.