### PR TITLE
doc: nrf-bm: ble_conn_params: link API reference

### DIFF
--- a/doc/nrf-bm/api/api.rst
+++ b/doc/nrf-bm/api/api.rst
@@ -12,6 +12,8 @@ API documentation
 Libraries
 *********
 
+.. _api_ble_conn_params:
+
 Bluetooth LE Connection Parameter library
 =========================================
 

--- a/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
@@ -146,4 +146,4 @@ API documentation
 | Header file: :file:`include/ble_conn_params.h`
 | Source files: :file:`lib/ble_conn_params/`
 
-   .. doxygengroup:: ble_conn_params
+:ref:`Bluetooth LE Connection Parameter library API reference <api_ble_conn_params>`


### PR DESCRIPTION
Adds API reference.