### PR TITLE
doc: nrf-bm: lib: add documentation for sensor simulator library

### DIFF
--- a/doc/nrf-bm/api/api.rst
+++ b/doc/nrf-bm/api/api.rst
@@ -127,6 +127,8 @@ Record Access Control Point
    :inner:
    :members:
 
+.. _api_sensorsim:
+
 Sensor data simulator library
 =============================
 

--- a/doc/nrf-bm/libraries/sensorsim.rst
+++ b/doc/nrf-bm/libraries/sensorsim.rst
@@ -1,0 +1,44 @@
+.. _lib_sensorsim:
+
+Sensor Simulator
+################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The sensor simulator library provides functionality for simulating sensor data for testing and development purposes.
+
+It currently supports simulating data using a triangular waveform.
+
+Configuration
+*************
+
+The library is enabled using the Kconfig system.
+Set the :kconfig:option:`CONFIG_SENSORSIM` Kconfig option to enable the library.
+
+Initialization
+==============
+
+To initialize a sensor simulator instance, use the :c:func:`sensorsim_init` function.
+The function requires providing a configuration for the minimal, maximum, and starting values, as well as the increment between each measurement.
+
+For details on the configuration parameters, see the :c:struct:`sensorsim_cfg` structure.
+
+Usage
+*****
+
+After initialization, you can call the :c:func:`sensorsim_measure` function to generate measurements based on a triangular waveform.
+
+Dependencies
+************
+
+This library does not have any dependencies.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bm/sensorsim.h`
+| Source files: :file:`lib/sensorsim/`
+
+:ref:`Sensor data simulator library API reference <api_sensorsim>`

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -108,4 +108,4 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Documentation
 =============
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* Added documentation for the :ref:`lib_sensorsim` library.


### PR DESCRIPTION
Add documentation for sensor simulator library.