### PR TITLE
treewide: remove module-dep=LOG from Kconfig

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -44,7 +44,8 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Logging
 =======
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* Removed ``module-dep=LOG`` in Kconfig files.
+  This is no longer defined.
 
 Drivers
 =======

--- a/lib/ble_adv/Kconfig
+++ b/lib/ble_adv/Kconfig
@@ -120,7 +120,6 @@ config BLE_ADV_SECONDARY_PHY
 	default 0x04 if BLE_ADV_SECONDARY_PHY_CODED
 
 module=BLE_ADV
-module-dep=LOG
 module-str=BLE Advertising
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/ble_conn_params/Kconfig
+++ b/lib/ble_conn_params/Kconfig
@@ -158,7 +158,6 @@ config BLE_CONN_PARAMS_INITIATE_PHY_UPDATE
 endif # BLE_CONN_PARAMS_AUTO_PHY_UPDATE
 
 module=BLE_CONN_PARAMS
-module-dep=LOG
 module-str=BLE Connection Parameters
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/ble_conn_state/Kconfig
+++ b/lib/ble_conn_state/Kconfig
@@ -23,7 +23,6 @@ config BLE_CONN_STATE_BLE_OBSERVER_PRIO
 	default 0
 
 module=BLE_CONN_STATE
-module-dep=LOG
 module-str=BLE Connection state
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/ble_gq/Kconfig
+++ b/lib/ble_gq/Kconfig
@@ -35,7 +35,6 @@ config BLE_GQ_OBSERVER_PRIO
 	default 0
 
 module=BLE_GQ
-module-dep=LOG
 module-str=BLE GATT Queue
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/ble_qwr/Kconfig
+++ b/lib/ble_qwr/Kconfig
@@ -19,7 +19,6 @@ config BLE_QWR_BLE_OBSERVER_PRIO
 	default 2
 
 module=BLE_QWR
-module-dep=LOG
 module-str=BLE QWR
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/ble_racp/Kconfig
+++ b/lib/ble_racp/Kconfig
@@ -10,7 +10,6 @@ menuconfig BLE_RACP
 if BLE_RACP
 
 module=BLE_RACP
-module-dep=LOG
 module-str=BLE RACP
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/bm_buttons/Kconfig
+++ b/lib/bm_buttons/Kconfig
@@ -20,7 +20,6 @@ config BM_BUTTONS_NUM_PINS
 	default 24 if SOC_SERIES_NRF54LX
 
 module=BM_BUTTONS
-module-dep=LOG
 module-str=Bare Metal Buttons
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/bm_timer/Kconfig
+++ b/lib/bm_timer/Kconfig
@@ -22,7 +22,6 @@ config BM_TIMER_IRQ_PRIO
 	  when softdevice is used.
 
 module=BM_TIMER
-module-dep=LOG
 module-str=Bare Metal Timer
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/bm_zms/Kconfig
+++ b/lib/bm_zms/Kconfig
@@ -72,7 +72,6 @@ config BM_ZMS_OP_QUEUE_SIZE
 	  defines the maximum number of operations that can be queued in BM_ZMS
 
 module=BM_ZMS
-module-dep=LOG
 module-str=BM_ZMS
 source "subsys/logging/Kconfig.template.log_config"
 

--- a/lib/event_scheduler/Kconfig
+++ b/lib/event_scheduler/Kconfig
@@ -19,7 +19,6 @@ config EVENT_SCHEDULER_BUF_SIZE
 	  This is a dedicated heap.
 
 module=EVENT_SCHEDULER
-module-dep=LOG
 module-str=Event scheduler
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/peer_manager/Kconfig
+++ b/lib/peer_manager/Kconfig
@@ -123,7 +123,6 @@ config PM_HANDLER_SEC_DELAY_MS
 	  This might be necessary for interoperability reasons, especially as peripheral.
 
 module=PEER_MANAGER
-module-dep=LOG
 module-str=Peer Manager
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_cgms/Kconfig
+++ b/samples/bluetooth/ble_cgms/Kconfig
@@ -63,7 +63,6 @@ config GLUCOSE_CONCENTRATION_MIN
 endmenu # "BLE CGMS sample"
 
 module=BLE_CGMS_SAMPLE
-module-dep=LOG
 module-str=BLE CGMS Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_hids_keyboard/Kconfig
