### PR TITLE
samples: peripherals: Remove SoftDevice handler

### DIFF
--- a/samples/peripherals/buttons/prj.conf
+++ b/samples/peripherals/buttons/prj.conf
@@ -3,7 +3,6 @@ CONFIG_LOG_BACKEND_BM_UARTE=y
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y
-CONFIG_NRF_SDH=y
 
 CONFIG_BM_TIMER=y
 CONFIG_BM_BUTTONS=y

--- a/samples/peripherals/leds/prj.conf
+++ b/samples/peripherals/leds/prj.conf
@@ -3,6 +3,5 @@ CONFIG_LOG_BACKEND_BM_UARTE=y
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y
-CONFIG_NRF_SDH=y
 
 CONFIG_CLOCK_CONTROL=y

--- a/samples/peripherals/lpuarte/prj.conf
+++ b/samples/peripherals/lpuarte/prj.conf
@@ -6,7 +6,6 @@ CONFIG_BM_UARTE_CONSOLE=n
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y
-CONFIG_NRF_SDH=y
 
 CONFIG_BM_TIMER=y
 CONFIG_CLOCK_CONTROL=y

--- a/samples/peripherals/timer/prj.conf
+++ b/samples/peripherals/timer/prj.conf
@@ -3,7 +3,6 @@ CONFIG_LOG_BACKEND_BM_UARTE=y
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y
-CONFIG_NRF_SDH=y
 
 CONFIG_BM_TIMER=y
 CONFIG_CLOCK_CONTROL=y

--- a/samples/peripherals/uarte/prj.conf
+++ b/samples/peripherals/uarte/prj.conf
@@ -3,7 +3,6 @@ CONFIG_BM_UARTE_CONSOLE=y
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y
-CONFIG_NRF_SDH=y
 
 CONFIG_CLOCK_CONTROL=y
 


### PR DESCRIPTION
SoftDevice handler is not needed by the boards as the SoftDevice is.