### PR TITLE
subsys: softdevice_handler: remove the limits of link count on s115

### DIFF
--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -81,7 +81,6 @@ config NRF_SDH_BLE_CENTRAL_LINK_COUNT
 
 config NRF_SDH_BLE_TOTAL_LINK_COUNT
 	int "Maximum number of total concurrent connections"
-	range 1 1 if SOFTDEVICE_S115
 	range 1 64
 	default 1
 


### PR DESCRIPTION
There is no need setting the upper limit of total link count (CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT) to 1 for s115.