+++ b/samples/bluetooth/ble_hids_keyboard/Kconfig
@@ -33,7 +33,6 @@ config BATTERY_LEVEL_INCREMENT
 endmenu # Battery measurement simulation
 
 module=BLE_HIDS_KEYBOARD_SAMPLE
-module-dep=LOG
 module-str=BLE HIDS Keyboard Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_hids_mouse/Kconfig
+++ b/samples/bluetooth/ble_hids_mouse/Kconfig
@@ -29,7 +29,6 @@ config BATTERY_LEVEL_INCREMENT
 endmenu # Battery measurement simulation
 
 module=BLE_HIDS_MOUSE_SAMPLE
-module-dep=LOG
 module-str=BLE HIDS Mouse Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_hrs/Kconfig
+++ b/samples/bluetooth/ble_hrs/Kconfig
@@ -107,7 +107,6 @@ config SENSOR_CONTACT_DETECTED_INTERVAL
 endmenu # "Sensor contact simulation"
 
 module=BLE_HRS_SAMPLE
-module-dep=LOG
 module-str=BLE Heart Rate Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_lbs/Kconfig
+++ b/samples/bluetooth/ble_lbs/Kconfig
@@ -7,7 +7,6 @@
 menu "BLE LBS sample"
 
 module=BLE_LBS_SAMPLE
-module-dep=LOG
 module-str=BLE LED Button Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_nus/Kconfig
+++ b/samples/bluetooth/ble_nus/Kconfig
@@ -37,7 +37,6 @@ config NUS_UART_RX_BUF_SIZE
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
 module=BLE_NUS_SAMPLE
-module-dep=LOG
 module-str=BLE NUS Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/ble_pwr_profiling/Kconfig
+++ b/samples/bluetooth/ble_pwr_profiling/Kconfig
@@ -44,7 +44,6 @@ config BLE_PWR_PROFILING_LED
 	bool "Power profiling LED"
 
 module=BLE_PWR_PROFILING_SAMPLE
-module-dep=LOG
 module-str=BLE Power Profiling Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/bluetooth/hello_softdevice/Kconfig
+++ b/samples/bluetooth/hello_softdevice/Kconfig
@@ -7,7 +7,6 @@
 menu "Hello SoftDevice sample"
 
 module=BLE_HELLO_SD_SAMPLE
-module-dep=LOG
 module-str=Hello SoftDevice Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/boot/mcuboot_recovery_entry/Kconfig
+++ b/samples/boot/mcuboot_recovery_entry/Kconfig
@@ -7,7 +7,6 @@
 menu "MCUboot recovery entry sample"
 
 module=APP
-module-dep=LOG
 module-str=MCUboot recovery entry
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/boot/mcuboot_recovery_retention/Kconfig
+++ b/samples/boot/mcuboot_recovery_retention/Kconfig
@@ -7,7 +7,6 @@
 menu "MCUboot recovery retention sample"
 
 module=APP
-module-dep=LOG
 module-str=MCUboot recovery retention
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/mcumgr/ble_mcumgr/Kconfig
+++ b/samples/mcumgr/ble_mcumgr/Kconfig
@@ -7,7 +7,6 @@
 menu "BLE MCUmgr sample"
 
 module=APP
-module-dep=LOG
 module-str=BLE MCUmgr Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/mcumgr/uart_mcumgr/Kconfig
+++ b/samples/mcumgr/uart_mcumgr/Kconfig
@@ -39,7 +39,6 @@ config UARTE_IRQ_PRIO
 	default 3
 
 module=UART_MCUMGR_SAMPLE
-module-dep=LOG
 module-str=UART MCUmgr Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/bm_zms/Kconfig
+++ b/samples/peripherals/bm_zms/Kconfig
@@ -21,7 +21,6 @@ config BM_ZMS_ITERATIONS_DELETE_INTERVAL
 	  Specifies the number of iterations between deleting all basic items.
 
 module=BM_ZMS_SAMPLE
-module-dep=LOG
 module-str=Bare Metal ZMS Sample
 source "subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/buttons/Kconfig
+++ b/samples/peripherals/buttons/Kconfig
@@ -7,7 +7,6 @@
 menu "Buttons sample"
 
 module=BUTTONS_SAMPLE
-module-dep=LOG
 module-str=Buttons Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/leds/Kconfig
