### PR TITLE
lib: ble_conn_params: Kconfig: add missing dependencies

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -53,7 +53,9 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Libraries
 =========
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* :ref:`lib_ble_conn_params` library:
+
+   * Added missing Kconfig dependencies.
 
 Samples
 =======

--- a/lib/ble_conn_params/Kconfig
+++ b/lib/ble_conn_params/Kconfig
@@ -5,6 +5,8 @@
 #
 menuconfig BLE_CONN_PARAMS
 	bool "BLE Connection Parameters"
+	depends on SOFTDEVICE
+	depends on NRF_SDH
 
 if BLE_CONN_PARAMS
 


### PR DESCRIPTION
Adds missing Kconfig dependencies.