### PR TITLE
sdh: ble: add assert condition when pulling BLE events

### DIFF
--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -318,7 +318,8 @@ static void ble_evt_poll(void *context)
 		}
 	}
 
-	__ASSERT(err == NRF_ERROR_NOT_FOUND,
+	/* An SoC event may have triggered this round of polling, and BLE may not be enabled */
+	__ASSERT((err == NRF_ERROR_NOT_FOUND) || (err == BLE_ERROR_NOT_ENABLED),
 		"Failed to receive SoftDevice event, nrf_error %#x", err);
 }
 


### PR DESCRIPTION
When an SoC event triggers the SoftDevice handler to pull events, if BLE is not enabled, `sd_ble_evt_get()` can return an undocumented error code: `BLE_ERROR_NOT_ENABLED`.

In that case, we don't want to assert.