+++ b/samples/peripherals/leds/Kconfig
@@ -7,7 +7,6 @@
 menu "LEDs sample"
 
 module=LEDS_SAMPLE
-module-dep=LOG
 module-str=LEDs Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/lpuarte/Kconfig
+++ b/samples/peripherals/lpuarte/Kconfig
@@ -26,7 +26,6 @@ config LPUARTE_GPIOTE_IRQ_PRIO
 	default 3
 
 module=LPUARTE_SAMPLE
-module-dep=LOG
 module-str=Low Power UARTE Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/storage/Kconfig
+++ b/samples/peripherals/storage/Kconfig
@@ -7,7 +7,6 @@
 menu "Storage sample"
 
 module=STORAGE_SAMPLE
-module-dep=LOG
 module-str=Storage Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/timer/Kconfig
+++ b/samples/peripherals/timer/Kconfig
@@ -23,7 +23,6 @@ config BYE_TIMER_DURATION_MS
 	default 4000
 
 module=TIMER_SAMPLE
-module-dep=LOG
 module-str=Timer Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/samples/peripherals/uarte/Kconfig
+++ b/samples/peripherals/uarte/Kconfig
@@ -27,7 +27,6 @@ config UARTE_IRQ_PRIO
 	default 5
 
 module=UARTE_SAMPLE
-module-dep=LOG
 module-str=UARTE Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_bas/Kconfig
+++ b/subsys/bluetooth/services/ble_bas/Kconfig
@@ -9,7 +9,6 @@ menuconfig BLE_BAS
 if BLE_BAS
 
 module=BLE_BAS
-module-dep=LOG
 module-str=BLE Battery service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_cgms/Kconfig
+++ b/subsys/bluetooth/services/ble_cgms/Kconfig
@@ -18,7 +18,6 @@ config BLE_CGMS_DB_RECORDS_MAX
 	default 100
 
 module=BLE_CGMS
-module-dep=LOG
 module-str=BLE CGMS
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_dis/Kconfig
+++ b/subsys/bluetooth/services/ble_dis/Kconfig
@@ -100,7 +100,6 @@ characteristic-str=Device Information Service characterstics
 source "$(ZEPHYR_NRF_BM_MODULE_DIR)/subsys/bluetooth/services/Kconfig.template.sec_mode"
 
 module=BLE_DIS
-module-dep=LOG
 module-str=BLE Device information service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_hids/Kconfig
+++ b/subsys/bluetooth/services/ble_hids/Kconfig
@@ -78,7 +78,6 @@ config BLE_HIDS_MAX_CLIENTS
 	default 1
 
 module=BLE_HIDS
-module-dep=LOG
 module-str=BLE HID service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_hrs/Kconfig
+++ b/subsys/bluetooth/services/ble_hrs/Kconfig
@@ -14,7 +14,6 @@ config BLE_HRS_MAX_BUFFERED_RR_INTERVALS
 	default 20
 
 module=BLE_HRS
-module-dep=LOG
 module-str=BLE Heart rate service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_lbs/Kconfig
+++ b/subsys/bluetooth/services/ble_lbs/Kconfig
@@ -10,7 +10,6 @@ menuconfig BLE_LBS
 if BLE_LBS
 
 module=BLE_LBS
-module-dep=LOG
 module-str=BLE LED Button Service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_mcumgr/Kconfig
+++ b/subsys/bluetooth/services/ble_mcumgr/Kconfig
@@ -10,7 +10,6 @@ menuconfig BLE_MCUMGR
 if BLE_MCUMGR
 
 module=BLE_MCUMGR
-module-dep=LOG
 module-str=BLE MCUmgr Service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/bluetooth/services/ble_nus/Kconfig
+++ b/subsys/bluetooth/services/ble_nus/Kconfig
@@ -10,7 +10,6 @@ menuconfig BLE_NUS
 if BLE_NUS
 
 module=BLE_NUS
-module-dep=LOG
 module-str=BLE Nordic UART Service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -121,7 +121,6 @@ config NRF_SDH_STR_TABLES
 	  Disable to save non-volatile memory.
 
 module=NRF_SDH
-module-dep=LOG
 module-str= SoftDevice handler log level
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 


### PR DESCRIPTION
Remove module-dep=LOG from Kconfig. This is removed in Zephyr.