### PR TITLE
treewide: bluetooth: change error codes to nrf_error

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <errno.h>
+#include <nrf_error.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -50,9 +50,9 @@ static struct mgmt_callback os_mgmt_reboot_callback = {
  */
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
+	uint32_t nrf_err;
 
-	__ASSERT(ble_evt, "BLE event is NULL");
+	__ASSERT(evt, "BLE event is NULL");
 
 	if (evt == NULL) {
 		return;
@@ -63,10 +63,10 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 		break;
 	}
@@ -92,11 +92,12 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 	{
 		/* Pairing not supported */
-		err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
-						  BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL);
+		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
+						      BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP,
+						      NULL, NULL);
 
-		if (err) {
-			LOG_ERR("Failed to reply with Security params, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to reply with Security params, nrf_error %#x", nrf_err);
 		}
 
 		break;
@@ -106,10 +107,10 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
-		err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 
 		break;
@@ -154,18 +155,16 @@ static enum mgmt_cb_return os_mgmt_reboot_hook(uint32_t event, enum mgmt_cb_retu
 
 /**
  * @brief Change Bluetooth address from the default random address
- *
- * @param[out] err Error code
  */
-static int ble_change_address(void)
+static uint32_t ble_change_address(void)
 {
-	int err;
+	uint32_t nrf_err;
 	ble_gap_addr_t device_address;
 
-	err = sd_ble_gap_addr_get(&device_address);
+	nrf_err = sd_ble_gap_addr_get(&device_address);
 
-	if (err != 0) {
-		return err;
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	device_address.addr[0] ^= 0x1;
@@ -221,10 +220,10 @@ int main(void)
 
 	LOG_INF("Services initialized");
 
-	err = ble_change_address();
+	nrf_err = ble_change_address();
 
-	if (err) {
-		LOG_ERR("Failed to change Bluetooth address, err %d", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to change Bluetooth address, nrf_error %#x", nrf_err);
 	}
 
 	/* Add MCUmgr Bluetooth service UUID to scan response */
@@ -259,10 +258,10 @@ int main(void)
 	}
 
 	if (device_disconnected == false) {
-		err = sd_ble_gap_disconnect(conn_handle,
-					    BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+		nrf_err = sd_ble_gap_disconnect(conn_handle,
+						BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 
-		if (err != NRF_SUCCESS) {
+		if (nrf_err) {
 			device_disconnected = true;
 		}
 

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -211,10 +211,10 @@ int main(void)
 
 	LOG_INF("Bluetooth enabled");
 
-	err = ble_mcumgr_init();
+	nrf_err = ble_mcumgr_init();
 
-	if (err) {
-		LOG_ERR("Failed to initialize MCUmgr service, err %d", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize MCUmgr service, nrf_error %#x", nrf_err);
 		return 0;
 	}
 

--- a/doc/nrf-bm/libraries/bluetooth/ble_peer_manager.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_peer_manager.rst
@@ -149,14 +149,14 @@ The following code example shows how the Peer Manager is initialized:
 
 .. code-block:: c
 
-   static int peer_manager_init(bool erase_bonds)
+   static uint32_t peer_manager_init(bool erase_bonds)
    {
-      uint32_t err;
+      uint32_t nrf_err;
       ble_gap_sec_params_t sec_param;
 
-      err = pm_init();
-      if (err) {
-         return -EFAULT;
+      nrf_err = pm_init();
+      if (nrf_err) {
+         return nrf_err;
       }
 
       if (erase_bonds) {
@@ -179,17 +179,19 @@ The following code example shows how the Peer Manager is initialized:
          .kdist_peer.id = 1,
       };
 
-      err = pm_sec_params_set(&sec_param);
-      if (err) {
-         LOG_ERR("pm_sec_params_set() failed, err: 0x%x", err);
-         return -EFAULT;
+      nrf_err = pm_sec_params_set(&sec_param);
+      if (nrf_err) {
+         LOG_ERR("pm_sec_params_set() failed, nrf_error 0x%x", nrf_err);
+         return nrf_err;
       }
 
-      err = pm_register(pm_evt_handler);
-      if (err) {
-         LOG_ERR("pm_register() failed, err: 0x%x", err);
-         return -EFAULT;
+      nrf_err = pm_register(pm_evt_handler);
+      if (nrf_err) {
+         LOG_ERR("pm_register() failed, nrf_error 0x%x", nrf_err);
+         return nrf_err;
       }
+
+      return NRF_SUCCESS;
    }
 
 Usage
@@ -348,12 +350,12 @@ The store operation is finished when either the :c:enum:`PM_EVT_PEER_DATA_UPDATE
 
 .. code-block:: c
 
-   uint32_t err;
+   uint32_t nrf_err;
    uint32_t store_token;
 
-   err = pm_peer_data_remote_db_store(peer_id, array_of_services, number_of_services, &store_token);
-   if (err != NRF_ERROR_BUSY) {
-      return err;
+   nrf_err = pm_peer_data_remote_db_store(peer_id, array_of_services, number_of_services, &store_token);
+   if (nrf_err != NRF_SUCCESS && nrf_err != NRF_ERROR_BUSY) {
+      return nrf_err;
    }
 
 The :c:func:`pm_peer_data_remote_db_store`, :c:func:`pm_peer_data_bonding_store`, and :c:func:`pm_peer_data_app_data_store` functions call the :c:func:`pm_peer_data_store` function.
@@ -361,12 +363,12 @@ The :c:func:`pm_peer_data_store` function can also be used directly, as in the f
 
 .. code-block:: c
 
-   uint32_t err;
+   uint32_t nrf_err;
    uint32_t store_token;
 
-   err = pm_peer_data_store(peer_id, PM_PEER_DATA_ID_GATT_REMOTE, array_of_services, number_of_services, &store_token);
-   if (err != NRF_ERROR_BUSY) {
-      return err;
+   nrf_err = pm_peer_data_store(peer_id, PM_PEER_DATA_ID_GATT_REMOTE, array_of_services, number_of_services, &store_token);
+   if (nrf_err != NRF_SUCCESS && nrf_err != NRF_ERROR_BUSY) {
+      return nrf_err;
    }
 
 Using a whitelist
@@ -392,9 +394,9 @@ The following example shows how to use the :c:func:`pm_whitelist_set` function t
       }
 
       /* Whitelist peers. */
-      err = pm_whitelist_set(peer_ids, n_peer_ids);
-      if (err != NRF_SUCCESS) {
-         return err;
+      nrf_err = pm_whitelist_set(peer_ids, n_peer_ids);
+      if (nrf_err) {
+         return nrf_err;
       }
    }
 
@@ -409,7 +411,7 @@ The following example shows how to use the :c:func:`pm_whitelist_set` function t
              * previously whitelisted using pm_whitelist_set().
              */
 
-            uint32_t err;
+            uint32_t nrf_err;
 
             /* Storage for the whitelist. */
             ble_gap_irk_t irks[8] = {0};
@@ -418,15 +420,15 @@ The following example shows how to use the :c:func:`pm_whitelist_set` function t
             uint32_t irk_cnt = 8;
             uint32_t addr_cnt = 8;
 
-            err = pm_whitelist_get(addrs, &addr_cnt, irks, &irk_cnt);
-            if (err != NRF_SUCCESS) {
-               return err;
+            nrf_err = pm_whitelist_get(addrs, &addr_cnt, irks, &irk_cnt);
+            if (nrf_err) {
+               return;
             }
 
             /* Apply the whitelist. */
-            err = ble_advertising_whitelist_reply(addrs, addr_cnt, irks, irk_cnt);
-            if (err != NRF_SUCCESS) {
-               return err;
+            nrf_err = ble_advertising_whitelist_reply(addrs, addr_cnt, irks, irk_cnt);
+            if (nrf_err) {
+               return;
             }
 
             break;

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -85,6 +85,7 @@ Libraries
   * :ref:`lib_ble_service_bas` service.
   * :ref:`lib_ble_service_dis` service.
   * :ref:`lib_ble_service_hrs` service.
+  * :ref:`lib_ble_service_lbs` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -76,12 +76,13 @@ Libraries
 
 * Added the :ref:`lib_ble_radio_notification` library.
 
-* Updated the following libraries to return ``nrf_errors`` instead of ``errnos``:
+* Updated the following libraries and BLE services to return ``nrf_errors`` instead of ``errnos``:
 
   * :ref:`lib_ble_adv` library.
   * :ref:`lib_ble_conn_params` library.
   * :ref:`lib_ble_gatt_queue` library.
   * :ref:`lib_ble_queued_writes` library.
+  * :ref:`lib_ble_service_bas` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -42,9 +42,9 @@ Boards
 
 * MCUboot partition size has been reduced from 36 KiB to 31 KiB for the following board targets:
 
-  * `bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot`
-  * `bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot`
-  * `bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot`
+  * ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
+  * ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
+  * ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
 
 * Removed unused peripheral nodes from Devicetree.
 
@@ -56,7 +56,7 @@ Build system
 DFU
 ===
 
-* Support for KMU usage for MCUboot keys has been added, along with west auto-provisioning support (`west flash --erase` or `west flash --recover` must be used during first programming of a board to program the KMU with the keys).
+* Support for KMU usage for MCUboot keys has been added, along with west auto-provisioning support (``west flash --erase`` or ``west flash --recover`` must be used during first programming of a board to program the KMU with the keys).
   This feature can be controlled with sysbuild Kconfig options :kconfig:option:`SB_CONFIG_BM_BOOTLOADER_MCUBOOT_SIGNATURE_USING_KMU` to use KMU for key storage and :kconfig:option:`SB_CONFIG_BM_BOOTLOADER_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE` to auto-provision the KMU when using the above west flash commands.
 * The code for the UART MCUmgr application has now been refactored into a separate library to facilitate reuse in other applications.
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -83,6 +83,7 @@ Libraries
   * :ref:`lib_ble_gatt_queue` library.
   * :ref:`lib_ble_queued_writes` library.
   * :ref:`lib_ble_service_bas` service.
+  * :ref:`lib_ble_service_dis` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -86,6 +86,7 @@ Libraries
   * :ref:`lib_ble_service_dis` service.
   * :ref:`lib_ble_service_hrs` service.
   * :ref:`lib_ble_service_lbs` service.
+  * :ref:`lib_ble_service_mcumgr` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -84,6 +84,7 @@ Libraries
   * :ref:`lib_ble_queued_writes` library.
   * :ref:`lib_ble_service_bas` service.
   * :ref:`lib_ble_service_dis` service.
+  * :ref:`lib_ble_service_hrs` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -81,6 +81,7 @@ Libraries
   * :ref:`lib_ble_adv` library.
   * :ref:`lib_ble_conn_params` library.
   * :ref:`lib_ble_gatt_queue` library.
+  * :ref:`lib_ble_queued_writes` library.
 
 * :ref:`lib_ble_conn_params` library:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -87,6 +87,7 @@ Libraries
   * :ref:`lib_ble_service_hrs` service.
   * :ref:`lib_ble_service_lbs` service.
   * :ref:`lib_ble_service_mcumgr` service.
+  * :ref:`lib_ble_service_nus` service.
   * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -78,7 +78,8 @@ Libraries
 
 * Updated the following libraries to return ``nrf_errors`` instead of ``errnos``:
 
-  * :ref:`lib_ble_adv`.
+  * :ref:`lib_ble_adv` library.
+  * :ref:`lib_ble_conn_params` library.
 
 * :ref:`lib_ble_conn_params` library:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -80,6 +80,7 @@ Libraries
 
   * :ref:`lib_ble_adv` library.
   * :ref:`lib_ble_conn_params` library.
+  * :ref:`lib_ble_gatt_queue` library.
 
 * :ref:`lib_ble_conn_params` library:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -82,6 +82,7 @@ Libraries
   * :ref:`lib_ble_conn_params` library.
   * :ref:`lib_ble_gatt_queue` library.
   * :ref:`lib_ble_queued_writes` library.
+  * BLE Record Access Control Point library.
 
 * :ref:`lib_ble_conn_params` library:
 

--- a/drivers/bm_lpuarte/lpuarte.c
+++ b/drivers/bm_lpuarte/lpuarte.c
@@ -79,7 +79,7 @@ static void req_pin_arm(struct bm_lpuarte *lpu)
 static nrfx_err_t req_pin_init(struct bm_lpuarte *lpu, nrfx_gpiote_pin_t pin)
 {
 	uint8_t ch;
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	nrf_gpio_pin_pull_t pull_config = NRF_GPIO_PIN_PULLDOWN;
 	nrfx_gpiote_trigger_config_t trigger_config = {
 		.trigger = NRFX_GPIOTE_TRIGGER_HITOLO,
@@ -95,14 +95,14 @@ static nrfx_err_t req_pin_init(struct bm_lpuarte *lpu, nrfx_gpiote_pin_t pin)
 		.p_handler_config = &handler_config
 	};
 
-	err = nrfx_gpiote_channel_alloc(gpiote_get(pin), &ch);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_gpiote_channel_alloc(gpiote_get(pin), &ch);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
-	err = nrfx_gpiote_input_configure(gpiote_get(pin), pin, &input_config);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_gpiote_input_configure(gpiote_get(pin), pin, &input_config);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
 	lpu->req_pin = pin;
@@ -127,7 +127,7 @@ static void rdy_pin_suspend(struct bm_lpuarte *lpu)
 
 static nrfx_err_t rdy_pin_init(struct bm_lpuarte *lpu, nrfx_gpiote_pin_t pin)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	nrf_gpio_pin_pull_t pull_config = NRF_GPIO_PIN_NOPULL;
 	nrfx_gpiote_handler_config_t handler_config = {
 		.handler = rdy_pin_handler,
@@ -139,14 +139,14 @@ static nrfx_err_t rdy_pin_init(struct bm_lpuarte *lpu, nrfx_gpiote_pin_t pin)
 		.p_handler_config = &handler_config
 	};
 
-	err = nrfx_gpiote_channel_alloc(gpiote_get(pin), &lpu->rdy_ch);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_gpiote_channel_alloc(gpiote_get(pin), &lpu->rdy_ch);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
-	err = nrfx_gpiote_input_configure(gpiote_get(pin), pin, &input_config);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_gpiote_input_configure(gpiote_get(pin), pin, &input_config);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
 	lpu->rdy_pin = pin;
@@ -163,7 +163,7 @@ static void rdy_pin_uninit(struct bm_lpuarte *lpu, nrfx_gpiote_pin_t pin)
 /* Pin activated to detect high state (using SENSE). */
 static void rdy_pin_idle(struct bm_lpuarte *lpu)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	nrfx_gpiote_trigger_config_t trigger_config = {
 		.trigger = NRFX_GPIOTE_TRIGGER_HIGH
 	};
@@ -174,8 +174,8 @@ static void rdy_pin_idle(struct bm_lpuarte *lpu)
 	};
 	const nrfx_gpiote_t *gpiote = gpiote_get(lpu->rdy_pin);
 
-	err = nrfx_gpiote_input_configure(gpiote, lpu->rdy_pin, &input_config);
-	__ASSERT(err == NRFX_SUCCESS, "Unexpected nrfx_err %#x", err);
+	nrfx_err = nrfx_gpiote_input_configure(gpiote, lpu->rdy_pin, &input_config);
+	__ASSERT(nrfx_err == NRFX_SUCCESS, "Unexpected nrfx_err %#x", nrfx_err);
 
 	nrfx_gpiote_trigger_enable(gpiote, lpu->rdy_pin, true);
 }
@@ -189,7 +189,7 @@ static void rdy_pin_idle(struct bm_lpuarte *lpu)
  */
 static bool rdy_pin_blink(struct bm_lpuarte *lpu)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	nrfx_gpiote_trigger_config_t trigger_config = {
 		.trigger = NRFX_GPIOTE_TRIGGER_HITOLO,
 		.p_in_channel = &lpu->rdy_ch
@@ -207,8 +207,8 @@ static bool rdy_pin_blink(struct bm_lpuarte *lpu)
 	/* Drive low for a moment */
 	nrf_gpio_reconfigure(lpu->rdy_pin, &dir_out, NULL, NULL, NULL, NULL);
 
-	err = nrfx_gpiote_input_configure(gpiote, lpu->rdy_pin, &input_config);
-	__ASSERT(err == NRFX_SUCCESS, "Unexpected nrfx_err %#x", err);
+	nrfx_err = nrfx_gpiote_input_configure(gpiote, lpu->rdy_pin, &input_config);
+	__ASSERT(nrfx_err == NRFX_SUCCESS, "Unexpected nrfx_err %#x", nrfx_err);
 
 	nrfx_gpiote_trigger_enable(gpiote, lpu->rdy_pin, true);
 
@@ -241,14 +241,14 @@ static bool rdy_pin_blink(struct bm_lpuarte *lpu)
 /* Set response pin to idle and disable RX. */
 static void deactivate_rx(struct bm_lpuarte *lpu)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 
 	/* abort rx */
 	LOG_DBG("RX: Deactivate");
 	lpu->rx_state = RX_TO_IDLE;
-	err = nrfx_uarte_rx_abort(&lpu->uarte_inst, true, false);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("RX: Failed to disable, nrfx_err %#x", err);
+	nrfx_err = nrfx_uarte_rx_abort(&lpu->uarte_inst, true, false);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("RX: Failed to disable, nrfx_err %#x", nrfx_err);
 	}
 
 	rdy_pin_idle(lpu);
@@ -260,14 +260,14 @@ static void deactivate_rx(struct bm_lpuarte *lpu)
  */
 static void activate_rx(struct bm_lpuarte *lpu)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 
 	LOG_DBG("Activating uarte RX");
 
-	err = nrfx_uarte_rx_enable(&lpu->uarte_inst,
+	nrfx_err = nrfx_uarte_rx_enable(&lpu->uarte_inst,
 				   NRFX_UARTE_RX_ENABLE_CONT | NRFX_UARTE_RX_ENABLE_STOP_ON_END);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("lpuarte rx enable failed, nrfx_err %#x", err);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("lpuarte rx enable failed, nrfx_err %#x", nrfx_err);
 	}
 
 	lpu->rx_state = RX_ACTIVE;
@@ -312,7 +312,7 @@ static void req_pin_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t trigger
 	ARG_UNUSED(pin);
 	const uint8_t *buf;
 	size_t len;
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	struct bm_lpuarte *lpu = context;
 
 	LOG_DBG("req_pin_evt");
@@ -334,9 +334,9 @@ static void req_pin_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t trigger
 	buf = lpu->tx_buf;
 	len = lpu->tx_len;
 	NRFX_CRITICAL_SECTION_EXIT();
-	err = nrfx_uarte_tx(&lpu->uarte_inst, buf, len, 0);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("TX: Not started, nrfx_err %#x", err);
+	nrfx_err = nrfx_uarte_tx(&lpu->uarte_inst, buf, len, 0);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("TX: Not started, nrfx_err %#x", nrfx_err);
 		tx_complete(lpu);
 
 		const nrfx_uarte_event_t tx_done_aborted_evt = {
@@ -384,17 +384,17 @@ static void rdy_pin_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t trigger
 
 static void tx_timeout(void *context)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	struct bm_lpuarte *lpu = context;
 	const uint8_t *buf = lpu->tx_buf;
 
 	LOG_WRN("TX abort timeout");
 	if (lpu->tx_active) {
-		err = nrfx_uarte_tx_abort(&lpu->uarte_inst, true);
-		if (err == NRFX_ERROR_INVALID_STATE) {
+		nrfx_err = nrfx_uarte_tx_abort(&lpu->uarte_inst, true);
+		if (nrfx_err == NRFX_ERROR_INVALID_STATE) {
 			LOG_DBG("No active transfer. Already finished?");
-		} else if (err != NRFX_SUCCESS) {
-			__ASSERT(0, "Unexpected tx_abort, nrfx_err %#x", err);
+		} else if (nrfx_err != NRFX_SUCCESS) {
+			__ASSERT(0, "Unexpected tx_abort, nrfx_err %#x", nrfx_err);
 		}
 		return;
 	}
@@ -448,7 +448,7 @@ nrfx_err_t bm_lpuarte_init(struct bm_lpuarte *lpu,
 			   struct bm_lpuarte_config *lpu_cfg,
 			   nrfx_uarte_event_handler_t  event_handler)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 
 	/* We use the uarte context for storing the pointer to the lpu instance */
 	lpu_cfg->uarte_cfg.p_context = lpu;
@@ -461,42 +461,42 @@ nrfx_err_t bm_lpuarte_init(struct bm_lpuarte *lpu,
 	lpu->callback = event_handler;
 
 	if (!nrfx_gpiote_init_check(&gpiote20_instance)) {
-		err = nrfx_gpiote_init(&gpiote20_instance, 0);
-		if (err != NRFX_SUCCESS) {
-			LOG_ERR("Failed to initialize gpiote20, nrfx_err: %#x", err);
+		nrfx_err = nrfx_gpiote_init(&gpiote20_instance, 0);
+		if (nrfx_err != NRFX_SUCCESS) {
+			LOG_ERR("Failed to initialize gpiote20, nrfx_err: %#x", nrfx_err);
 			return NRFX_ERROR_INVALID_STATE;
 		}
 	}
 
 	if (!nrfx_gpiote_init_check(&gpiote30_instance)) {
-		err = nrfx_gpiote_init(&gpiote30_instance, 0);
-		if (err != NRFX_SUCCESS) {
-			LOG_ERR("Failed to initialize gpiote30, nrfx_err: %#x", err);
+		nrfx_err = nrfx_gpiote_init(&gpiote30_instance, 0);
+		if (nrfx_err != NRFX_SUCCESS) {
+			LOG_ERR("Failed to initialize gpiote30, nrfx_err: %#x", nrfx_err);
 			return NRFX_ERROR_INVALID_STATE;
 		}
 	}
 
-	err = req_pin_init(lpu, lpu_cfg->req_pin);
-	if (err < 0) {
-		LOG_ERR("req pin init failed, nrfx_err %#x", err);
-		return err;
+	nrfx_err = req_pin_init(lpu, lpu_cfg->req_pin);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("req pin init failed, nrfx_err %#x", nrfx_err);
+		return nrfx_err;
 	}
 
-	err = rdy_pin_init(lpu, lpu_cfg->rdy_pin);
-	if (err < 0) {
-		LOG_ERR("rdy pin init failed, nrfx_err %#x", err);
-		return err;
+	nrfx_err = rdy_pin_init(lpu, lpu_cfg->rdy_pin);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("rdy pin init failed, nrfx_err %#x", nrfx_err);
+		return nrfx_err;
 	}
 
 	bm_timer_init(&lpu->tx_timer, BM_TIMER_MODE_SINGLE_SHOT, tx_timeout);
 
-	err = nrfx_uarte_init(&lpu->uarte_inst, &lpu_cfg->uarte_cfg, nrfx_uarte_evt_handler);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize UARTE, nrfx_err %#x", err);
-		return err;
+	nrfx_err = nrfx_uarte_init(&lpu->uarte_inst, &lpu_cfg->uarte_cfg, nrfx_uarte_evt_handler);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to initialize UARTE, nrfx_err %#x", nrfx_err);
+		return nrfx_err;
 	}
 
-	return err;
+	return nrfx_err;
 }
 
 void bm_lpuarte_uninit(struct bm_lpuarte *lpu)
@@ -544,7 +544,7 @@ bool bm_lpuarte_tx_in_progress(struct bm_lpuarte *lpu)
 
 nrfx_err_t bm_lpuarte_tx_abort(struct bm_lpuarte *lpu, bool sync)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	const uint8_t *buf = lpu->tx_buf;
 
 	if (!lpu) {
@@ -559,10 +559,10 @@ nrfx_err_t bm_lpuarte_tx_abort(struct bm_lpuarte *lpu, bool sync)
 	tx_complete(lpu);
 	NRFX_CRITICAL_SECTION_EXIT();
 
-	err = nrfx_uarte_tx_abort(&lpu->uarte_inst, sync);
-	if (err == NRFX_ERROR_INVALID_STATE && !sync) {
+	nrfx_err = nrfx_uarte_tx_abort(&lpu->uarte_inst, sync);
+	if (nrfx_err == NRFX_ERROR_INVALID_STATE && !sync) {
 		/* If abort is before TX is started we report ABORT from here. */
-		err = NRFX_SUCCESS;
+		nrfx_err = NRFX_SUCCESS;
 
 		const nrfx_uarte_event_t tx_done_aborted_evt = {
 			.type = NRFX_UARTE_EVT_TX_DONE,
@@ -576,7 +576,7 @@ nrfx_err_t bm_lpuarte_tx_abort(struct bm_lpuarte *lpu, bool sync)
 		lpu->callback(&tx_done_aborted_evt, lpu);
 	}
 
-	return err;
+	return nrfx_err;
 }
 
 nrfx_err_t bm_lpuarte_rx_enable(struct bm_lpuarte *lpu)
@@ -599,15 +599,15 @@ nrfx_err_t bm_lpuarte_rx_buffer_set(struct bm_lpuarte *lpu,
 
 nrfx_err_t bm_lpuarte_rx_abort(struct bm_lpuarte *lpu, bool sync)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 
 	if (lpu->rx_state == RX_OFF) {
 		return NRFX_ERROR_INVALID_STATE;
 	}
 
 	lpu->rx_state = RX_TO_OFF;
-	err = nrfx_uarte_rx_abort(&lpu->uarte_inst, true, sync);
-	if (err == NRFX_ERROR_INVALID_STATE || sync) {
+	nrfx_err = nrfx_uarte_rx_abort(&lpu->uarte_inst, true, sync);
+	if (nrfx_err == NRFX_ERROR_INVALID_STATE || sync) {
 		lpu->rx_state = RX_OFF;
 		rdy_pin_idle(lpu);
 
@@ -627,5 +627,5 @@ nrfx_err_t bm_lpuarte_rx_abort(struct bm_lpuarte *lpu, bool sync)
 		}
 	}
 
-	return err;
+	return nrfx_err;
 }

--- a/drivers/console/console_bm_uarte.c
+++ b/drivers/console/console_bm_uarte.c
@@ -19,9 +19,9 @@ ISR_DIRECT_DECLARE(console_bm_uarte_direct_isr)
 	return 0;
 }
 
-static int uarte_init(void)
+static nrfx_err_t uarte_init(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	nrfx_uarte_config_t uarte_config = NRFX_UARTE_DEFAULT_CONFIG(
 		BOARD_CONSOLE_UARTE_PIN_TX, NRF_UARTE_PSEL_DISCONNECTED);
@@ -45,12 +45,12 @@ static int uarte_init(void)
 
 	irq_enable(NRFX_IRQ_NUMBER_GET(NRF_UARTE_INST_GET(BOARD_CONSOLE_UARTE_INST)));
 
-	err = nrfx_uarte_init(&uarte_inst, &uarte_config, NULL);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_uarte_init(&uarte_inst, &uarte_config, NULL);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
-	return 0;
+	return NRFX_SUCCESS;
 }
 
 static int console_out(int c)

--- a/include/bm/bluetooth/ble_conn_params.h
+++ b/include/bm/bluetooth/ble_conn_params.h
@@ -114,10 +114,10 @@ typedef void (*ble_conn_params_evt_handler_t)(const struct ble_conn_params_evt *
  *
  * @param handler Handler.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p handler is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p handler is @c NULL.
  */
-int ble_conn_params_evt_handler_set(ble_conn_params_evt_handler_t handler);
+uint32_t ble_conn_params_evt_handler_set(ble_conn_params_evt_handler_t handler);
 
 /**
  * @brief Override GAP connection parameters for given peer.
@@ -129,11 +129,11 @@ int ble_conn_params_evt_handler_set(ble_conn_params_evt_handler_t handler);
  * @param conn_handle Connection handle.
  * @param conn_params Connection parameters.
  *
- * @retval 0 Connection parameter update initiated successfully.
- * @retval -EINVAL If @p conn_handle is invalid.
- * @retval -EFAULT If @p conn_params is @c NULL.
+ * @retval NRF_SUCCESS Connection parameter update initiated successfully.
+ * @retval NRF_ERROR_INVALID_PARAM If @p conn_handle is invalid.
+ * @retval NRF_ERROR_NULL If @p conn_params is @c NULL.
  */
-int ble_conn_params_override(uint16_t conn_handle, const ble_gap_conn_params_t *conn_params);
+uint32_t ble_conn_params_override(uint16_t conn_handle, const ble_gap_conn_params_t *conn_params);
 
 /**
  * @brief Initiate an ATT MTU exchange procedure for a given connection.
@@ -152,10 +152,10 @@ int ble_conn_params_override(uint16_t conn_handle, const ble_gap_conn_params_t *
  * @param conn_handle Handle to the connection.
  * @param att_mtu Desired ATT MTU.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid ATT MTU or connection handle.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid ATT MTU or connection handle.
  */
-int ble_conn_params_att_mtu_set(uint16_t conn_handle, uint16_t att_mtu);
+uint32_t ble_conn_params_att_mtu_set(uint16_t conn_handle, uint16_t att_mtu);
 
 /**
  * @brief Retrieve the current ATT MTU for a given connection.
@@ -163,11 +163,11 @@ int ble_conn_params_att_mtu_set(uint16_t conn_handle, uint16_t att_mtu);
  * @param conn_handle Handle to the connection.
  * @param[out] att_mtu The ATT MTU value.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid connection handle.
- * @retval -EFAULT @p att_mtu is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid connection handle.
+ * @retval NRF_ERROR_NULL @p att_mtu is @c NULL.
  */
-int ble_conn_params_att_mtu_get(uint16_t conn_handle, uint16_t *att_mtu);
+uint32_t ble_conn_params_att_mtu_get(uint16_t conn_handle, uint16_t *att_mtu);
 
 /**
  * @brief Initiate a GAP data length update procedure for a given connection.
@@ -178,10 +178,11 @@ int ble_conn_params_att_mtu_get(uint16_t conn_handle, uint16_t *att_mtu);
  * @param conn_handle Handle to the connection.
  * @param data_length Desired GAP data length.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid data length or connection handle.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid data length or connection handle.
  */
-int ble_conn_params_data_length_set(uint16_t conn_handle, struct ble_conn_params_data_length dl);
+uint32_t ble_conn_params_data_length_set(uint16_t conn_handle,
+					 struct ble_conn_params_data_length dl);
 
 /**
  * @brief Retrieve the current GAP data length for a given connection.
@@ -189,11 +190,12 @@ int ble_conn_params_data_length_set(uint16_t conn_handle, struct ble_conn_params
  * @param conn_handle Handle to the connection.
  * @param[out] data_length The data length value.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid connection handle.
- * @retval -EFAULT @p data_length is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid connection handle.
+ * @retval NRF_ERROR_NULL @p data_length is @c NULL.
  */
-int ble_conn_params_data_length_get(uint16_t conn_handle, struct ble_conn_params_data_length *dl);
+uint32_t ble_conn_params_data_length_get(uint16_t conn_handle,
+					 struct ble_conn_params_data_length *dl);
 
 /**
  * @brief Initiate a GAP radio PHY mode update procedure for a given connection.
@@ -204,10 +206,10 @@ int ble_conn_params_data_length_get(uint16_t conn_handle, struct ble_conn_params
  * @param conn_handle Handle to the connection.
  * @param phy_pref Desired GAP radio PHY mode.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid data length or connection handle.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid data length or connection handle.
  */
-int ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t phy_pref);
+uint32_t ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t phy_pref);
 
 /**
  * @brief Retrieve the current GAP radio PHY mode for a given connection.
@@ -215,11 +217,11 @@ int ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t phy_
  * @param conn_handle Handle to the connection.
  * @param[out] phy_pref The radio PHY mode.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid connection handle.
- * @retval -EFAULT @p phy_pref is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid connection handle.
+ * @retval NRF_ERROR_NULL @p phy_pref is @c NULL.
  */
-int ble_conn_params_phy_radio_mode_get(uint16_t conn_handle, ble_gap_phys_t *phy_pref);
+uint32_t ble_conn_params_phy_radio_mode_get(uint16_t conn_handle, ble_gap_phys_t *phy_pref);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/ble_gq.h
+++ b/include/bm/bluetooth/ble_gq.h
@@ -254,12 +254,14 @@ struct ble_gq {
  * @param[in] req          Pointer to the request.
  * @param[in] conn_handle  Connection handle associated with the request.
  *
- * @retval 0        Request was added successfully.
- * @retval -EFAULT  Any parameter was NULL.
- * @retval -EINVAL  If @p conn_handle is not registered or type of request @p req is not valid.
- * @retval -ENOMEM  There was no room in the queue or in the data pool.
+ * @retval NRF_SUCCESS Request was added successfully.
+ * @retval NRF_ERROR_NULL Any parameter was NULL.
+ * @retval NRF_ERROR_INVALID_PARAM If @p conn_handle is not registered or type of request
+ *                                 @p req is not valid.
+ * @retval NRF_ERROR_NO_MEM There was no room in the queue or in the data pool.
  */
-int ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req, uint16_t conn_handle);
+uint32_t ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req,
+			 uint16_t conn_handle);
 
 /**
  * @brief Register connection handle in the GATT queue instance.
@@ -271,11 +273,11 @@ int ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req, uin
  * @param[in] gatt_queue   Pointer to the @ref ble_gq instance.
  * @param[in] conn_handle  Connection handle.
  *
- * @retval 0        Connection handle was successful registered.
- * @retval -EFAULT  If @p gatt_queue was NULL.
- * @retval -ENOMEM  No space for another connection handle.
+ * @retval NRF_SUCCESS Connection handle was successful registered.
+ * @retval NRF_ERROR_NULL If @p gatt_queue was NULL.
+ * @retval NRF_ERROR_NO_MEM No space for another connection handle.
  */
-int ble_gq_conn_handle_register(const struct ble_gq *gatt_queue, uint16_t conn_handle);
+uint32_t ble_gq_conn_handle_register(const struct ble_gq *gatt_queue, uint16_t conn_handle);
 
 /**
  * @brief Handle BLE events from the SoftDevice.

--- a/include/bm/bluetooth/ble_qwr.h
+++ b/include/bm/bluetooth/ble_qwr.h
@@ -67,7 +67,7 @@ struct ble_qwr_evt {
 	union {
 		/** @ref BLE_QWR_EVT_ERROR event data. */
 		struct {
-			int reason;
+			uint32_t reason;
 		} error;
 		/** @ref BLE_QWR_EVT_EXECUTE_WRITE event data. */
 		struct {
@@ -159,11 +159,11 @@ struct ble_qwr_config {
  *                 Queued Writes instance.
  * @param[in] qwr_init Initialization structure.
  *
- * @retval 0 If the Queued Writes module was initialized successfully.
- * @retval -EFAULT If @p qwr or @p qwr_init is @c NULL.
- * @retval -EPERM If the given @p qwr instance has already been initialized.
+ * @retval NRF_SUCCESS If the Queued Writes module was initialized successfully.
+ * @retval NRF_ERROR_NULL If @p qwr or @p qwr_init is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If the given @p qwr instance has already been initialized.
  */
-int ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config);
+uint32_t ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config);
 
 /**
  * @brief Function for assigning a connection handle to an instance of the Queued Writes module.
@@ -175,11 +175,11 @@ int ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config);
  * @param[in] qwr Queued Writes structure.
  * @param[in] conn_handle Connection handle to be associated with the given Queued Writes instance.
  *
- * @retval 0 If the assignment was successful.
- * @retval -EFAULT If @p qwr is @c NULL.
- * @retval -EPERM If the given @p qwr instance has not been initialized.
+ * @retval NRF_SUCCESS If the assignment was successful.
+ * @retval NRF_ERROR_NULL If @p qwr is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If the given @p qwr instance has not been initialized.
  */
-int ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle);
+uint32_t ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle);
 
 /**
  * @brief Function for handling BLE stack events.
@@ -201,12 +201,12 @@ void ble_qwr_on_ble_evt(ble_evt_t const *ble_evt, void *context);
  * @param[in] qwr Queued Writes structure.
  * @param[in] attr_handle Handle of the attribute to register.
  *
- * @retval 0 If the registration was successful.
- * @retval -ENOMEM If no more memory is available to add this registration.
- * @retval -EFAULT If @p qwr is @c NULL.
- * @retval -EPERM If the given @p qwr instance has not been initialized.
+ * @retval NRF_SUCCESS If the registration was successful.
+ * @retval NRF_ERROR_NO_MEM If no more memory is available to add this registration.
+ * @retval NRF_ERROR_NULL If @p qwr is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If the given @p qwr instance has not been initialized.
  */
-int ble_qwr_attr_register(struct ble_qwr *qwr, uint16_t attr_handle);
+uint32_t ble_qwr_attr_register(struct ble_qwr *qwr, uint16_t attr_handle);
 
 /**
  * @brief Function for retrieving the received data for a given attribute.
@@ -219,12 +219,12 @@ int ble_qwr_attr_register(struct ble_qwr *qwr, uint16_t attr_handle);
  * @param[out] mem Pointer to the application buffer where the received data will be copied.
  * @param[in,out] len Input: length of the input buffer. Output: length of the received data.
  *
- * @retval 0 If the data was retrieved and stored successfully.
- * @retval -ENOMEM If the provided buffer was smaller than the received data.
- * @retval -EFAULT If @p qwr, @p mem or @p len is @c NULL.
- * @retval -EPERM If the given @p qwr instance has not been initialized.
+ * @retval NRF_SUCCESS If the data was retrieved and stored successfully.
+ * @retval NRF_ERROR_NO_MEM If the provided buffer was smaller than the received data.
+ * @retval NRF_ERROR_NULL If @p qwr, @p mem or @p len is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If the given @p qwr instance has not been initialized.
  */
-int ble_qwr_value_get(
+uint32_t ble_qwr_value_get(
 	struct ble_qwr *qwr, uint16_t attr_handle, uint8_t *mem, uint16_t *len);
 #endif /* (CONFIG_BLE_QWR_MAX_ATTR > 0) */
 

--- a/include/bm/bluetooth/ble_racp.h
+++ b/include/bm/bluetooth/ble_racp.h
@@ -114,9 +114,10 @@ struct ble_racp_value {
  * @param[in] data_len Length of data.
  * @param[out] racp_val Decoded Record Access Control Point value.
  *
- * @return 0 on success or negative errno on error.
+ * @retval NRF_SUCCESS on success.
+ * @retval NRF_ERROR_NULL if @p data or @p racp_val is NULL.
  */
-int ble_racp_decode(uint8_t const *data, size_t data_len, struct ble_racp_value *racp_val);
+uint32_t ble_racp_decode(uint8_t const *data, size_t data_len, struct ble_racp_value *racp_val);
 
 /**
  * @brief Encode a Record Access Control Point response.
@@ -127,9 +128,9 @@ int ble_racp_decode(uint8_t const *data, size_t data_len, struct ble_racp_value 
  * @param[out] buf Buffer for encoded data.
  * @param[out] len Buffer size.
  *
- * @return Length of encoded data or negative errno on error.
+ * @return Length of encoded data or 0 on error.
  */
-int ble_racp_encode(const struct ble_racp_value *racp_val, uint8_t *buf, size_t len);
+size_t ble_racp_encode(const struct ble_racp_value *racp_val, uint8_t *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_bas.h
+++ b/include/bm/bluetooth/services/ble_bas.h
@@ -152,11 +152,11 @@ struct ble_bas {
  * @param bas Battery service.
  * @param bas_config Battery service configuration.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p bas or @p bas_config are @c NULL.
- * @retval -EINVAL Invalid parameters.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p bas or @p bas_config are @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
  */
-int ble_bas_init(struct ble_bas *bas, const struct ble_bas_config *bas_config);
+uint32_t ble_bas_init(struct ble_bas *bas, const struct ble_bas_config *bas_config);
 
 /**
  * @brief Update battery level.
@@ -168,13 +168,14 @@ int ble_bas_init(struct ble_bas *bas, const struct ble_bas_config *bas_config);
  * @param conn_handle Connection handle.
  * @param battery_level Battery level (in percent of full capacity).
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p bas is @c NULL.
- * @retval -EINVAL Invalid parameters.
- * @retval -ENOTCONN Invalid connection handle.
- * @retval -EPIPE Notifications not enabled in the CCCD.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p bas is @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
+ * @retval NRF_ERROR_NOT_FOUND Invalid connection handle.
+ * @retval NRF_ERROR_INVALID_STATE Notifications not enabled in the CCCD.
  */
-int ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle, uint8_t battery_level);
+uint32_t ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle,
+				      uint8_t battery_level);
 
 /**
  * @brief Notify battery level.
@@ -186,13 +187,13 @@ int ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle, uint
  * @param bas Battery service.
  * @param conn_handle Connection handle.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p bas is @c NULL.
- * @retval -EINVAL Invalid parameters.
- * @retval -ENOTCONN Invalid connection handle.
- * @retval -EPIPE Notifications not enabled in the CCCD.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p bas is @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
+ * @retval NRF_ERROR_NOT_FOUND Invalid connection handle.
+ * @retval NRF_ERROR_INVALID_STATE Notifications not enabled in the CCCD.
  */
-int ble_bas_battery_level_notify(struct ble_bas *bas, uint16_t conn_handle);
+uint32_t ble_bas_battery_level_notify(struct ble_bas *bas, uint16_t conn_handle);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_dis.h
+++ b/include/bm/bluetooth/services/ble_dis.h
@@ -1,47 +1,12 @@
-/**
- * Copyright (c) 2012 - 2021, Nordic Semiconductor ASA
+/*
+ * Copyright (c) 2012 - 2025 Nordic Semiconductor ASA
  *
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form, except as embedded into a Nordic
- *    Semiconductor ASA integrated circuit in a product or a software update for
- *    such product, must reproduce the above copyright notice, this list of
- *    conditions and the following disclaimer in the documentation and/or other
- *    materials provided with the distribution.
- *
- * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA integrated circuit.
- *
- * 5. Any software provided in binary form under this license must not be reverse
- *    engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
- * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
- * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
- * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /** @file
  *
  * @defgroup ble_dis Device Information Service
- * @{
- * @ingroup ble_sdk_srv
+ *
  * @brief Device Information Service module.
  *
  * @details This module implements the Device Information Service.
@@ -62,72 +27,22 @@
 extern "C" {
 #endif
 
-/** @defgroup DIS_VENDOR_ID_SRC_VALUES Vendor ID Source values
- * @{
- */
-#define BLE_DIS_VENDOR_ID_SRC_BLUETOOTH_SIG   1                 /**< Vendor ID assigned by Bluetooth SIG. */
-#define BLE_DIS_VENDOR_ID_SRC_USB_IMPL_FORUM  2                 /**< Vendor ID assigned by USB Implementer's Forum. */
-/** @} */
-
-/**@brief System ID parameters */
-typedef struct
-{
-    uint64_t manufacturer_id;                                   /**< Manufacturer ID. Only 5 LSOs shall be used. */
-    uint32_t organizationally_unique_id;                        /**< Organizationally unique ID. Only 3 LSOs shall be used. */
-} ble_dis_sys_id_t;
-
-/**@brief IEEE 11073-20601 Regulatory Certification Data List Structure */
-typedef struct
-{
-    uint8_t *  p_list;                                          /**< Pointer the byte array containing the encoded opaque structure based on IEEE 11073-20601 specification. */
-    uint8_t    list_len;                                        /**< Length of the byte array. */
-} ble_dis_reg_cert_data_list_t;
-
-/**@brief PnP ID parameters */
-typedef struct
-{
-    uint8_t  vendor_id_source;                                  /**< Vendor ID Source. see @ref DIS_VENDOR_ID_SRC_VALUES. */
-    uint16_t vendor_id;                                         /**< Vendor ID. */
-    uint16_t product_id;                                        /**< Product ID. */
-    uint16_t product_version;                                   /**< Product Version. */
-} ble_dis_pnp_id_t;
-
-/**@brief Device Information Service init structure. This contains all possible characteristics
- *        needed for initialization of the service.
- */
- #if 0
-typedef struct
-{
-    ble_srv_utf8_str_t             manufact_name_str;           /**< Manufacturer Name String. */
-    ble_srv_utf8_str_t             model_num_str;               /**< Model Number String. */
-    ble_srv_utf8_str_t             serial_num_str;              /**< Serial Number String. */
-    ble_srv_utf8_str_t             hw_rev_str;                  /**< Hardware Revision String. */
-    ble_srv_utf8_str_t             fw_rev_str;                  /**< Firmware Revision String. */
-    ble_srv_utf8_str_t             sw_rev_str;                  /**< Software Revision String. */
-    ble_dis_sys_id_t *             p_sys_id;                    /**< System ID. */
-    ble_dis_reg_cert_data_list_t * p_reg_cert_data_list;        /**< IEEE 11073-20601 Regulatory Certification Data List. */
-    ble_dis_pnp_id_t *             p_pnp_id;                    /**< PnP ID. */
-    security_req_t                 dis_char_rd_sec;             /**< Security requirement for reading any DIS characteristic value. */
-} ble_dis_init_t;
-#endif
-/**@brief Function for initializing the Device Information Service.
+/**
+ * @brief Function for initializing the Device Information Service.
  *
  * @details This call allows the application to initialize the device information service.
  *          It adds the DIS service and DIS characteristics to the database, using the initial
  *          values supplied through the p_dis_init parameter. Characteristics which are not to be
  *          added, shall be set to NULL in p_dis_init.
  *
- * @param[in]   p_dis_init   The structure containing the values of characteristics needed by the
- *                           service.
- *
- * @return      NRF_SUCCESS on successful initialization of service.
+ * @return NRF_SUCCESS on successful initialization of service or nrf_error on failure.
  */
-int ble_dis_init(void);
+uint32_t ble_dis_init(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // BLE_DIS_H__
+#endif /* BLE_DIS_H__ */
 
 /** @} */

--- a/include/bm/bluetooth/services/ble_hrs.h
+++ b/include/bm/bluetooth/services/ble_hrs.h
@@ -161,11 +161,11 @@ struct ble_hrs {
  * @param hrs Heart rate service.
  * @param hrs_config Heart rate service configuration.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs or @p hrs_config are @c NULL.
- * @retval -EINVAL Invalid parameters.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs or @p hrs_config are @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
  */
-int ble_hrs_init(struct ble_hrs *hrs, const struct ble_hrs_config *hrs_config);
+uint32_t ble_hrs_init(struct ble_hrs *hrs, const struct ble_hrs_config *hrs_config);
 
 /**
  * @brief Connection parameters event handler.
@@ -187,13 +187,13 @@ void ble_hrs_conn_params_evt(struct ble_hrs *hrs, const struct ble_conn_params_e
  * @param hrs Heart rate service.
  * @param heart_rate heart rate Measurement.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs is @c NULL.
- * @retval -EINVAL Failed to send notification.
- * @retval -ENOTCONN Invalid connection handle.
- * @retval -EPIPE Notifications not enabled in the CCCD.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Failed to send notification.
+ * @retval NRF_ERROR_NOT_FOUND Invalid connection handle.
+ * @retval NRF_ERROR_INVALID_STATE Notifications not enabled in the CCCD.
  */
-int ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart_rate);
+uint32_t ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart_rate);
 
 /**
  * @brief Function for adding a RR Interval measurement to the RR Interval buffer.
@@ -205,10 +205,10 @@ int ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart_rate
  * @param hrs Heart rate service.
  * @param rr_interval New RR interval measurement.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
  */
-int ble_hrs_rr_interval_add(struct ble_hrs *hrs, uint16_t rr_interval);
+uint32_t ble_hrs_rr_interval_add(struct ble_hrs *hrs, uint16_t rr_interval);
 
 /**
  * @brief Function for checking if RR Interval buffer is full.
@@ -227,11 +227,12 @@ bool ble_hrs_rr_interval_buffer_is_full(struct ble_hrs *hrs);
  * @param hrs Heart rate service.
  * @param is_sensor_contact_supported New state of the sensor contact support bit.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs is @c NULL.
- * @retval -EISCONN If in a connection.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If in a connection.
  */
-int ble_hrs_sensor_contact_supported_set(struct ble_hrs *hrs, bool is_sensor_contact_supported);
+uint32_t ble_hrs_sensor_contact_supported_set(struct ble_hrs *hrs,
+					      bool is_sensor_contact_supported);
 
 /**
  * @brief Function for setting the state of the sensor contact detected bit.
@@ -239,10 +240,11 @@ int ble_hrs_sensor_contact_supported_set(struct ble_hrs *hrs, bool is_sensor_con
  * @param hrs Heart rate service.
  * @param is_sensor_contact_detected New state of the sensor contact detected bit.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs is @c NULL.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
  */
-int ble_hrs_sensor_contact_detected_update(struct ble_hrs *hrs, bool is_sensor_contact_detected);
+uint32_t ble_hrs_sensor_contact_detected_update(struct ble_hrs *hrs,
+						bool is_sensor_contact_detected);
 
 /**
  * @brief Function for setting the Body Sensor Location.
@@ -253,11 +255,11 @@ int ble_hrs_sensor_contact_detected_update(struct ble_hrs *hrs, bool is_sensor_c
  * @param hrs Heart rate service.
  * @param body_sensor_location New body sensor location.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p hrs is @c NULL.
- * @retval -EINVAL Failed to set new value.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Failed to set new value.
  */
-int ble_hrs_body_sensor_location_set(struct ble_hrs *hrs, uint8_t body_sensor_location);
+uint32_t ble_hrs_body_sensor_location_set(struct ble_hrs *hrs, uint8_t body_sensor_location);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_lbs.h
+++ b/include/bm/bluetooth/services/ble_lbs.h
@@ -94,9 +94,11 @@ struct ble_lbs {
  *                 be used to identify this particular service instance.
  * @param[in] cfg  Information needed to initialize the service.
  *
- * @retval 0 If the service was initialized successfully. Otherwise, an error code is returned.
+ * @retval NRF_SUCCESS If the service was initialized successfully.
+ * @retval NRF_ERROR_NULL If @p lbs or @p cfg is NULL.
+ * @retval NRF_ERROR_INVALID_PARAM If the supplied configuration is invalid.
  */
-int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg);
+uint32_t ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg);
 
 /**
  * @brief Function for handling the application's BLE stack events.
@@ -117,9 +119,11 @@ void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs_instance);
  * @param[in] lbs           LED Button Service structure.
  * @param[in] button_state  New button state.
  *
- * @retval 0 If the notification was sent successfully. Otherwise, an error code is returned.
+ * @retval NRF_SUCCESS If the notification was sent successfully.
+ * @retval NRF_ERROR_NULL If @p lbs is NULL.
+ * @retval NRF_ERROR_INVALID_PARAM If the parameters are invalid.
  */
-int ble_lbs_on_button_change(struct ble_lbs *lbs, uint16_t conn_handle, uint8_t button_state);
+uint32_t ble_lbs_on_button_change(struct ble_lbs *lbs, uint16_t conn_handle, uint8_t button_state);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_mcumgr.h
+++ b/include/bm/bluetooth/services/ble_mcumgr.h
@@ -37,10 +37,10 @@ extern "C" {
 /**
  * @brief Function for initializing the MCUmgr Bluetooth service.
  *
- * @retval 0 On success.
- * @retval -EINVAL Invalid parameters.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
  */
-int ble_mcumgr_init(void);
+uint32_t ble_mcumgr_init(void);
 
 /**
  * @brief Function for getting the MCUmgr Bluetooth service UUID type.

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -162,11 +162,11 @@ struct ble_nus {
  *                 later be used to identify this particular service instance.
  * @param[in] nus_init Information needed to initialize the service.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p nus or @p nus_config is @c NULL.
- * @retval -EINVAL Invalid parameters.
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @p nus or @p nus_config is @c NULL.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid parameters.
  */
-int ble_nus_init(struct ble_nus *nus, struct ble_nus_config const *nus_config);
+uint32_t ble_nus_init(struct ble_nus *nus, struct ble_nus_config const *nus_config);
 
 /**
  * @brief Function for handling the Nordic UART Service's BLE events.
@@ -192,17 +192,11 @@ void ble_nus_on_ble_evt(ble_evt_t const *ble_evt, void *context);
  * @param[in,out] length In: Length of the @p data string. Out: Number of bytes sent.
  * @param[in] conn_handle Connection handle of the destination client.
  *
- * @retval 0 On success.
- * @retval -EFAULT If @p nus, @p data or @p length is @c NULL.
- * @retval -EINVAL Invalid parameters.
- * @retval -ENOENT Invalid @p conn_handle.
- * @retval -EIO Failed to send notification.
- * @retval -ENOTCONN Connection handle unknown to the softdevice.
- * @retval -EPIPE Notifications not enabled in the CCCD.
- * @retval -EBADF Not found.
- * @retval -EAGAIN Not enough resources for operation.
+ * @retval NRF_SUCCESS On success.
+ * @return nrf_error on failure.
  */
-int ble_nus_data_send(struct ble_nus *nus, uint8_t *data, uint16_t *length, uint16_t conn_handle);
+uint32_t ble_nus_data_send(struct ble_nus *nus, uint8_t *data, uint16_t *length,
+			   uint16_t conn_handle);
 
 #ifdef __cplusplus
 }

--- a/lib/bluetooth/ble_adv/ble_adv.c
+++ b/lib/bluetooth/ble_adv/ble_adv.c
@@ -391,7 +391,7 @@ uint32_t ble_adv_start(struct ble_adv *ble_adv, enum ble_adv_mode mode)
 			adv_evt.evt_type = BLE_ADV_EVT_FAST;
 			nrf_err = set_adv_mode_fast(ble_adv, &ble_adv->adv_params);
 			if (nrf_err) {
-				LOG_ERR("Failed to set fast advertising params, error: %d",
+				LOG_ERR("Failed to set fast advertising params, nrf_error %#x",
 					nrf_err);
 				return NRF_ERROR_INVALID_PARAM;
 			}
@@ -405,7 +405,7 @@ uint32_t ble_adv_start(struct ble_adv *ble_adv, enum ble_adv_mode mode)
 			adv_evt.evt_type = BLE_ADV_EVT_SLOW;
 			nrf_err = set_adv_mode_slow(ble_adv, &ble_adv->adv_params);
 			if (nrf_err) {
-				LOG_ERR("Failed to set slow advertising params, error: %d",
+				LOG_ERR("Failed to set slow advertising params, nrf_error %#x",
 					nrf_err);
 				return NRF_ERROR_INVALID_PARAM;
 			}

--- a/lib/bluetooth/ble_conn_params/event.c
+++ b/lib/bluetooth/ble_conn_params/event.c
@@ -20,13 +20,13 @@ void ble_conn_params_event_send(const struct ble_conn_params_evt *evt)
 	}
 }
 
-int ble_conn_params_evt_handler_set(ble_conn_params_evt_handler_t handler)
+uint32_t ble_conn_params_evt_handler_set(ble_conn_params_evt_handler_t handler)
 {
-	if (handler == NULL) {
-		return -EFAULT;
+	if (!handler) {
+		return NRF_ERROR_NULL;
 	}
 
 	evt_handler = handler;
 
-	return 0;
+	return NRF_SUCCESS;
 }

--- a/lib/bluetooth/ble_qwr/ble_qwr.c
+++ b/lib/bluetooth/ble_qwr/ble_qwr.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <errno.h>
+#include <nrf_error.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -27,14 +27,14 @@ static inline uint16_t uint16_decode(const uint8_t *encoded_data)
 	return sys_get_le16(encoded_data);
 }
 
-int ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config)
+uint32_t ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config)
 {
 	if (!qwr || !qwr_config) {
-		return -EFAULT;
+		return NRF_ERROR_NULL;
 	}
 
 	if (qwr->initialized == BLE_QWR_INITIALIZED) {
-		return -EPERM;
+		return NRF_ERROR_INVALID_STATE;
 	}
 
 	qwr->initialized = BLE_QWR_INITIALIZED;
@@ -47,37 +47,37 @@ int ble_qwr_init(struct ble_qwr *qwr, struct ble_qwr_config const *qwr_config)
 	qwr->mem_buffer = qwr_config->mem_buffer;
 	qwr->nb_written_handles = 0;
 #endif
-	return 0;
+	return NRF_SUCCESS;
 }
 
 #if (CONFIG_BLE_QWR_MAX_ATTR > 0)
-int ble_qwr_attr_register(struct ble_qwr *qwr, uint16_t attr_handle)
+uint32_t ble_qwr_attr_register(struct ble_qwr *qwr, uint16_t attr_handle)
 {
 	if (!qwr) {
-		return -EFAULT;
+		return NRF_ERROR_NULL;
 	}
 
 	if (qwr->initialized != BLE_QWR_INITIALIZED) {
-		return -EPERM;
+		return NRF_ERROR_INVALID_STATE;
 	}
 
 	if ((qwr->nb_registered_attr == CONFIG_BLE_QWR_MAX_ATTR) ||
 	    (qwr->mem_buffer.p_mem == NULL) ||
 	    (qwr->mem_buffer.len == 0))	{
-		return -ENOMEM;
+		return NRF_ERROR_NO_MEM;
 	}
 
 	if (attr_handle == BLE_GATT_HANDLE_INVALID) {
-		return -EINVAL;
+		return NRF_ERROR_INVALID_PARAM;
 	}
 
 	qwr->attr_handles[qwr->nb_registered_attr] = attr_handle;
 	qwr->nb_registered_attr++;
 
-	return 0;
+	return NRF_SUCCESS;
 }
 
-int ble_qwr_value_get(
+uint32_t ble_qwr_value_get(
 	struct ble_qwr *qwr, uint16_t attr_handle, uint8_t *mem, uint16_t *len)
 {
 	uint16_t i = 0;
@@ -87,11 +87,11 @@ int ble_qwr_value_get(
 	uint32_t cur_len = 0;
 
 	if (!qwr || !mem || !len) {
-		return -EFAULT;
+		return NRF_ERROR_NULL;
 	}
 
 	if (qwr->initialized != BLE_QWR_INITIALIZED) {
-		return -EPERM;
+		return NRF_ERROR_INVALID_STATE;
 	}
 
 	do {
@@ -111,7 +111,7 @@ int ble_qwr_value_get(
 			if (cur_len <= *len) {
 				memcpy((mem + val_offset), &(qwr->mem_buffer.p_mem[i]), val_len);
 			} else {
-				return -ENOMEM;
+				return NRF_ERROR_NO_MEM;
 			}
 		}
 
@@ -119,23 +119,23 @@ int ble_qwr_value_get(
 	} while (i < qwr->mem_buffer.len);
 
 	*len = cur_len;
-	return 0;
+	return NRF_SUCCESS;
 }
 #endif
 
-int ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle)
+uint32_t ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle)
 {
 	if (!qwr) {
-		return -EFAULT;
+		return NRF_ERROR_NULL;
 	}
 
 	if (qwr->initialized != BLE_QWR_INITIALIZED) {
-		return -EPERM;
+		return NRF_ERROR_INVALID_STATE;
 	}
 
 	qwr->conn_handle = conn_handle;
 
-	return 0;
+	return NRF_SUCCESS;
 }
 
 /**

--- a/lib/bluetooth/ble_racp/ble_racp.c
+++ b/lib/bluetooth/ble_racp/ble_racp.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <errno.h>
+#include <nrf_error.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <bm/bluetooth/ble_racp.h>
 
-int ble_racp_decode(const uint8_t *data, size_t data_len, struct ble_racp_value *racp_val)
+uint32_t ble_racp_decode(const uint8_t *data, size_t data_len, struct ble_racp_value *racp_val)
 {
 	if (!data || !racp_val) {
-		return -EFAULT;
+		return NRF_ERROR_NULL;
 	}
 
 	racp_val->opcode = (data_len >= 1) ? data[0] : 0xFF;
@@ -20,19 +20,19 @@ int ble_racp_decode(const uint8_t *data, size_t data_len, struct ble_racp_value 
 	racp_val->operand_len = (data_len >= 3) ? (data_len - 2) : 0;
 	racp_val->operand = (data_len >= 3) ? (uint8_t *)&data[2] : NULL;
 
-	return 0;
+	return NRF_SUCCESS;
 }
 
-int ble_racp_encode(const struct ble_racp_value *racp_val, uint8_t *buf, size_t buf_len)
+size_t ble_racp_encode(const struct ble_racp_value *racp_val, uint8_t *buf, size_t buf_len)
 {
 	uint8_t len = 0;
 
 	if (!racp_val || !buf) {
-		return -EFAULT;
+		return 0;
 	}
 
 	if (buf_len < (racp_val->operand_len + 2)) {
-		return -EINVAL;
+		return 0;
 	}
 
 	buf[len++] = racp_val->opcode;

--- a/lib/bluetooth/peer_manager/include/modules/pm_buffer.h
+++ b/lib/bluetooth/peer_manager/include/modules/pm_buffer.h
@@ -29,14 +29,14 @@ extern "C" {
  * @param[out] buffer      The buffer instance to initialize.
  * @param[in]  n_blocks    The desired number of blocks in the buffer.
  * @param[in]  block_size  The desired block size of the buffer.
- * @param[out] err_code    The return code from @ref pm_buffer_init.
+ * @param[out] nrf_err     The return code from @ref pm_buffer_init.
  */
-#define PM_BUFFER_INIT(buffer, n_blocks, block_size, err_code)                                     \
+#define PM_BUFFER_INIT(buffer, n_blocks, block_size, nrf_err)                                      \
 	do {                                                                                       \
 		__ALIGN(4) static uint8_t buffer_memory[(n_blocks) * (block_size)];                \
 		static atomic_t mutex_memory[(n_blocks - 1) / (sizeof(atomic_t) * 8) + 1];         \
-		err_code = pm_buffer_init((buffer), buffer_memory, (n_blocks) * (block_size),      \
-					  mutex_memory, (n_blocks), (block_size));                 \
+		nrf_err = pm_buffer_init((buffer), buffer_memory, (n_blocks) * (block_size),       \
+					 mutex_memory, (n_blocks), (block_size));                  \
 	} while (0)
 
 struct pm_buffer {

--- a/lib/bluetooth/peer_manager/modules/auth_status_tracker.c
+++ b/lib/bluetooth/peer_manager/modules/auth_status_tracker.c
@@ -149,9 +149,9 @@ static void blacklisted_peers_state_transition_handle(void *context)
 
 uint32_t ast_init(void)
 {
-	int err_code = bm_timer_init(&pairing_attempt_timer, BM_TIMER_MODE_SINGLE_SHOT,
-					blacklisted_peers_state_transition_handle);
-	if (err_code) {
+	int err = bm_timer_init(&pairing_attempt_timer, BM_TIMER_MODE_SINGLE_SHOT,
+				blacklisted_peers_state_transition_handle);
+	if (err) {
 		return NRF_ERROR_INTERNAL;
 	}
 
@@ -161,18 +161,18 @@ uint32_t ast_init(void)
 void ast_auth_error_notify(uint16_t conn_handle)
 {
 	int err;
-	uint32_t err_code;
+	uint32_t nrf_err;
 	ble_gap_addr_t peer_addr;
 	uint32_t new_timeout;
 	uint32_t free_id = ARRAY_SIZE(blacklisted_peers);
 	bool new_bl_entry = true;
 
 	/* Get the peer address associated with connection handle. */
-	err_code = im_ble_addr_get(conn_handle, &peer_addr);
-	if (err_code != NRF_SUCCESS) {
+	nrf_err = im_ble_addr_get(conn_handle, &peer_addr);
+	if (nrf_err) {
 		LOG_WRN("im_ble_addr_get() returned %s. conn_handle: %d. "
 			"Link was likely disconnected.",
-			nrf_strerror_get(err_code), conn_handle);
+			nrf_strerror_get(nrf_err), conn_handle);
 		return;
 	}
 
@@ -251,14 +251,14 @@ void ast_auth_error_notify(uint16_t conn_handle)
 
 bool ast_peer_blacklisted(uint16_t conn_handle)
 {
-	uint32_t err_code;
+	uint32_t nrf_err;
 	ble_gap_addr_t peer_addr;
 
-	err_code = im_ble_addr_get(conn_handle, &peer_addr);
-	if (err_code != NRF_SUCCESS) {
+	nrf_err = im_ble_addr_get(conn_handle, &peer_addr);
+	if (nrf_err) {
 		LOG_WRN("im_ble_addr_get() returned %s. conn_handle: %d. "
 			"Link was likely disconnected.",
-			nrf_strerror_get(err_code), conn_handle);
+			nrf_strerror_get(nrf_err), conn_handle);
 		return true;
 	}
 

--- a/lib/bluetooth/peer_manager/modules/peer_data_storage.c
+++ b/lib/bluetooth/peer_manager/modules/peer_data_storage.c
@@ -92,16 +92,16 @@ static bool peer_data_id_is_valid(enum pm_peer_data_id data_id)
 /**
  * @brief Function for sending a PM_EVT_ERROR_UNEXPECTED event.
  *
- * @param[in]  peer_id    The peer the event pertains to.
- * @param[in]  err_code   The unexpected error that occurred.
+ * @param[in]  peer_id   The peer the event pertains to.
+ * @param[in]  nrf_err   The unexpected error that occurred.
  */
-static void send_unexpected_error(uint16_t peer_id, uint32_t err_code)
+static void send_unexpected_error(uint16_t peer_id, uint32_t nrf_err)
 {
 	struct pm_evt error_evt = {
 		.evt_id = PM_EVT_ERROR_UNEXPECTED,
 		.peer_id = peer_id,
 		.params.error_unexpected = {
-			.error = err_code,
+			.error = nrf_err,
 		},
 	};
 	pds_evt_send(&error_evt);
@@ -247,13 +247,13 @@ static void bm_zms_evt_handler(const bm_zms_evt_t *evt)
 				pds_evt_send(&pds_evt);
 			} else {
 				uint32_t next_entry_id;
-				uint32_t ret;
+				uint32_t nrf_err;
 
-				ret = find_next_data_entry_in_peer(peer_id, &next_entry_id);
-				if (ret == NRF_SUCCESS) {
+				nrf_err = find_next_data_entry_in_peer(peer_id, &next_entry_id);
+				if (nrf_err == NRF_SUCCESS) {
 					/* Process the next entry for the peer. */
 					peer_delete_deferred = true;
-				} else if (ret == NRF_ERROR_NOT_FOUND) {
+				} else if (nrf_err == NRF_ERROR_NOT_FOUND) {
 					atomic_dec(&delete_counter);
 
 					/* Process the next deleted peers, if any are present. */

--- a/lib/bm_buttons/bm_buttons.c
+++ b/lib/bm_buttons/bm_buttons.c
@@ -91,12 +91,12 @@ ISR_DIRECT_DECLARE(gpiote_30_direct_isr)
 
 static int gpiote_init(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	if (!nrfx_gpiote_init_check(&gpiote20_instance)) {
-		err = nrfx_gpiote_init(&gpiote20_instance, 0);
-		if (err != NRFX_SUCCESS) {
-			LOG_ERR("Failed to initialize gpiote20, err: 0x%08X", err);
+		nrfx_err = nrfx_gpiote_init(&gpiote20_instance, 0);
+		if (nrfx_err != NRFX_SUCCESS) {
+			LOG_ERR("Failed to initialize gpiote20, nrfx_err: 0x%08X", nrfx_err);
 			return -EIO;
 		}
 
@@ -106,9 +106,9 @@ static int gpiote_init(void)
 	}
 
 	if (!nrfx_gpiote_init_check(&gpiote30_instance)) {
-		err = nrfx_gpiote_init(&gpiote30_instance, 0);
-		if (err != NRFX_SUCCESS) {
-			LOG_ERR("Failed to initialize gpiote30, err: 0x%08X", err);
+		nrfx_err = nrfx_gpiote_init(&gpiote30_instance, 0);
+		if (nrfx_err != NRFX_SUCCESS) {
+			LOG_ERR("Failed to initialize gpiote30, nrfx_err: 0x%08X", nrfx_err);
 			return -EIO;
 		}
 
@@ -123,13 +123,13 @@ static int gpiote_init(void)
 static int gpiote_input_configure(nrfx_gpiote_pin_t pin,
 				  const nrfx_gpiote_input_pin_config_t *input_config)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	const nrfx_gpiote_t *gpiote_inst = gpiote_get(NRF_PIN_NUMBER_TO_PORT(pin));
 
-	err = nrfx_gpiote_input_configure(gpiote_inst, pin, input_config);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("nrfx_gpiote_input_configure, err: 0x%08X", err);
+	nrfx_err = nrfx_gpiote_input_configure(gpiote_inst, pin, input_config);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("nrfx_gpiote_input_configure, nrfx_err: 0x%08X", nrfx_err);
 		return -EIO;
 	}
 

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -330,10 +330,10 @@ static uint32_t services_init(void)
 		.evt_handler = qwr_evt_handler,
 	};
 
-	err = ble_qwr_init(&ble_qwr, &qwr_config);
-	if (err) {
-		LOG_ERR("Failed to initialize QWR service, err %d", err);
-		return err;
+	nrf_err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize QWR service, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Initialize Glucose Service */
@@ -441,7 +441,7 @@ static void led_indication_set(enum led_indicate led_indicate)
 
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
+
 	uint32_t nrf_err;
 
 	switch (evt->header.evt_id) {
@@ -450,9 +450,9 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		led_indication_set(LED_INDICATE_CONNECTED);
 
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
-		if (err) {
-			LOG_ERR("Failed to assign BLE QWR conn handle, err %d", err);
+		nrf_err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
+		if (nrf_err) {
+			LOG_ERR("Failed to assign BLE QWR conn handle, nrf_error %#x", nrf_err);
 		}
 
 		nrf_err = ble_cgms_conn_handle_assign(&ble_cgms, conn_handle);

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -742,9 +742,9 @@ int main(void)
 	}
 	(void)sensor_simulator_init();
 
-	err = ble_conn_params_evt_handler_set(on_conn_params_evt);
-	if (err) {
-		LOG_ERR("Failed to setup conn param event handler, err %d", err);
+	nrf_err = ble_conn_params_evt_handler_set(on_conn_params_evt);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup conn param event handler, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -87,6 +87,7 @@ static uint8_t qwr_mem[CONFIG_QWR_MEM_BUFF_SIZE];
 static void battery_level_update(void)
 {
 	int err;
+	uint32_t nrf_err;
 	uint32_t battery_level;
 
 	err = (uint8_t)sensorsim_measure(&battery_sim_state, &battery_level);
@@ -94,11 +95,11 @@ static void battery_level_update(void)
 		LOG_ERR("Sensorsim measure failed, err %d", err);
 	}
 
-	err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	if (err) {
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	if (nrf_err) {
 		/* Ignore if not in a connection or notifications disabled in CCCD. */
-		if (err != -ENOTCONN && err != -EPIPE) {
-			LOG_ERR("Failed to update battery level, err %d", err);
+		if (nrf_err != NRF_ERROR_NOT_FOUND && nrf_err != NRF_ERROR_INVALID_STATE) {
+			LOG_ERR("Failed to update battery level, nrf_error %#x", nrf_err);
 		}
 	}
 }
@@ -349,10 +350,10 @@ static uint32_t services_init(void)
 
 	/* Add a basic battery measurement with only mandatory fields */
 
-	err = ble_bas_init(&ble_bas, &bas_config);
-	if (err) {
-		LOG_ERR("Failed to initialize BAS service, err %d", err);
-		return err;
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize BAS service, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Initialize Device Information Service. */

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -298,7 +298,6 @@ uint16_t qwr_evt_handler(struct ble_qwr *qwr, const struct ble_qwr_evt *evt)
  */
 static uint32_t services_init(void)
 {
-	int err;
 	uint32_t nrf_err;
 	struct ble_cgms_config cgms_config = {
 		.evt_handler = cgms_evt_handler,
@@ -357,10 +356,10 @@ static uint32_t services_init(void)
 	}
 
 	/* Initialize Device Information Service. */
-	err = ble_dis_init();
-	if (err) {
-		LOG_ERR("Failed to initialize DIS service, err %d", err);
-		return err;
+	nrf_err = ble_dis_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize DIS service, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	return NRF_SUCCESS;
@@ -737,8 +736,8 @@ int main(void)
 	if (nrf_err) {
 		goto idle;
 	}
-	err = services_init();
-	if (err) {
+	nrf_err = services_init();
+	if (nrf_err) {
 		goto idle;
 	}
 	(void)sensor_simulator_init();

--- a/samples/bluetooth/ble_hids_keyboard/src/main.c
+++ b/samples/bluetooth/ble_hids_keyboard/src/main.c
@@ -173,6 +173,7 @@ void report_fifo_clear(void)
 static void battery_level_meas_timeout_handler(void *context)
 {
 	int err;
+	uint32_t nrf_err;
 	uint32_t battery_level;
 
 	ARG_UNUSED(context);
@@ -182,11 +183,11 @@ static void battery_level_meas_timeout_handler(void *context)
 		LOG_ERR("Sensorsim measure failed, err %d", err);
 	}
 
-	err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	if (err) {
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	if (nrf_err) {
 		/* Ignore if not in a connection or notifications disabled in CCCD. */
-		if (err != -ENOTCONN && err != -EPIPE) {
-			LOG_ERR("Failed to update battery level, err %d", err);
+		if (nrf_err != NRF_ERROR_NOT_FOUND && nrf_err != NRF_ERROR_INVALID_STATE) {
+			LOG_ERR("Failed to update battery level, nrf_error %#x", nrf_err);
 		}
 	}
 }
@@ -961,9 +962,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_bas_init(&ble_bas, &bas_config);
-	if (err) {
-		LOG_ERR("Failed to initialize BAS service, err %d", err);
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize BAS service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hids_keyboard/src/main.c
+++ b/samples/bluetooth/ble_hids_keyboard/src/main.c
@@ -949,9 +949,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_qwr_init(&ble_qwr, &qwr_config);
-	if (err) {
-		LOG_ERR("ble_qwr_init failed, err %d", err);
+	nrf_err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (nrf_err) {
+		LOG_ERR("ble_qwr_init failed, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hids_keyboard/src/main.c
+++ b/samples/bluetooth/ble_hids_keyboard/src/main.c
@@ -956,9 +956,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_dis_init();
-	if (err) {
-		LOG_ERR("Failed to initialize device information service, err %d", err);
+	nrf_err = ble_dis_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize device information service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -103,6 +103,7 @@ static bool auth_key_request;
 static void battery_level_meas_timeout_handler(void *context)
 {
 	int err;
+	uint32_t nrf_err;
 	uint32_t battery_level;
 
 	ARG_UNUSED(context);
@@ -112,11 +113,11 @@ static void battery_level_meas_timeout_handler(void *context)
 		LOG_ERR("Sensorsim measure failed, err %d", err);
 	}
 
-	err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	if (err) {
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	if (nrf_err) {
 		/* Ignore if not in a connection or notifications disabled in CCCD. */
-		if (err != -ENOTCONN && err != -EPIPE) {
-			LOG_ERR("Failed to update battery level, err %d", err);
+		if (nrf_err != NRF_ERROR_NOT_FOUND && nrf_err != NRF_ERROR_INVALID_STATE) {
+			LOG_ERR("Failed to update battery level, nrf_error %#x", nrf_err);
 		}
 	}
 }
@@ -810,9 +811,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_bas_init(&ble_bas, &bas_config);
-	if (err) {
-		LOG_ERR("Failed to initialize BAS service, err %d", err);
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize BAS service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -123,16 +123,16 @@ static void battery_level_meas_timeout_handler(void *context)
 
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
+	uint32_t nrf_err;
 
 	switch (evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
 
-		err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
-		if (err) {
-			LOG_ERR("Failed to assign qwr handle, nrf_error %#x", err);
+		nrf_err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
+		if (nrf_err) {
+			LOG_ERR("Failed to assign qwr handle, nrf_error %#x", nrf_err);
 			return;
 		}
 
@@ -798,9 +798,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_qwr_init(&ble_qwr, &qwr_config);
-	if (err) {
-		LOG_ERR("ble_qwr_init failed, err %d", err);
+	nrf_err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (nrf_err) {
+		LOG_ERR("ble_qwr_init failed, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -805,9 +805,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_dis_init();
-	if (err) {
-		LOG_ERR("Failed to initialize device information service, err %d", err);
+	nrf_err = ble_dis_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize device information service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -71,6 +71,7 @@ static struct bm_timer sensor_contact_timer;
 void battery_level_meas_timeout_handler(void *context)
 {
 	int err;
+	uint32_t nrf_err;
 	uint32_t battery_level;
 
 	ARG_UNUSED(context);
@@ -81,11 +82,11 @@ void battery_level_meas_timeout_handler(void *context)
 		return;
 	}
 
-	err = ble_bas_battery_level_update(&ble_bas, conn_handle, (uint8_t)battery_level);
-	if (err) {
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	if (nrf_err) {
 		/* Ignore if not in a connection or notifications disabled in CCCD. */
-		if (err != -ENOTCONN && err != -EPIPE) {
-			LOG_ERR("Failed to update battery level, err %d", err);
+		if (nrf_err != NRF_ERROR_NOT_FOUND && nrf_err != NRF_ERROR_INVALID_STATE) {
+			LOG_ERR("Failed to update battery level, nrf_error %#x", nrf_err);
 		}
 	}
 }
@@ -509,9 +510,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_bas_init(&ble_bas, &bas_cfg);
-	if (err) {
-		LOG_ERR("Failed to initialize battery service, err %d", err);
+	nrf_err = ble_bas_init(&ble_bas, &bas_cfg);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize battery service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -256,14 +256,15 @@ NRF_SDH_BLE_OBSERVER(sdh_ble, on_ble_evt, NULL, 0);
 
 void on_conn_params_evt(const struct ble_conn_params_evt *evt)
 {
-	int err;
+	uint32_t nrf_err;
 
 	switch (evt->id) {
 	case BLE_CONN_PARAMS_EVT_REJECTED:
-		err = sd_ble_gap_disconnect(evt->conn_handle, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE);
-		if (err) {
+		nrf_err = sd_ble_gap_disconnect(evt->conn_handle,
+						BLE_HCI_CONN_INTERVAL_UNACCEPTABLE);
+		if (nrf_err) {
 			LOG_ERR("Disconnect failed on conn params update rejection, nrf_error %#x",
-			       err);
+				nrf_err);
 		} else {
 			LOG_ERR("Disconnected from peer, unacceptable conn params");
 		}
@@ -352,19 +353,19 @@ static int buttons_init(bool *erase_bonds)
 
 static void delete_bonds(void)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 
 	LOG_INF("Erase bonds!");
 
-	err = pm_peers_delete();
-	if (err) {
-		LOG_ERR("Failed to delete peers, err %d", err);
+	nrf_err = pm_peers_delete();
+	if (nrf_err) {
+		LOG_ERR("Failed to delete peers, nrf_error %#x", nrf_err);
 	}
 }
 
 static void advertising_start(bool erase_bonds)
 {
-	int nrf_err;
+	uint32_t nrf_err;
 
 	if (erase_bonds) {
 		delete_bonds();
@@ -393,14 +394,14 @@ static void pm_evt_handler(struct pm_evt const *p_evt)
 	}
 }
 
-static int peer_manager_init(void)
+static uint32_t peer_manager_init(void)
 {
 	ble_gap_sec_params_t sec_param;
-	int err;
+	uint32_t nrf_err;
 
-	err = pm_init();
-	if (err) {
-		return -EFAULT;
+	nrf_err = pm_init();
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	memset(&sec_param, 0, sizeof(ble_gap_sec_params_t));
@@ -421,19 +422,19 @@ static int peer_manager_init(void)
 		.kdist_peer.id = 1,
 	};
 
-	err = pm_sec_params_set(&sec_param);
-	if (err) {
-		LOG_ERR("pm_sec_params_set() failed, err: %d", err);
-		return -EFAULT;
+	nrf_err = pm_sec_params_set(&sec_param);
+	if (nrf_err) {
+		LOG_ERR("pm_sec_params_set() failed, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
-	err = pm_register(pm_evt_handler);
-	if (err) {
-		LOG_ERR("pm_register() failed, err: %d", err);
-		return -EFAULT;
+	nrf_err = pm_register(pm_evt_handler);
+	if (nrf_err) {
+		LOG_ERR("pm_register() failed, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
-	return 0;
+	return NRF_SUCCESS;
 }
 
 int main(void)
@@ -494,9 +495,9 @@ int main(void)
 
 	LOG_INF("Bluetooth enabled");
 
-	err = peer_manager_init();
-	if (err) {
-		LOG_ERR("Failed to initialize Peer Manager, err %d", err);
+	nrf_err = peer_manager_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize Peer Manager, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -523,9 +523,9 @@ int main(void)
 
 	LOG_INF("Services initialized");
 
-	err = ble_conn_params_evt_handler_set(on_conn_params_evt);
-	if (err) {
-		LOG_ERR("Failed to setup conn param event handler, err %d", err);
+	nrf_err = ble_conn_params_evt_handler_set(on_conn_params_evt);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup conn param event handler, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -95,6 +95,7 @@ static void heart_rate_meas_timeout_handler(void *context)
 {
 	static uint32_t cnt;
 	int err;
+	uint32_t nrf_err;
 	uint32_t heart_rate;
 
 	ARG_UNUSED(context);
@@ -105,11 +106,11 @@ static void heart_rate_meas_timeout_handler(void *context)
 		return;
 	}
 
-	err = ble_hrs_heart_rate_measurement_send(&ble_hrs, (uint16_t)heart_rate);
-	if (err) {
+	nrf_err = ble_hrs_heart_rate_measurement_send(&ble_hrs, (uint16_t)heart_rate);
+	if (nrf_err) {
 		/* Ignore if not in a connection or notifications disabled in CCCD. */
-		if (err != -ENOTCONN && err != -EPIPE) {
-			LOG_ERR("Failed to update heart rate measurement, err %d", err);
+		if (nrf_err != NRF_ERROR_NOT_FOUND && nrf_err != NRF_ERROR_INVALID_STATE) {
+			LOG_ERR("Failed to update heart rate measurement, nrf_error %#x", nrf_err);
 		}
 	}
 
@@ -123,6 +124,7 @@ static void heart_rate_meas_timeout_handler(void *context)
 static void rr_interval_timeout_handler(void *context)
 {
 	int err;
+	uint32_t nrf_err;
 	uint32_t rr_interval;
 
 	ARG_UNUSED(context);
@@ -138,9 +140,9 @@ static void rr_interval_timeout_handler(void *context)
 			break;
 		}
 
-		err = ble_hrs_rr_interval_add(&ble_hrs, (uint16_t)rr_interval);
-		if (err) {
-			LOG_ERR("Failed to add RR interval, err %d", err);
+		nrf_err = ble_hrs_rr_interval_add(&ble_hrs, (uint16_t)rr_interval);
+		if (nrf_err) {
+			LOG_ERR("Failed to add RR interval, nrf_error %#x", nrf_err);
 		}
 	}
 }
@@ -148,14 +150,14 @@ static void rr_interval_timeout_handler(void *context)
 static void sensor_contact_detected_timeout_handler(void *context)
 {
 	static bool sim_sensor_contact_detected;
-	int err;
+	uint32_t nrf_err;
 
 	ARG_UNUSED(context);
 
 	sim_sensor_contact_detected = !sim_sensor_contact_detected;
-	err = ble_hrs_sensor_contact_detected_update(&ble_hrs, sim_sensor_contact_detected);
-	if (err) {
-		LOG_ERR("Failed to update sensor contact detected state, err %d", err);
+	nrf_err = ble_hrs_sensor_contact_detected_update(&ble_hrs, sim_sensor_contact_detected);
+	if (nrf_err) {
+		LOG_ERR("Failed to update sensor contact detected state, nrf_error %#x", nrf_err);
 	}
 }
 
@@ -504,9 +506,9 @@ int main(void)
 
 	LOG_INF("Peer Manager initialized");
 
-	err = ble_hrs_init(&ble_hrs, &hrs_cfg);
-	if (err) {
-		LOG_ERR("Failed to initialize heart rate service, err %d", err);
+	nrf_err = ble_hrs_init(&ble_hrs, &hrs_cfg);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize heart rate service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -516,9 +516,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_dis_init();
-	if (err) {
-		LOG_ERR("Failed to initialize device information service, err %d", err);
+	nrf_err = ble_dis_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize device information service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -29,15 +29,15 @@ static uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
+	uint32_t nrf_err;
 
 	switch (evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 		break;
 
@@ -55,19 +55,20 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 		/* Pairing not supported */
-		err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
-						  BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL);
-		if (err) {
-			LOG_ERR("Failed to reply with Security params, nrf_error %#x", err);
+		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
+						      BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL,
+						      NULL);
+		if (nrf_err) {
+			LOG_ERR("Failed to reply with Security params, nrf_error %#x", nrf_err);
 		}
 		break;
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
-		err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 		break;
 	}
@@ -203,7 +204,7 @@ int main(void)
 
 	nrf_err = ble_adv_init(&ble_adv, &ble_adv_config);
 	if (nrf_err) {
-		LOG_ERR("Failed to initialize BLE advertising, nrf_err %#x", nrf_err);
+		LOG_ERR("Failed to initialize BLE advertising, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -181,9 +181,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_lbs_init(&ble_lbs, &lbs_cfg);
-	if (err) {
-		LOG_ERR("Failed to setup LED Button Service, err %d", err);
+	nrf_err = ble_lbs_init(&ble_lbs, &lbs_cfg);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup LED Button Service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -187,9 +187,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_dis_init();
-	if (err) {
-		LOG_ERR("Failed to initialize device information service, err %d", err);
+	nrf_err = ble_dis_init();
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize device information service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -71,26 +71,26 @@ static int buf_idx;
 #if defined(CONFIG_NUS_LPUARTE)
 static void lpuarte_rx_handler(char *data, size_t data_len)
 {
-	int err;
+	uint32_t nrf_err;
 	uint16_t len = data_len;
 
 	LOG_INF("Sending data over BLE NUS, len %d", len);
 
 	do {
-		err = ble_nus_data_send(&ble_nus, data, &len, conn_handle);
-		if ((err != 0) &&
-			(err != -EPIPE) &&
-			(err != -EAGAIN) &&
-			(err != -EBADF)) {
-			LOG_ERR("Failed to send NUS data, err %d", err);
+		nrf_err = ble_nus_data_send(&ble_nus, data, &len, conn_handle);
+		if ((nrf_err) &&
+		    (nrf_err != NRF_ERROR_INVALID_STATE) &&
+		    (nrf_err != NRF_ERROR_RESOURCES) &&
+		    (nrf_err != NRF_ERROR_NOT_FOUND)) {
+			LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
 			return;
 		}
-	} while (err == -EAGAIN);
+	} while (nrf_err == NRF_ERROR_RESOURCES);
 }
 #else
 static void uarte_rx_handler(char *data, size_t data_len)
 {
-	int err;
+	uint32_t nrf_err;
 	uint8_t c;
 	/* receive buffer used in UART ISR callback */
 	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
@@ -114,15 +114,15 @@ static void uarte_rx_handler(char *data, size_t data_len)
 			LOG_INF("Sending data over BLE NUS, len %d", len);
 
 			do {
-				err = ble_nus_data_send(&ble_nus, rx_buf, &len, conn_handle);
-				if ((err != 0) &&
-				    (err != -EPIPE) &&
-				    (err != -EAGAIN) &&
-				    (err != -EBADF)) {
-					LOG_ERR("Failed to send NUS data, err %d", err);
+				nrf_err = ble_nus_data_send(&ble_nus, rx_buf, &len, conn_handle);
+				if ((nrf_err) &&
+				    (nrf_err != NRF_ERROR_INVALID_STATE) &&
+				    (nrf_err != NRF_ERROR_RESOURCES) &&
+				    (nrf_err != NRF_ERROR_NOT_FOUND)) {
+					LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
 					return;
 				}
-			} while (err == -EAGAIN);
+			} while (nrf_err == NRF_ERROR_RESOURCES);
 
 			if (len == rx_buf_idx) {
 				rx_buf_idx = 0;
@@ -488,9 +488,9 @@ int main(void)
 		goto idle;
 	}
 
-	err = ble_nus_init(&ble_nus, &nus_cfg);
-	if (err) {
-		LOG_ERR("Failed to initialize Nordic uart service, err %d", err);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize Nordic uart service, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -188,7 +188,6 @@ static void uarte_evt_handler(nrfx_uarte_event_t const *event, void *ctx)
  */
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
 	uint32_t nrf_err;
 
 	switch (evt->header.evt_id) {
@@ -201,9 +200,9 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 
-		err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
-		if (err) {
-			LOG_ERR("Failed to assign qwr handle, err %d", err);
+		nrf_err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
+		if (nrf_err) {
+			LOG_ERR("Failed to assign qwr handle, nrf_error %#x", nrf_err);
 			return;
 		}
 		break;
@@ -483,9 +482,9 @@ int main(void)
 
 	LOG_INF("Bluetooth enabled");
 
-	err = ble_qwr_init(&ble_qwr, &qwr_config);
-	if (err) {
-		LOG_ERR("ble_qwr_init failed, err %d", err);
+	nrf_err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (nrf_err) {
+		LOG_ERR("ble_qwr_init failed, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -505,9 +505,9 @@ int main(void)
 
 	LOG_INF("Services initialized");
 
-	err = ble_conn_params_evt_handler_set(on_conn_params_evt);
-	if (err) {
-		LOG_ERR("Failed to setup conn param event handler, err %d", err);
+	nrf_err = ble_conn_params_evt_handler_set(on_conn_params_evt);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup conn param event handler, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -604,6 +604,7 @@ static uint32_t adv_init(void)
 int main(void)
 {
 	int err;
+	uint32_t nrf_err;
 	uint8_t uuid_type;
 	struct ble_qwr_config qwr_config = {
 		.evt_handler = on_ble_qwr_evt,
@@ -677,9 +678,9 @@ int main(void)
 
 	LOG_INF("Bluetooth enabled");
 
-	err = ble_qwr_init(&ble_qwr, &qwr_config);
-	if (err) {
-		LOG_ERR("Failed to initialize QWR, err %d", err);
+	nrf_err = ble_qwr_init(&ble_qwr, &qwr_config);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize QWR, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -631,9 +631,9 @@ int main(void)
 	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 #endif
 
-	err = ble_conn_params_evt_handler_set(on_conn_params_evt);
-	if (err) {
-		LOG_ERR("Failed to setup conn param event handler, err %d", err);
+	nrf_err = ble_conn_params_evt_handler_set(on_conn_params_evt);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup conn param event handler, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -43,7 +43,7 @@ static struct mgmt_callback os_mgmt_reboot_callback = {
  */
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
-	int err;
+	uint32_t nrf_err;
 
 	__ASSERT(ble_evt, "BLE event is NULL");
 
@@ -56,10 +56,10 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 		break;
 	}
@@ -85,11 +85,12 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 	{
 		/* Pairing not supported */
-		err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
-						  BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL);
+		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,
+						      BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL,
+						      NULL);
 
-		if (err) {
-			LOG_ERR("Failed to reply with Security params, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to reply with Security params, nrf_error %#x", nrf_err);
 		}
 
 		break;
@@ -99,10 +100,10 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
-		err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 
-		if (err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", err);
+		if (nrf_err) {
+			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}
 
 		break;
@@ -226,10 +227,10 @@ int main(void)
 	}
 
 	if (device_disconnected == false) {
-		err = sd_ble_gap_disconnect(conn_handle,
-					    BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+		nrf_err = sd_ble_gap_disconnect(conn_handle,
+						BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 
-		if (err != NRF_SUCCESS) {
+		if (nrf_err) {
 			device_disconnected = true;
 		}
 

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -186,10 +186,10 @@ int main(void)
 
 	LOG_INF("Bluetooth enabled");
 
-	err = ble_mcumgr_init();
+	nrf_err = ble_mcumgr_init();
 
-	if (err) {
-		LOG_ERR("Failed to initialize MCUmgr: %d", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to initialize MCUmgr, nrf_error %#x", nrf_err);
 		return 0;
 	}
 

--- a/samples/peripherals/pwm/src/main.c
+++ b/samples/peripherals/pwm/src/main.c
@@ -35,7 +35,7 @@ ISR_DIRECT_DECLARE(pwm_direct_isr)
 
 int main(void)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	nrfx_pwm_t pwm_instance = NRFX_PWM_INSTANCE(PWM_INST_IDX);
 	/*
 	 * PWM signal can be exposed on GPIO pin only within the same domain.
@@ -59,9 +59,9 @@ int main(void)
 			   CONFIG_PWM_IRQ_PRIO,
 			   pwm_direct_isr, 0);
 
-	err = nrfx_pwm_init(&pwm_instance, &config, pwm_handler, &pwm_instance);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize PWM, nrfx_error %#x", err);
+	nrfx_err = nrfx_pwm_init(&pwm_instance, &config, pwm_handler, &pwm_instance);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to initialize PWM, nrfx_err %#x", nrfx_err);
 		goto idle;
 	}
 

--- a/samples/peripherals/uarte/src/main.c
+++ b/samples/peripherals/uarte/src/main.c
@@ -22,7 +22,7 @@ static int buf_idx;
 /* Handle data received from UARTE. */
 static void uarte_rx_handler(char *data, size_t data_len)
 {
-	nrfx_err_t err;
+	nrfx_err_t nrfx_err;
 	uint8_t c;
 	static char rx_buf[CONFIG_UARTE_DATA_LEN_MAX];
 	static uint16_t rx_buf_idx;
@@ -47,10 +47,10 @@ static void uarte_rx_handler(char *data, size_t data_len)
 				rx_buf[rx_buf_idx++] = '\n';
 			}
 
-			err = nrfx_uarte_tx(&uarte_inst, rx_buf, rx_buf_idx,
+			nrfx_err = nrfx_uarte_tx(&uarte_inst, rx_buf, rx_buf_idx,
 					    NRFX_UARTE_TX_BLOCKING);
-			if (err != NRFX_SUCCESS) {
-				LOG_ERR("nrfx_uarte_tx failed, nrfx_err %d", err);
+			if (nrfx_err != NRFX_SUCCESS) {
+				LOG_ERR("nrfx_uarte_tx failed, nrfx_err %#x", nrfx_err);
 			}
 
 			rx_buf_idx = 0;
@@ -92,9 +92,9 @@ ISR_DIRECT_DECLARE(uarte_direct_isr)
 }
 
 /* Initialize UARTE driver. */
-static int uarte_init(void)
+static nrfx_err_t uarte_init(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	nrfx_uarte_config_t uarte_config = NRFX_UARTE_DEFAULT_CONFIG(BOARD_APP_UARTE_PIN_TX,
 								     BOARD_APP_UARTE_PIN_RX);
@@ -118,39 +118,39 @@ static int uarte_init(void)
 
 	irq_enable(NRFX_IRQ_NUMBER_GET(NRF_UARTE_INST_GET(BOARD_APP_UARTE_INST)));
 
-	err = nrfx_uarte_init(&uarte_inst, &uarte_config, uarte_event_handler);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize UARTE, nrfx err %d", err);
-		return err;
+	nrfx_err = nrfx_uarte_init(&uarte_inst, &uarte_config, uarte_event_handler);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to initialize UARTE, nrfx_err %#x", nrfx_err);
+		return nrfx_err;
 	}
 
-	return 0;
+	return NRFX_SUCCESS;
 }
 
 int main(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	LOG_INF("UARTE sample started");
 
-	err = uarte_init();
-	if (err) {
-		LOG_ERR("Failed to enable UARTE, err %d", err);
+	nrfx_err = uarte_init();
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to enable UARTE, nrfx_err %#x", nrfx_err);
 		goto idle;
 	}
 
 	const uint8_t out[] = "Hello world! I will echo the lines you enter:\r\n";
 
-	err = nrfx_uarte_tx(&uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("UARTE TX failed, nrfx err %d", err);
+	nrfx_err = nrfx_uarte_tx(&uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("UARTE TX failed, nrfx_err %#x", nrfx_err);
 		goto idle;
 	}
 
 	/* Start reception */
-	err = nrfx_uarte_rx_enable(&uarte_inst, 0);
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("UARTE RX failed, nrfx err %d", err);
+	nrfx_err = nrfx_uarte_rx_enable(&uarte_inst, 0);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("UARTE RX failed, nrfx_err %#x", nrfx_err);
 	}
 
 idle:

--- a/subsys/bluetooth/services/ble_cgms/cgms.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms.c
@@ -179,7 +179,7 @@ uint32_t ble_cgms_init(struct ble_cgms *cgms, const struct ble_cgms_config *cgms
 		return NRF_ERROR_NULL;
 	}
 
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_uuid_t ble_uuid;
 	const uint8_t init_calib_val[] = {
 		0x3E, 0x00, 0x07, 0x00,
@@ -188,9 +188,9 @@ uint32_t ble_cgms_init(struct ble_cgms *cgms, const struct ble_cgms_config *cgms
 	};
 
 	/* Initialize data base. */
-	err = cgms_db_init();
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = cgms_db_init();
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Initialize service structure. */
@@ -209,59 +209,59 @@ uint32_t ble_cgms_init(struct ble_cgms *cgms, const struct ble_cgms_config *cgms
 	/* Add service. */
 	BLE_UUID_BLE_ASSIGN(ble_uuid, BLE_UUID_CGM_SERVICE);
 
-	err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY,
-				       &ble_uuid, &cgms->service_handle);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY,
+					   &ble_uuid, &cgms->service_handle);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add CGM Measurement characteristic. */
-	err = cgms_meas_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS measurement characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = cgms_meas_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS measurement characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Feature characteristic. */
-	err = feature_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS feature characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = feature_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS feature characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Status characteristic. */
-	err = status_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS status characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = status_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS status characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Session Start Time characteristic. */
-	err = cgms_sst_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS SST characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = cgms_sst_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS SST characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Session Run Time characteristic. */
-	err = srt_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS SRT characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = srt_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS SRT characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Record Access Control Point characteristic. */
-	err = cgms_racp_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS RACP characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = cgms_racp_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS RACP characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	/* Add CGM Specific Ops Control Point characteristic. */
-	err = cgms_socp_char_add(cgms);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add CGMS SOCP characteristic, nrf_error %#x", err);
-		return err;
+	nrf_err = cgms_socp_char_add(cgms);
+	if (nrf_err) {
+		LOG_ERR("Failed to add CGMS SOCP characteristic, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	return 0;
@@ -330,19 +330,19 @@ void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *context)
 
 uint32_t ble_cgms_meas_create(struct ble_cgms *cgms, struct ble_cgms_rec *rec)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t nb_rec_to_send = 1;
 
-	err = cgms_db_record_add(rec);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = cgms_db_record_add(rec);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	if ((cgms->conn_handle != BLE_CONN_HANDLE_INVALID) && (cgms->comm_interval != 0)) {
-		err = cgms_meas_send(cgms, rec, &nb_rec_to_send);
+		nrf_err = cgms_meas_send(cgms, rec, &nb_rec_to_send);
 	}
 
-	return err;
+	return nrf_err;
 }
 
 uint32_t ble_cgms_update_status(struct ble_cgms *cgms, struct ble_cgms_status *status)

--- a/subsys/bluetooth/services/ble_cgms/cgms_meas.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_meas.c
@@ -69,16 +69,16 @@ static uint8_t cgms_meas_encode(struct ble_cgms *cgms,
 /* Add a characteristic for the Continuous Glucose Meter Measurement. */
 uint32_t cgms_meas_char_add(struct ble_cgms *cgms)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t num_recs;
 	uint8_t encoded_cgms_meas[BLE_CGMS_MEAS_LEN_MAX];
 	struct ble_cgms_rec initial_cgms_rec_value = {0};
 
 	num_recs = cgms_db_num_records_get();
 	if (num_recs > 0) {
-		err = cgms_db_record_get(&initial_cgms_rec_value, num_recs - 1);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_db_record_get(&initial_cgms_rec_value, num_recs - 1);
+		if (nrf_err) {
+			return nrf_err;
 		}
 	}
 
@@ -118,7 +118,7 @@ uint32_t cgms_meas_char_add(struct ble_cgms *cgms)
 
 uint32_t cgms_meas_send(struct ble_cgms *cgms, struct ble_cgms_rec *rec, uint16_t *count)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t encoded_meas[BLE_CGMS_MEAS_LEN_MAX + BLE_CGMS_MEAS_REC_LEN_MAX];
 	uint16_t len = 0;
 	uint16_t hvx_len = BLE_CGMS_MEAS_LEN_MAX;
@@ -144,17 +144,17 @@ uint32_t cgms_meas_send(struct ble_cgms *cgms, struct ble_cgms_rec *rec, uint16_
 	*count = i;
 	hvx_len  = len;
 
-	err = sd_ble_gatts_hvx(cgms->conn_handle, &hvx_params);
-	if (err == NRF_SUCCESS) {
+	nrf_err = sd_ble_gatts_hvx(cgms->conn_handle, &hvx_params);
+	if (nrf_err == NRF_SUCCESS) {
 		if (hvx_len != len) {
-			err = NRF_ERROR_DATA_SIZE;
+			nrf_err = NRF_ERROR_DATA_SIZE;
 		} else {
 			/* Measurement successfully sent */
 			cgms->racp_data.racp_proc_records_reported += *count;
 		}
 	}
 
-	return err;
+	return nrf_err;
 }
 
 /* Glucose measurement CCCD write event handler */

--- a/subsys/bluetooth/services/ble_cgms/cgms_racp.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_racp.c
@@ -69,7 +69,7 @@ uint32_t cgms_racp_char_add(struct ble_cgms *cgms)
 
 static void racp_send(struct ble_cgms *cgms, struct ble_racp_value *racp_val)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t encoded_resp[25];
 	uint16_t len;
 
@@ -91,13 +91,13 @@ static void racp_send(struct ble_cgms *cgms, struct ble_racp_value *racp_val)
 		.gatts_hvx.p_len = &len,
 	};
 
-	err = ble_gq_item_add(cgms->gatt_queue, &cgms_req, cgms->conn_handle);
+	nrf_err = ble_gq_item_add(cgms->gatt_queue, &cgms_req, cgms->conn_handle);
 
 	/* Report error to application */
 	if ((cgms->evt_handler != NULL) &&
-	    (err != NRF_SUCCESS) &&
-	    (err != NRF_ERROR_INVALID_STATE)) {
-		evt.error.reason = err;
+	    (nrf_err) &&
+	    (nrf_err != NRF_ERROR_INVALID_STATE)) {
+		evt.error.reason = nrf_err;
 		cgms->evt_handler(cgms, &evt);
 	}
 }
@@ -127,7 +127,7 @@ static uint32_t racp_report_records_all(struct ble_cgms *cgms)
 	if (cgms->racp_data.racp_proc_record_idx >= total_records) {
 		cgms->racp_data.racp_processing_active = false;
 	} else {
-		uint32_t err;
+		uint32_t nrf_err;
 		struct ble_cgms_rec rec[BLE_CGMS_MEAS_REC_PER_NOTIF_MAX];
 
 		cur_num_rec = total_records - cgms->racp_data.racp_proc_record_idx;
@@ -138,16 +138,16 @@ static uint32_t racp_report_records_all(struct ble_cgms *cgms)
 		recs_to_send = cur_num_rec;
 
 		for (i = 0; i < cur_num_rec; i++) {
-			err = cgms_db_record_get(&(rec[i]),
-						 cgms->racp_data.racp_proc_record_idx + i);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = cgms_db_record_get(&(rec[i]),
+						     cgms->racp_data.racp_proc_record_idx + i);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 
-		err = cgms_meas_send(cgms, rec, &recs_to_send);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_meas_send(cgms, rec, &recs_to_send);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		cgms->racp_data.racp_proc_record_idx += recs_to_send;
@@ -159,7 +159,7 @@ static uint32_t racp_report_records_all(struct ble_cgms *cgms)
 /* Respond to the FIRST or the LAST operation. */
 static uint32_t racp_report_records_first_last(struct ble_cgms *cgms)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_cgms_rec rec;
 	uint16_t total_records;
 	uint16_t recs_to_send = 1;
@@ -170,20 +170,20 @@ static uint32_t racp_report_records_first_last(struct ble_cgms *cgms)
 		cgms->racp_data.racp_processing_active = false;
 	} else {
 		if (cgms->racp_data.racp_proc_operator == RACP_OPERATOR_FIRST) {
-			err = cgms_db_record_get(&rec, 0);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = cgms_db_record_get(&rec, 0);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		} else if (cgms->racp_data.racp_proc_operator == RACP_OPERATOR_LAST) {
-			err = cgms_db_record_get(&rec, total_records - 1);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = cgms_db_record_get(&rec, total_records - 1);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 
-		err = cgms_meas_send(cgms, &rec, &recs_to_send);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_meas_send(cgms, &rec, &recs_to_send);
+		if (nrf_err) {
+			return nrf_err;
 		}
 		cgms->racp_data.racp_proc_record_idx++;
 	}
@@ -204,7 +204,7 @@ static uint32_t racp_report_records_less_equal(struct ble_cgms *cgms)
 	if (cgms->racp_data.racp_proc_record_idx >= recs_to_send_total) {
 		cgms->racp_data.racp_processing_active = false;
 	} else {
-		uint32_t err;
+		uint32_t nrf_err;
 		struct ble_cgms_rec rec[BLE_CGMS_MEAS_REC_PER_NOTIF_MAX];
 
 		recs_to_send_remaining = (recs_to_send_total -
@@ -217,16 +217,16 @@ static uint32_t racp_report_records_less_equal(struct ble_cgms *cgms)
 		}
 
 		for (i = 0; i < recs_to_send; i++) {
-			err = cgms_db_record_get(&(rec[i]),
-						 cgms->racp_data.racp_proc_record_idx + i);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = cgms_db_record_get(&(rec[i]),
+						     cgms->racp_data.racp_proc_record_idx + i);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 
-		err = cgms_meas_send(cgms, rec, &recs_to_send);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_meas_send(cgms, rec, &recs_to_send);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		cgms->racp_data.racp_proc_record_idx += recs_to_send;
@@ -238,7 +238,7 @@ static uint32_t racp_report_records_less_equal(struct ble_cgms *cgms)
 /* Respond to the GREATER OR EQUAL operation. */
 static uint32_t racp_report_records_greater_equal(struct ble_cgms *cgms)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t recs_total = cgms_db_num_records_get();
 	uint16_t recs_to_send_remaining;
 	uint16_t recs_to_send;
@@ -261,14 +261,14 @@ static uint32_t racp_report_records_greater_equal(struct ble_cgms *cgms)
 	}
 
 	for (i = 0; i < recs_to_send; i++) {
-		err = cgms_db_record_get(&(rec[i]), cgms->racp_data.racp_proc_record_idx + i);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_db_record_get(&(rec[i]), cgms->racp_data.racp_proc_record_idx + i);
+		if (nrf_err) {
+			return nrf_err;
 		}
 	}
-	err = cgms_meas_send(cgms, rec, &recs_to_send);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = cgms_meas_send(cgms, rec, &recs_to_send);
+	if (nrf_err) {
+		return nrf_err;
 	}
 	cgms->racp_data.racp_proc_record_idx += recs_to_send;
 
@@ -292,7 +292,7 @@ static void racp_report_records_completed(struct ble_cgms *cgms)
 /* RACP report records procedure. */
 static void racp_report_records_procedure(struct ble_cgms *cgms)
 {
-	uint32_t err = NRF_SUCCESS;
+	uint32_t nrf_err = NRF_SUCCESS;
 	struct ble_cgms_evt evt = {
 		.evt_type = BLE_CGMS_EVT_ERROR,
 	};
@@ -301,19 +301,19 @@ static void racp_report_records_procedure(struct ble_cgms *cgms)
 		/* Execute requested procedure */
 		switch (cgms->racp_data.racp_proc_operator) {
 		case RACP_OPERATOR_ALL:
-			err = racp_report_records_all(cgms);
+			nrf_err = racp_report_records_all(cgms);
 			break;
 
 		case RACP_OPERATOR_FIRST:
 			/* Fall through. */
 		case RACP_OPERATOR_LAST:
-			err = racp_report_records_first_last(cgms);
+			nrf_err = racp_report_records_first_last(cgms);
 			break;
 		case RACP_OPERATOR_GREATER_OR_EQUAL:
-			err = racp_report_records_greater_equal(cgms);
+			nrf_err = racp_report_records_greater_equal(cgms);
 			break;
 		case RACP_OPERATOR_LESS_OR_EQUAL:
-			err = racp_report_records_less_equal(cgms);
+			nrf_err = racp_report_records_less_equal(cgms);
 			break;
 		default:
 			/* Report error to application */
@@ -327,7 +327,7 @@ static void racp_report_records_procedure(struct ble_cgms *cgms)
 		}
 
 		/* Error handling */
-		switch (err) {
+		switch (nrf_err) {
 		case NRF_SUCCESS:
 			if (!cgms->racp_data.racp_processing_active) {
 				racp_report_records_completed(cgms);
@@ -436,14 +436,14 @@ static bool is_request_to_be_executed(struct ble_cgms *cgms,
 /* Get a record with time offset less or equal to the input param. */
 static uint32_t record_index_offset_less_or_equal_get(uint16_t offset, uint16_t *record_num)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_cgms_rec rec;
 	uint16_t upper_bound = cgms_db_num_records_get();
 
 	for ((*record_num) = upper_bound; ((*record_num)-- > 0);) {
-		err = cgms_db_record_get(&rec, *record_num);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_db_record_get(&rec, *record_num);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		if (rec.meas.time_offset <= offset) {
@@ -457,14 +457,14 @@ static uint32_t record_index_offset_less_or_equal_get(uint16_t offset, uint16_t 
 /* Get a record with time offset greater or equal to the input param. */
 static uint32_t record_index_offset_greater_or_equal_get(uint16_t offset, uint16_t *record_num)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_cgms_rec rec;
 	uint16_t upper_bound = cgms_db_num_records_get();
 
 	for (*record_num = 0; *record_num < upper_bound; (*record_num)++) {
-		err = cgms_db_record_get(&rec, *record_num);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = cgms_db_record_get(&rec, *record_num);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		if (rec.meas.time_offset >= offset) {
@@ -479,7 +479,7 @@ static uint32_t record_index_offset_greater_or_equal_get(uint16_t offset, uint16
 static void report_records_request_execute(struct ble_cgms *cgms,
 					   struct ble_racp_value *racp_request)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t offset_requested;
 	uint16_t *record_num;
 	const uint8_t *op;
@@ -495,8 +495,8 @@ static void report_records_request_execute(struct ble_cgms *cgms,
 		op = &cgms->racp_data.racp_request.operand[OPERAND_LESS_GREATER_FILTER_TYPE_SIZE];
 		offset_requested = sys_get_le16(op);
 		record_num = &cgms->racp_data.racp_proc_record_idx;
-		err = record_index_offset_greater_or_equal_get(offset_requested, record_num);
-		if (err != NRF_SUCCESS) {
+		nrf_err = record_index_offset_greater_or_equal_get(offset_requested, record_num);
+		if (nrf_err) {
 			racp_report_records_completed(cgms);
 		}
 	}
@@ -505,8 +505,8 @@ static void report_records_request_execute(struct ble_cgms *cgms,
 		op = &cgms->racp_data.racp_request.operand[OPERAND_LESS_GREATER_FILTER_TYPE_SIZE];
 		offset_requested = sys_get_le16(op);
 		record_num = &cgms->racp_data.racp_proc_records_idx_last_to_send;
-		err = record_index_offset_less_or_equal_get(offset_requested, record_num);
-		if (err != NRF_SUCCESS) {
+		nrf_err = record_index_offset_less_or_equal_get(offset_requested, record_num);
+		if (nrf_err) {
 			racp_report_records_completed(cgms);
 		}
 	}
@@ -518,7 +518,7 @@ static void report_records_request_execute(struct ble_cgms *cgms,
 static void report_num_records_request_execute(struct ble_cgms   *cgms,
 					       struct ble_racp_value *racp_request)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t total_records;
 	uint16_t num_records;
 
@@ -537,9 +537,10 @@ static void report_num_records_request_execute(struct ble_cgms   *cgms,
 		uint8_t *operand = cgms->racp_data.racp_request.operand;
 		uint16_t offset_requested =
 			sys_get_le16(&operand[OPERAND_LESS_GREATER_FILTER_TYPE_SIZE]);
-		err = record_index_offset_greater_or_equal_get(offset_requested, &index_of_offset);
+		nrf_err = record_index_offset_greater_or_equal_get(offset_requested,
+								   &index_of_offset);
 
-		if (err != NRF_SUCCESS) {
+		if (nrf_err) {
 			num_records = 0;
 		} else {
 			num_records = total_records - index_of_offset;
@@ -588,7 +589,7 @@ static void on_racp_value_write(struct ble_cgms *cgms, const ble_gatts_evt_write
 void cgms_racp_on_rw_auth_req(struct ble_cgms *cgms,
 			      const ble_gatts_evt_rw_authorize_request_t *auth_req)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_cgms_evt cgms_evt = {
 		.evt_type = BLE_CGMS_EVT_ERROR,
 	};
@@ -608,16 +609,16 @@ void cgms_racp_on_rw_auth_req(struct ble_cgms *cgms,
 		.offset = 0,
 	};
 
-	err = sd_ble_gatts_value_get(cgms->conn_handle, cgms->char_handles.racp.cccd_handle,
-				     &gatts_val);
-	if ((err != NRF_SUCCESS) || !is_indication_enabled(gatts_val.p_value)) {
+	nrf_err = sd_ble_gatts_value_get(cgms->conn_handle, cgms->char_handles.racp.cccd_handle,
+					 &gatts_val);
+	if (nrf_err || !is_indication_enabled(gatts_val.p_value)) {
 		auth_reply.params.write.gatt_status = BLE_GATT_STATUS_ATTERR_CPS_CCCD_CONFIG_ERROR;
 	}
 
-	err = sd_ble_gatts_rw_authorize_reply(cgms->conn_handle, &auth_reply);
-	if (err != NRF_SUCCESS) {
+	nrf_err = sd_ble_gatts_rw_authorize_reply(cgms->conn_handle, &auth_reply);
+	if (nrf_err) {
 		if (cgms->evt_handler != NULL) {
-			cgms_evt.error.reason = err;
+			cgms_evt.error.reason = nrf_err;
 			cgms->evt_handler(cgms, &cgms_evt);
 		}
 		return;

--- a/subsys/bluetooth/services/ble_cgms/cgms_socp.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_socp.c
@@ -344,7 +344,7 @@ uint32_t cgms_socp_char_add(struct ble_cgms *cgms)
 /* Send a Specific Ops Control Point response. */
 static void socp_send(struct ble_cgms *cgms)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t encoded_resp[BLE_CGMS_SOCP_LEN];
 	uint16_t len;
 	struct ble_cgms_evt cgms_evt = {
@@ -365,13 +365,13 @@ static void socp_send(struct ble_cgms *cgms)
 		.gatts_hvx.p_len = &len,
 	};
 
-	err = ble_gq_item_add(cgms->gatt_queue, &cgms_req, cgms->conn_handle);
+	nrf_err = ble_gq_item_add(cgms->gatt_queue, &cgms_req, cgms->conn_handle);
 
 	/* Report error to application. */
 	if ((cgms->evt_handler != NULL) &&
-	    (err != NRF_SUCCESS) &&
-	    (err != NRF_ERROR_INVALID_STATE)) {
-		cgms_evt.error.reason = err;
+	    (nrf_err) &&
+	    (nrf_err != NRF_ERROR_INVALID_STATE)) {
+		cgms_evt.error.reason = nrf_err;
 		cgms->evt_handler(cgms, &cgms_evt);
 	}
 }

--- a/subsys/bluetooth/services/ble_cgms/cgms_sst.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_sst.c
@@ -91,12 +91,12 @@ static uint8_t sst_encode(struct ble_cgms_sst *sst, uint8_t *sst_encoded)
 
 static uint32_t cgm_update_sst(struct ble_cgms *cgms, const ble_gatts_evt_write_t *evt_write)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_cgms_sst sst = {0};
 	struct tm c_time_and_date;
 
-	err = sst_decode(&sst, evt_write->data, evt_write->len);
-	if (err != NRF_SUCCESS) {
+	nrf_err = sst_decode(&sst, evt_write->data, evt_write->len);
+	if (nrf_err) {
 		/* Silently drop the update */
 		return NRF_SUCCESS;
 	}
@@ -110,7 +110,7 @@ static uint32_t cgm_update_sst(struct ble_cgms *cgms, const ble_gatts_evt_write_
 /* Glucose session start time write event handler. */
 static void on_sst_value_write(struct ble_cgms *cgms, const ble_gatts_evt_write_t *evt_write)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_gatts_rw_authorize_reply_params_t auth_reply = {
 		.type = BLE_GATTS_AUTHORIZE_TYPE_WRITE,
 		.params = {
@@ -124,18 +124,18 @@ static void on_sst_value_write(struct ble_cgms *cgms, const ble_gatts_evt_write_
 		.evt_type = BLE_CGMS_EVT_ERROR,
 	};
 
-	err = sd_ble_gatts_rw_authorize_reply(cgms->conn_handle, &auth_reply);
-	if (err != NRF_SUCCESS) {
+	nrf_err = sd_ble_gatts_rw_authorize_reply(cgms->conn_handle, &auth_reply);
+	if (nrf_err) {
 		if (cgms->evt_handler != NULL) {
-			cgms_evt.error.reason = err;
+			cgms_evt.error.reason = nrf_err;
 			cgms->evt_handler(cgms, &cgms_evt);
 		}
 	}
 
-	err = cgm_update_sst(cgms, evt_write);
-	if (err != NRF_SUCCESS) {
+	nrf_err = cgm_update_sst(cgms, evt_write);
+	if (nrf_err) {
 		if (cgms->evt_handler != NULL) {
-			cgms_evt.error.reason = err;
+			cgms_evt.error.reason = nrf_err;
 			cgms->evt_handler(cgms, &cgms_evt);
 		}
 	}

--- a/subsys/bluetooth/services/ble_dis/dis.c
+++ b/subsys/bluetooth/services/ble_dis/dis.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <nrf_error.h>
+#include <stdint.h>
 #include <ble_gatts.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/common.h>
@@ -56,9 +58,9 @@ static const uint8_t regulatory_certifications[IEEE_CERT_LEN] =
 
 LOG_MODULE_REGISTER(ble_dis, CONFIG_BLE_DIS_LOG_LEVEL);
 
-int ble_dis_init(void)
+uint32_t ble_dis_init(void)
 {
-	int err;
+	uint32_t nrf_err;
 	uint16_t service_handle;
 	ble_uuid_t ble_uuid;
 	ble_gatts_char_handles_t char_handles = {0};
@@ -102,10 +104,10 @@ int ble_dis_init(void)
 	/* Add service */
 	BLE_UUID_BLE_ASSIGN(ble_uuid, BLE_UUID_DEVICE_INFORMATION_SERVICE);
 
-	err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid, &service_handle);
-	if (err) {
-		LOG_ERR("Failed to add device information service, nrf_error %#x", err);
-		return -EINVAL;
+	nrf_err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid, &service_handle);
+	if (nrf_err) {
+		LOG_ERR("Failed to add device information service, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(chars); i++) {
@@ -121,13 +123,13 @@ int ble_dis_init(void)
 
 		LOG_DBG("Added char %#x, len %d", chars[i].uuid, chars[i].len);
 
-		err = sd_ble_gatts_characteristic_add(service_handle, &char_md,
-						      &attr_char_value, &char_handles);
-		if (err) {
-			LOG_ERR("Failed to add characteristic, nrf_error %#x", err);
-			return -EINVAL;
+		nrf_err = sd_ble_gatts_characteristic_add(service_handle, &char_md,
+							  &attr_char_value, &char_handles);
+		if (nrf_err) {
+			LOG_ERR("Failed to add characteristic, nrf_error %#x", nrf_err);
+			return nrf_err;
 		}
 	}
 
-	return 0;
+	return NRF_SUCCESS;
 }

--- a/subsys/bluetooth/services/ble_hids/hids.c
+++ b/subsys/bluetooth/services/ble_hids/hids.c
@@ -111,15 +111,15 @@ static struct ble_hids_char_id make_char_id(uint16_t uuid, uint8_t report_type,
 
 static void on_connect(struct ble_hids *hids, ble_evt_t const *ble_evt)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_gatts_value_t gatts_value;
 	struct ble_hids_client_context *client = NULL;
 
-	err = link_ctx_get(hids, ble_evt->evt.gap_evt.conn_handle, (void *)&client);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gap_evt.conn_handle, (void *)&client);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -142,13 +142,13 @@ static void on_connect(struct ble_hids *hids, ble_evt_t const *ble_evt)
 		gatts_value.offset = 0;
 		gatts_value.p_value = &client->protocol_mode;
 
-		err = sd_ble_gatts_value_set(ble_evt->evt.gap_evt.conn_handle,
-					     hids->protocol_mode_handles.value_handle,
-					     &gatts_value);
-		if (err != NRF_SUCCESS) {
+		nrf_err = sd_ble_gatts_value_set(ble_evt->evt.gap_evt.conn_handle,
+						 hids->protocol_mode_handles.value_handle,
+						 &gatts_value);
+		if (nrf_err) {
 			struct ble_hids_evt evt = {
 				.evt_type = BLE_HIDS_EVT_ERROR,
-				.params.error.reason = err,
+				.params.error.reason = nrf_err,
 			};
 
 			hids->evt_handler(hids, &evt);
@@ -158,15 +158,15 @@ static void on_connect(struct ble_hids *hids, ble_evt_t const *ble_evt)
 
 static void on_control_point_write(struct ble_hids *hids, ble_evt_t const *ble_evt)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_hids_client_context *host;
 	ble_gatts_evt_write_t const *evt_write = &ble_evt->evt.gatts_evt.params.write;
 
-	err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -206,15 +206,15 @@ static void on_control_point_write(struct ble_hids *hids, ble_evt_t const *ble_e
 
 static void on_protocol_mode_write(struct ble_hids *hids, ble_evt_t const *ble_evt)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	struct ble_hids_client_context *host;
 	ble_gatts_evt_write_t const *evt_write = &ble_evt->evt.gatts_evt.params.write;
 
-	err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -254,17 +254,17 @@ static void on_protocol_mode_write(struct ble_hids *hids, ble_evt_t const *ble_e
 
 void on_protocol_mode_read_auth(struct ble_hids *hids, ble_evt_t const *ble_evt)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_gatts_rw_authorize_reply_params_t auth_read_params;
 	struct ble_hids_client_context *host;
 	ble_gatts_evt_rw_authorize_request_t const *read_auth =
 		&ble_evt->evt.gatts_evt.params.authorize_request;
 
-	err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -281,12 +281,12 @@ void on_protocol_mode_read_auth(struct ble_hids *hids, ble_evt_t const *ble_evt)
 		auth_read_params.params.read.p_data = &host->protocol_mode;
 		auth_read_params.params.read.update = 1;
 
-		err = sd_ble_gatts_rw_authorize_reply(ble_evt->evt.gap_evt.conn_handle,
-						      &auth_read_params);
-		if (err != NRF_SUCCESS) {
+		nrf_err = sd_ble_gatts_rw_authorize_reply(ble_evt->evt.gap_evt.conn_handle,
+							  &auth_read_params);
+		if (nrf_err) {
 			struct ble_hids_evt evt = {
 				.evt_type = BLE_HIDS_EVT_ERROR,
-				.params.error.reason = err,
+				.params.error.reason = nrf_err,
 			};
 
 			hids->evt_handler(hids, &evt);
@@ -322,16 +322,16 @@ static void on_report_value_write(struct ble_hids *hids, ble_evt_t const *ble_ev
 				  uint16_t rep_max_len)
 {
 	/* Update host's Output Report data */
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t *report;
 	struct ble_hids_client_context *host;
 	ble_gatts_evt_write_t const *write = &ble_evt->evt.gatts_evt.params.write;
 
-	err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -368,13 +368,13 @@ static void on_report_value_read_auth(struct ble_hids *hids, struct ble_hids_cha
 	struct ble_hids_client_context *host;
 	uint8_t *report;
 	uint16_t read_offset;
-	uint32_t err = NRF_SUCCESS;
+	uint32_t nrf_err = NRF_SUCCESS;
 
-	err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
-	if (err != NRF_SUCCESS) {
+	nrf_err = link_ctx_get(hids, ble_evt->evt.gatts_evt.conn_handle, (void *)&host);
+	if (nrf_err) {
 		struct ble_hids_evt evt = {
 			.evt_type = BLE_HIDS_EVT_ERROR,
-			.params.error.reason = err,
+			.params.error.reason = nrf_err,
 		};
 
 		hids->evt_handler(hids, &evt);
@@ -393,13 +393,13 @@ static void on_report_value_read_auth(struct ble_hids *hids, struct ble_hids_cha
 		auth_read_params.params.read.p_data = report + read_offset;
 		auth_read_params.params.read.update = 1;
 
-		err = sd_ble_gatts_rw_authorize_reply(ble_evt->evt.gap_evt.conn_handle,
-						      &auth_read_params);
+		nrf_err = sd_ble_gatts_rw_authorize_reply(ble_evt->evt.gap_evt.conn_handle,
+							  &auth_read_params);
 
-		if (err != NRF_SUCCESS) {
+		if (nrf_err) {
 			struct ble_hids_evt evt = {
 				.evt_type = BLE_HIDS_EVT_ERROR,
-				.params.error.reason = err,
+				.params.error.reason = nrf_err,
 			};
 
 			hids->evt_handler(hids, &evt);
@@ -633,7 +633,7 @@ static uint32_t rep_char_add(struct ble_hids *hids, ble_gatt_char_props_t *prope
 			     struct ble_hids_char_sec const *const char_sec,
 			     struct ble_hids_rep_char *rep_char)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t encoded_rep_ref[BLE_SRV_ENCODED_REPORT_REF_LEN] = { report_id, report_type };
 
 	ble_gatts_char_md_t char_md = {
@@ -668,10 +668,10 @@ static uint32_t rep_char_add(struct ble_hids *hids, ble_gatt_char_props_t *prope
 		char_md.p_cccd_md = &cccd_md;
 	}
 
-	err = sd_ble_gatts_characteristic_add(hids->service_handle, &char_md, &attr_char_value,
-					       &rep_char->char_handles);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = sd_ble_gatts_characteristic_add(hids->service_handle, &char_md, &attr_char_value,
+						  &rep_char->char_handles);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	ble_uuid_t desc_uuid = {
@@ -698,7 +698,7 @@ static uint32_t rep_char_add(struct ble_hids *hids, ble_gatt_char_props_t *prope
 
 static uint32_t rep_map_char_add(struct ble_hids *hids, const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_gatts_char_md_t char_md = {
 		.char_props = {
 			.read = 1,
@@ -721,10 +721,10 @@ static uint32_t rep_map_char_add(struct ble_hids *hids, const struct ble_hids_co
 		.p_value = hids_cfg->report_map.data,
 	};
 
-	err = sd_ble_gatts_characteristic_add(hids->service_handle, &char_md, &attr_char_value,
-					       &hids->rep_map_handles);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = sd_ble_gatts_characteristic_add(hids->service_handle, &char_md, &attr_char_value,
+						  &hids->rep_map_handles);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	if (hids_cfg->report_map.ext_rep_ref_num != 0 && hids_cfg->report_map.ext_rep_ref == NULL) {
@@ -735,10 +735,10 @@ static uint32_t rep_map_char_add(struct ble_hids *hids, const struct ble_hids_co
 		uint8_t encoded_rep_ref[sizeof(ble_uuid128_t)];
 		uint8_t encoded_rep_ref_len;
 
-		err = sd_ble_uuid_encode(&hids_cfg->report_map.ext_rep_ref[i], &encoded_rep_ref_len,
-					 encoded_rep_ref);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = sd_ble_uuid_encode(&hids_cfg->report_map.ext_rep_ref[i],
+					     &encoded_rep_ref_len, encoded_rep_ref);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		ble_uuid_t desc_uuid = {
@@ -757,10 +757,11 @@ static uint32_t rep_map_char_add(struct ble_hids *hids, const struct ble_hids_co
 			.p_value = encoded_rep_ref,
 		};
 
-		err = sd_ble_gatts_descriptor_add(hids->rep_map_handles.value_handle, &descr_params,
-						  &hids->rep_map_ext_rep_ref_handle);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = sd_ble_gatts_descriptor_add(hids->rep_map_handles.value_handle,
+						      &descr_params,
+						      &hids->rep_map_ext_rep_ref_handle);
+		if (nrf_err) {
+			return nrf_err;
 		}
 	}
 
@@ -908,7 +909,7 @@ static uint32_t hid_control_point_char_add(struct ble_hids *hids,
 static uint32_t inp_rep_characteristics_add(struct ble_hids *hids,
 					    const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if ((hids_cfg->input_report_count != 0) && (hids_cfg->input_report != NULL)) {
 		for (uint8_t i = 0; i < hids_cfg->input_report_count; i++) {
@@ -919,11 +920,12 @@ static uint32_t inp_rep_characteristics_add(struct ble_hids *hids,
 				.notify = true,
 			};
 
-			err = rep_char_add(hids, &properties, rep_init->len, rep_init->report_id,
-					   rep_init->report_type, &rep_init->sec,
-					   &hids->inp_rep_array[i]);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = rep_char_add(hids, &properties, rep_init->len,
+					       rep_init->report_id,
+					       rep_init->report_type, &rep_init->sec,
+					       &hids->inp_rep_array[i]);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 	}
@@ -934,7 +936,7 @@ static uint32_t inp_rep_characteristics_add(struct ble_hids *hids,
 static uint32_t outp_rep_characteristics_add(struct ble_hids *hids,
 					     const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if ((hids_cfg->output_report_count != 0) && (hids_cfg->output_report != NULL)) {
 		for (uint8_t i = 0; i < hids_cfg->output_report_count; i++) {
@@ -946,11 +948,12 @@ static uint32_t outp_rep_characteristics_add(struct ble_hids *hids,
 				.write_wo_resp = true,
 			};
 
-			err = rep_char_add(hids, &properties, rep_init->len, rep_init->report_id,
-					   rep_init->report_type, &rep_init->sec,
-					   &hids->outp_rep_array[i]);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = rep_char_add(hids, &properties, rep_init->len,
+					       rep_init->report_id,
+					       rep_init->report_type, &rep_init->sec,
+					       &hids->outp_rep_array[i]);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 	}
@@ -961,7 +964,7 @@ static uint32_t outp_rep_characteristics_add(struct ble_hids *hids,
 static uint32_t feature_rep_characteristics_add(struct ble_hids *hids,
 						const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if ((hids_cfg->feature_report_count != 0) && (hids_cfg->feature_report != NULL)) {
 		for (uint8_t i = 0; i < hids_cfg->feature_report_count; i++) {
@@ -973,11 +976,12 @@ static uint32_t feature_rep_characteristics_add(struct ble_hids *hids,
 				.write = true,
 			};
 
-			err = rep_char_add(hids, &properties, rep_init->len, rep_init->report_id,
-					   rep_init->report_type, &rep_init->sec,
-					   &hids->feature_rep_array[i]);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = rep_char_add(hids, &properties, rep_init->len,
+					       rep_init->report_id,
+					       rep_init->report_type, &rep_init->sec,
+					       &hids->feature_rep_array[i]);
+			if (nrf_err) {
+				return nrf_err;
 			}
 		}
 	}
@@ -987,15 +991,15 @@ static uint32_t feature_rep_characteristics_add(struct ble_hids *hids,
 
 static uint32_t includes_add(struct ble_hids *hids, const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint16_t unused_include_handle;
 
 	for (uint8_t i = 0; i < hids_cfg->included_services_count; i++) {
-		err = sd_ble_gatts_include_add(hids->service_handle,
-					       hids_cfg->included_services_array[i],
-					       &unused_include_handle);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = sd_ble_gatts_include_add(hids->service_handle,
+						   hids_cfg->included_services_array[i],
+						   &unused_include_handle);
+		if (nrf_err) {
+			return nrf_err;
 		}
 	}
 
@@ -1004,7 +1008,7 @@ static uint32_t includes_add(struct ble_hids *hids, const struct ble_hids_config
 
 uint32_t ble_hids_init(struct ble_hids *hids, const struct ble_hids_config *hids_cfg)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	ble_uuid_t ble_uuid;
 
 	if (!hids || !hids_cfg) {
@@ -1028,97 +1032,97 @@ uint32_t ble_hids_init(struct ble_hids *hids, const struct ble_hids_config *hids
 
 	BLE_UUID_BLE_ASSIGN(ble_uuid, BLE_UUID_HUMAN_INTERFACE_DEVICE_SERVICE);
 
-	err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid,
-				       &hids->service_handle);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid,
+					   &hids->service_handle);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
-	err = includes_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = includes_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 #if defined(CONFIG_BLE_HIDS_BOOT_KEYBOARD) || defined(CONFIG_BLE_HIDS_BOOT_MOUSE)
 	/* Add Protocol Mode characteristic. */
-	err = protocol_mode_char_add(hids, hids_cfg->protocol_mode_sec.read,
-				     hids_cfg->protocol_mode_sec.write);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = protocol_mode_char_add(hids, hids_cfg->protocol_mode_sec.read,
+					 hids_cfg->protocol_mode_sec.write);
+	if (nrf_err) {
+		return nrf_err;
 	}
 #endif
 
 	/* Add Input Report characteristics (if any). */
-	err = inp_rep_characteristics_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = inp_rep_characteristics_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add Output Report characteristics (if any). */
-	err = outp_rep_characteristics_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = outp_rep_characteristics_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add Feature Report characteristic (if any). */
-	err = feature_rep_characteristics_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = feature_rep_characteristics_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add Report Map characteristic. */
-	err = rep_map_char_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = rep_map_char_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 #if defined(CONFIG_BLE_HIDS_BOOT_KEYBOARD)
 	/* Add Boot Keyboard Input Report characteristic. */
-	err = boot_inp_rep_char_add(hids, BLE_UUID_BOOT_KEYBOARD_INPUT_REPORT_CHAR,
-				    BLE_HIDS_BOOT_KB_INPUT_REPORT_MAX_SIZE,
-				    &hids_cfg->boot_kb_inp_rep_sec,
-				    &hids->boot_kb_inp_rep_handles);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = boot_inp_rep_char_add(hids, BLE_UUID_BOOT_KEYBOARD_INPUT_REPORT_CHAR,
+					BLE_HIDS_BOOT_KB_INPUT_REPORT_MAX_SIZE,
+					&hids_cfg->boot_kb_inp_rep_sec,
+					&hids->boot_kb_inp_rep_handles);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add Boot Keyboard Output Report characteristic. */
-	err = boot_kb_outp_rep_char_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = boot_kb_outp_rep_char_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 #endif
 
 #if defined(CONFIG_BLE_HIDS_BOOT_MOUSE)
 	/* Add Boot Mouse Input Report characteristic. */
-	err = boot_inp_rep_char_add(
+	nrf_err = boot_inp_rep_char_add(
 		hids, BLE_UUID_BOOT_MOUSE_INPUT_REPORT_CHAR,
 		BLE_HIDS_BOOT_MOUSE_INPUT_REPORT_MAX_SIZE,
 		&hids_cfg->boot_mouse_inp_rep_sec, &hids->boot_mouse_inp_rep_handles);
-	if (err != NRF_SUCCESS) {
-		return err;
+	if (nrf_err) {
+		return nrf_err;
 	}
 #endif
 
 	/* Add HID Information characteristic. */
-	err = hid_information_char_add(hids, hids_cfg);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = hid_information_char_add(hids, hids_cfg);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	/* Add HID Control Point characteristic. */
-	err = hid_control_point_char_add(hids, hids_cfg->ctrl_point_sec.write);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = hid_control_point_char_add(hids, hids_cfg->ctrl_point_sec.write);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
-	return err;
+	return nrf_err;
 }
 
 uint32_t ble_hids_inp_rep_send(struct ble_hids *hids, uint16_t conn_handle,
 			       struct ble_hids_input_report *report)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if (!hids || !report || !report->data) {
 		return NRF_ERROR_NULL;
@@ -1133,10 +1137,10 @@ uint32_t ble_hids_inp_rep_send(struct ble_hids *hids, uint16_t conn_handle,
 			uint16_t hvx_len = report->len;
 			uint8_t *host_rep_data;
 
-			err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
-			if (err != NRF_SUCCESS) {
-				LOG_ERR("Failed to get link context, nrf_err %d", err);
-				return err;
+			nrf_err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
+			if (nrf_err) {
+				LOG_ERR("Failed to get link context, nrf_error %#x", nrf_err);
+				return nrf_err;
 			}
 
 			host_rep_data += sizeof(struct ble_hids_client_context) +
@@ -1165,19 +1169,19 @@ uint32_t ble_hids_inp_rep_send(struct ble_hids *hids, uint16_t conn_handle,
 			hvx_params.p_len = &hvx_len;
 			hvx_params.p_data = report->data;
 
-			err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
-			if ((err == NRF_SUCCESS) && (*hvx_params.p_len != report->len)) {
-				LOG_ERR("Failed to update attribute value, nrf_err %d", err);
-				err = NRF_ERROR_DATA_SIZE;
+			nrf_err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
+			if ((nrf_err == NRF_SUCCESS) && (*hvx_params.p_len != report->len)) {
+				LOG_ERR("Failed to update attribute value, nrf_error %#x", nrf_err);
+				nrf_err = NRF_ERROR_DATA_SIZE;
 			}
 		} else {
-			err = NRF_ERROR_INVALID_STATE;
+			nrf_err = NRF_ERROR_INVALID_STATE;
 		}
 	} else {
-		err = NRF_ERROR_INVALID_PARAM;
+		nrf_err = NRF_ERROR_INVALID_PARAM;
 	}
 
-	return err;
+	return nrf_err;
 }
 
 uint32_t ble_hids_boot_kb_inp_rep_send(struct ble_hids *hids, uint16_t conn_handle,
@@ -1187,16 +1191,16 @@ uint32_t ble_hids_boot_kb_inp_rep_send(struct ble_hids *hids, uint16_t conn_hand
 		return NRF_ERROR_NULL;
 	}
 
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if (conn_handle != BLE_CONN_HANDLE_INVALID) {
 		ble_gatts_hvx_params_t hvx_params;
 		uint16_t hvx_len = report->len;
 		uint8_t *host_rep_data;
 
-		err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
-		if (err != NRF_SUCCESS) {
-			return err;
+		nrf_err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
+		if (nrf_err) {
+			return nrf_err;
 		}
 
 		host_rep_data += sizeof(struct ble_hids_client_context);
@@ -1215,15 +1219,15 @@ uint32_t ble_hids_boot_kb_inp_rep_send(struct ble_hids *hids, uint16_t conn_hand
 		hvx_params.p_len = &hvx_len;
 		hvx_params.p_data = report->data;
 
-		err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
-		if ((err == NRF_SUCCESS) && (*hvx_params.p_len != report->len)) {
-			err = NRF_ERROR_DATA_SIZE;
+		nrf_err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
+		if ((nrf_err == NRF_SUCCESS) && (*hvx_params.p_len != report->len)) {
+			nrf_err = NRF_ERROR_DATA_SIZE;
 		}
 	} else {
-		err = NRF_ERROR_INVALID_STATE;
+		nrf_err = NRF_ERROR_INVALID_STATE;
 	}
 
-	return err;
+	return nrf_err;
 }
 
 uint32_t ble_hids_boot_mouse_inp_rep_send(struct ble_hids *hids, uint16_t conn_handle,
@@ -1233,7 +1237,7 @@ uint32_t ble_hids_boot_mouse_inp_rep_send(struct ble_hids *hids, uint16_t conn_h
 		return NRF_ERROR_NULL;
 	}
 
-	uint32_t err;
+	uint32_t nrf_err;
 
 	if (conn_handle != BLE_CONN_HANDLE_INVALID) {
 		uint16_t hvx_len = BOOT_MOUSE_INPUT_REPORT_MIN_SIZE + report->optional_data_len;
@@ -1243,9 +1247,9 @@ uint32_t ble_hids_boot_mouse_inp_rep_send(struct ble_hids *hids, uint16_t conn_h
 			ble_gatts_hvx_params_t hvx_params;
 			uint8_t *host_rep_data;
 
-			err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
-			if (err != NRF_SUCCESS) {
-				return err;
+			nrf_err = link_ctx_get(hids, conn_handle, (void *)&host_rep_data);
+			if (nrf_err) {
+				return nrf_err;
 			}
 
 			host_rep_data += sizeof(struct ble_hids_client_context) +
@@ -1276,20 +1280,20 @@ uint32_t ble_hids_boot_mouse_inp_rep_send(struct ble_hids *hids, uint16_t conn_h
 			hvx_params.p_len = &hvx_len;
 			hvx_params.p_data = buffer;
 
-			err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
-			if ((err == NRF_SUCCESS) &&
+			nrf_err = sd_ble_gatts_hvx(conn_handle, &hvx_params);
+			if ((nrf_err == NRF_SUCCESS) &&
 			    (*hvx_params.p_len != (BOOT_MOUSE_INPUT_REPORT_MIN_SIZE +
 						   report->optional_data_len))) {
-				err = NRF_ERROR_DATA_SIZE;
+				nrf_err = NRF_ERROR_DATA_SIZE;
 			}
 		} else {
-			err = NRF_ERROR_DATA_SIZE;
+			nrf_err = NRF_ERROR_DATA_SIZE;
 		}
 	} else {
-		err = NRF_ERROR_INVALID_STATE;
+		nrf_err = NRF_ERROR_INVALID_STATE;
 	}
 
-	return err;
+	return nrf_err;
 }
 
 uint32_t ble_hids_outp_rep_get(struct ble_hids *hids, uint8_t report_index, uint16_t len,
@@ -1299,7 +1303,7 @@ uint32_t ble_hids_outp_rep_get(struct ble_hids *hids, uint8_t report_index, uint
 		return NRF_ERROR_NULL;
 	}
 
-	uint32_t err;
+	uint32_t nrf_err;
 	uint8_t *rep_data;
 	uint8_t index;
 
@@ -1307,9 +1311,9 @@ uint32_t ble_hids_outp_rep_get(struct ble_hids *hids, uint8_t report_index, uint
 		return NRF_ERROR_INVALID_PARAM;
 	}
 
-	err = link_ctx_get(hids, conn_handle, (void *)&rep_data);
-	if (err != NRF_SUCCESS) {
-		return err;
+	nrf_err = link_ctx_get(hids, conn_handle, (void *)&rep_data);
+	if (nrf_err) {
+		return nrf_err;
 	}
 
 	rep_data += sizeof(struct ble_hids_client_context) +

--- a/subsys/bluetooth/services/ble_lbs/lbs.c
+++ b/subsys/bluetooth/services/ble_lbs/lbs.c
@@ -52,7 +52,7 @@ void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs_instance)
 
 int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg)
 {
-	int err;
+	uint32_t nrf_err;
 	ble_uuid_t ble_uuid;
 	uint8_t initial_value = 0;
 
@@ -65,9 +65,9 @@ int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg)
 
 	ble_uuid128_t base_uuid = { .uuid128 = BLE_UUID_LBS_BASE };
 
-	err = sd_ble_uuid_vs_add(&base_uuid, &lbs->uuid_type);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add vendor UUID, nrf_error %#x", err);
+	nrf_err = sd_ble_uuid_vs_add(&base_uuid, &lbs->uuid_type);
+	if (nrf_err) {
+		LOG_ERR("Failed to add vendor UUID, nrf_error %#x", nrf_err);
 		return -EINVAL;
 	}
 
@@ -77,10 +77,10 @@ int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg)
 	};
 
 	/* Add service. */
-	err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid,
+	nrf_err = sd_ble_gatts_service_add(BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid,
 				       &lbs->service_handle);
-	if (err != NRF_SUCCESS) {
-		LOG_ERR("Failed to add GATT service, nrf_error %#x", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to add GATT service, nrf_error %#x", nrf_err);
 		return -EINVAL;
 	}
 
@@ -113,10 +113,10 @@ int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg)
 	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.read_perm);
 	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
 
-	err = sd_ble_gatts_characteristic_add(lbs->service_handle, &char_md, &attr_char_value,
+	nrf_err = sd_ble_gatts_characteristic_add(lbs->service_handle, &char_md, &attr_char_value,
 					      &lbs->button_char_handles);
-	if (err) {
-		LOG_ERR("Failed to add button GATT characteristic, nrf_error %#x", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to add button GATT characteristic, nrf_error %#x", nrf_err);
 		return -EINVAL;
 	}
 
@@ -145,10 +145,10 @@ int ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg)
 	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
 	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
 
-	err = sd_ble_gatts_characteristic_add(lbs->service_handle, &char_md, &attr_char_value,
+	nrf_err = sd_ble_gatts_characteristic_add(lbs->service_handle, &char_md, &attr_char_value,
 					      &lbs->led_char_handles);
-	if (err) {
-		LOG_ERR("Failed to add LED GATT characteristic, nrf_error %#x", err);
+	if (nrf_err) {
+		LOG_ERR("Failed to add LED GATT characteristic, nrf_error %#x", nrf_err);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
+++ b/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
@@ -291,6 +291,7 @@ int ble_mcumgr_data_send(uint8_t *data, uint16_t *len, struct ble_mcumgr_client_
 static int smp_ncs_bm_bt_tx_pkt(struct net_buf *nb)
 {
 	int rc;
+	uint32_t nrf_err;
 	struct ble_mcumgr_client_context *ctx;
 	uint16_t notification_size;
 	uint8_t *send_pos = nb->data;
@@ -301,9 +302,8 @@ static int smp_ncs_bm_bt_tx_pkt(struct net_buf *nb)
 	}
 
 	ctx = &contexts[0];
-	rc = ble_conn_params_att_mtu_get(conn_handle, &notification_size);
-
-	if (rc) {
+	nrf_err = ble_conn_params_att_mtu_get(conn_handle, &notification_size);
+	if (nrf_err) {
 		goto finish;
 	}
 

--- a/subsys/logging/backends/log_backend_bm_uarte.c
+++ b/subsys/logging/backends/log_backend_bm_uarte.c
@@ -28,7 +28,7 @@ ISR_DIRECT_DECLARE(log_backend_bm_uarte_direct_isr)
 
 static int uarte_init(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	nrfx_uarte_config_t uarte_config = NRFX_UARTE_DEFAULT_CONFIG(
 		BOARD_CONSOLE_UARTE_PIN_TX, NRF_UARTE_PSEL_DISCONNECTED);
@@ -54,9 +54,9 @@ static int uarte_init(void)
 
 	irq_enable(NRFX_IRQ_NUMBER_GET(NRF_UARTE_INST_GET(BOARD_CONSOLE_UARTE_INST)));
 
-	err = nrfx_uarte_init(&uarte_inst, &uarte_config, NULL);
-	if (err != NRFX_SUCCESS) {
-		return err;
+	nrfx_err = nrfx_uarte_init(&uarte_inst, &uarte_config, NULL);
+	if (nrfx_err != NRFX_SUCCESS) {
+		return nrfx_err;
 	}
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/src/bm_uart_mcumgr.c
+++ b/subsys/mgmt/mcumgr/transport/src/bm_uart_mcumgr.c
@@ -207,7 +207,7 @@ ISR_DIRECT_DECLARE(bm_uart_mcumgr_direct_isr)
  */
 static int bm_uarte_init(void)
 {
-	int err;
+	nrfx_err_t nrfx_err;
 
 	nrfx_uarte_config_t uarte_config = NRFX_UARTE_DEFAULT_CONFIG(BOARD_APP_UARTE_PIN_TX,
 								     BOARD_APP_UARTE_PIN_RX);
@@ -231,20 +231,20 @@ static int bm_uarte_init(void)
 
 	irq_enable(NRFX_IRQ_NUMBER_GET(NRF_UARTE_INST_GET(BOARD_APP_UARTE_INST)));
 
-	err = nrfx_uarte_init(&uarte_inst, &uarte_config, uarte_event_handler);
+	nrfx_err = nrfx_uarte_init(&uarte_inst, &uarte_config, uarte_event_handler);
 
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize UART, nrfx err %d", err);
-		return err;
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to initialize UART, nrfx_err %#x", nrfx_err);
+		return nrfx_err;
 	}
 
-	err = nrfx_uarte_rx(&uarte_inst, uarte_rx_buf, 1);
+	nrfx_err = nrfx_uarte_rx(&uarte_inst, uarte_rx_buf, 1);
 
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("UART RX failed, nrfx err %d", err);
+	if (nrfx_err != NRFX_SUCCESS) {
+		LOG_ERR("UART RX failed, nrfx_err %#x", nrfx_err);
 	}
 
-	return err;
+	return nrfx_err;
 }
 
 SYS_INIT(bm_uarte_init, APPLICATION, 0);

--- a/subsys/softdevice_handler/nrf_sdh_soc.c
+++ b/subsys/softdevice_handler/nrf_sdh_soc.c
@@ -45,15 +45,15 @@ static const char *tostr(uint32_t evt)
 
 static void softdevice_rng_seed(void)
 {
-	uint32_t err = NRF_ERROR_INVALID_DATA;
+	uint32_t nrf_err = NRF_ERROR_INVALID_DATA;
 	psa_status_t status;
 	uint8_t seed[SD_RAND_SEED_SIZE];
 
 	status = cracen_get_trng(seed, sizeof(seed));
 	if (status == PSA_SUCCESS) {
-		err = sd_rand_seed_set(seed);
+		nrf_err = sd_rand_seed_set(seed);
 		memset(seed, 0, sizeof(seed));
-		if (err == NRF_SUCCESS) {
+		if (nrf_err == NRF_SUCCESS) {
 			LOG_DBG("SoftDevice RNG seeded");
 			return;
 		}
@@ -61,17 +61,17 @@ static void softdevice_rng_seed(void)
 		LOG_ERR("Generate random failed, psa status %d", status);
 	}
 
-	LOG_ERR("Failed to seed SoftDevice RNG, nrf_error %#x", err);
+	LOG_ERR("Failed to seed SoftDevice RNG, nrf_error %#x", nrf_err);
 }
 
 static void soc_evt_poll(void *context)
 {
-	uint32_t err;
+	uint32_t nrf_err;
 	uint32_t evt_id;
 
 	while (true) {
-		err = sd_evt_get(&evt_id);
-		if (err != NRF_SUCCESS) {
+		nrf_err = sd_evt_get(&evt_id);
+		if (nrf_err) {
 			break;
 		}
 
@@ -92,8 +92,8 @@ static void soc_evt_poll(void *context)
 		}
 	}
 
-	__ASSERT(err == NRF_ERROR_NOT_FOUND,
-		 "Failed to receive SoftDevice event, nrf_error %#x", err);
+	__ASSERT(nrf_err == NRF_ERROR_NOT_FOUND,
+		 "Failed to receive SoftDevice event, nrf_error %#x", nrf_err);
 }
 
 /* Listen to SoftDevice events */

--- a/tests/lib/bluetooth/ble_adv/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_adv/src/unity_test.c
@@ -27,13 +27,13 @@ void test_ble_adv_conn_cfg_tag_set(void)
 {
 	struct ble_adv ble_adv;
 	uint8_t conn_cfg_tag = 1;
-	int ret;
+	uint32_t nrf_err;
 
-	ret = ble_adv_conn_cfg_tag_set(NULL, conn_cfg_tag);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_conn_cfg_tag_set(NULL, conn_cfg_tag);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_adv_conn_cfg_tag_set(&ble_adv, conn_cfg_tag);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_adv_conn_cfg_tag_set(&ble_adv, conn_cfg_tag);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(conn_cfg_tag, ble_adv.conn_cfg_tag);
 }
@@ -45,15 +45,15 @@ void test_ble_adv_init_error_null(void)
 		.conn_cfg_tag = 1,
 		.evt_handler = ble_adv_evt_handler,
 	};
-	int ret;
+	uint32_t nrf_err;
 
-	ret = ble_adv_init(NULL, &config);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
-	ret = ble_adv_init(&ble_adv, NULL);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_init(NULL, &config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
+	nrf_err = ble_adv_init(&ble_adv, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 	config.evt_handler = NULL;
-	ret = ble_adv_init(&ble_adv, &config);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_init(&ble_adv, &config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
 void test_ble_adv_init_error_invalid_param(void)
@@ -66,29 +66,32 @@ void test_ble_adv_init_error_invalid_param(void)
 		.evt_handler = ble_adv_evt_handler,
 	};
 	ble_gap_conn_sec_mode_t sec_mode = {0};
-	int ret;
+	uint32_t nrf_err;
 
 	BLE_GAP_CONN_SEC_MODE_SET_OPEN(&sec_mode);
 
 	/* Simulate an error in setting the device name */
 	__cmock_sd_ble_gap_device_name_set_ExpectAndReturn(&sec_mode, CONFIG_BLE_ADV_NAME,
-		strlen(CONFIG_BLE_ADV_NAME), NRF_ERROR_INVALID_ADDR);
-	ret = ble_adv_init(&ble_adv, &config);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, ret);
+							   strlen(CONFIG_BLE_ADV_NAME),
+							   NRF_ERROR_INVALID_ADDR);
+	nrf_err = ble_adv_init(&ble_adv, &config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	/* Simulate an error in setting the adv config */
 	__cmock_sd_ble_gap_device_name_set_ExpectAndReturn(&sec_mode, CONFIG_BLE_ADV_NAME,
-	strlen(CONFIG_BLE_ADV_NAME), NRF_SUCCESS);
+							   strlen(CONFIG_BLE_ADV_NAME),
+							   NRF_SUCCESS);
 	__cmock_sd_ble_gap_adv_set_configure_ExpectAndReturn(&ble_adv.adv_handle,
-		NULL, &ble_adv.adv_params, NRF_ERROR_INVALID_ADDR);
-	ret = ble_adv_init(&ble_adv, &config);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, ret);
+							     NULL, &ble_adv.adv_params,
+							     NRF_ERROR_INVALID_ADDR);
+	nrf_err = ble_adv_init(&ble_adv, &config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
 void test_ble_adv_init(void)
 {
 	uint8_t conn_cfg_tag = 1;
-	int ret;
+	uint32_t nrf_err;
 	struct ble_adv ble_adv = {
 		.adv_handle = BLE_GAP_ADV_SET_HANDLE_NOT_SET,
 	};
@@ -101,8 +104,8 @@ void test_ble_adv_init(void)
 	__cmock_sd_ble_gap_device_name_set_IgnoreAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gap_adv_set_configure_IgnoreAndReturn(NRF_SUCCESS);
 
-	ret = ble_adv_init(&ble_adv, &config);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_adv_init(&ble_adv, &config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_TRUE(ble_adv.mode_current == BLE_ADV_MODE_IDLE);
 	TEST_ASSERT_TRUE(ble_adv.conn_cfg_tag == conn_cfg_tag);
 	TEST_ASSERT_TRUE(ble_adv.conn_handle == BLE_CONN_HANDLE_INVALID);
@@ -123,16 +126,16 @@ void test_ble_adv_peer_addr_reply(void)
 		.peer_addr_reply_expected = true,
 	};
 	ble_gap_addr_t peer_addr = {0};
-	int ret;
+	uint32_t nrf_err;
 
-	ret = ble_adv_peer_addr_reply(NULL, &peer_addr);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_peer_addr_reply(NULL, &peer_addr);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_adv_peer_addr_reply(&ble_adv, NULL);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_peer_addr_reply(&ble_adv, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_adv_peer_addr_reply(&ble_adv, &peer_addr);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, ret);
+	nrf_err = ble_adv_peer_addr_reply(&ble_adv, &peer_addr);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	peer_addr = (ble_gap_addr_t){
 		.addr_id_peer = 0,
@@ -140,8 +143,8 @@ void test_ble_adv_peer_addr_reply(void)
 		.addr = {0x01, 0x02, 0x03, 0x00, 0x05, 0x06}
 	};
 
-	ret = ble_adv_peer_addr_reply(&ble_adv, &peer_addr);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_adv_peer_addr_reply(&ble_adv, &peer_addr);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_TRUE(ble_adv.peer_addr_reply_expected == false);
 	TEST_ASSERT_TRUE(ble_adv.peer_address.addr_type == peer_addr.addr_type);
 	TEST_ASSERT_TRUE(
@@ -152,29 +155,29 @@ void test_ble_adv_peer_addr_reply(void)
 void test_ble_adv_whitelist_reply(void)
 {
 	struct ble_adv ble_adv_config = {0};
-	int ret;
+	uint32_t nrf_err;
 	const ble_gap_addr_t addrs = {0};
 	const ble_gap_irk_t irks = {0};
 
-	ret = ble_adv_whitelist_reply(NULL, &addrs, 0, &irks, 0);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, ret);
+	nrf_err = ble_adv_whitelist_reply(NULL, &addrs, 0, &irks, 0);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 0, &irks, 0);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, ret);
+	nrf_err = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 0, &irks, 0);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 
 	ble_adv_config.whitelist_reply_expected = NULL;
-	ret = ble_adv_whitelist_reply(&ble_adv_config, NULL, 0, NULL, 0);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, ret);
+	nrf_err = ble_adv_whitelist_reply(&ble_adv_config, NULL, 0, NULL, 0);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 
 	ble_adv_config.whitelist_reply_expected = true;
-	ret = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 0, &irks, 0);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 0, &irks, 0);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_TRUE(ble_adv_config.whitelist_reply_expected == false);
 	TEST_ASSERT_TRUE(ble_adv_config.whitelist_in_use == false);
 
 	ble_adv_config.whitelist_reply_expected = true;
-	ret = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 1, &irks, 0);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_adv_whitelist_reply(&ble_adv_config, &addrs, 1, &irks, 0);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_TRUE(ble_adv_config.whitelist_reply_expected == false);
 	TEST_ASSERT_TRUE(ble_adv_config.whitelist_in_use == true);
 }
@@ -202,7 +205,7 @@ void test_ble_adv_start(void)
 		CONFIG_BLE_ADV_DIRECTED_ADVERTISING_INTERVAL,
 		CONFIG_BLE_ADV_FAST_ADVERTISING_INTERVAL,
 		CONFIG_BLE_ADV_SLOW_ADVERTISING_INTERVAL, 0};
-	int ret;
+	uint32_t nrf_err;
 
 	/* Verifying the different adv modes in the ble_adv_mode array */
 	for (int i = 0; i < MAX_ADV_MODES; i++) {
@@ -214,8 +217,8 @@ void test_ble_adv_start(void)
 		__cmock_sd_ble_gap_adv_set_configure_IgnoreAndReturn(NRF_SUCCESS);
 		__cmock_sd_ble_gap_adv_start_IgnoreAndReturn(NRF_SUCCESS);
 
-		ret = ble_adv_start(&ble_adv, mode[i]);
-		TEST_ASSERT_EQUAL(0, ret);
+		nrf_err = ble_adv_start(&ble_adv, mode[i]);
+		TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 		TEST_ASSERT_TRUE(ble_adv.mode_current == mode[i]);
 		TEST_ASSERT_TRUE(ble_adv.whitelist_in_use == false);
 		TEST_ASSERT_TRUE(ble_adv.adv_params.primary_phy == CONFIG_BLE_ADV_PRIMARY_PHY);
@@ -255,16 +258,16 @@ void test_ble_adv_start_error_invalid_param(void)
 		.evt_handler = ble_adv_evt_handler,
 		.whitelist_temporarily_disabled = false,
 	};
-	int ret;
+	uint32_t nrf_err;
 
 	__cmock_sd_ble_gap_adv_set_configure_IgnoreAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_adv_start(&ble_adv, BLE_ADV_MODE_SLOW);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, ret);
+	nrf_err = ble_adv_start(&ble_adv, BLE_ADV_MODE_SLOW);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_gap_adv_set_configure_IgnoreAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gap_adv_start_IgnoreAndReturn(NRF_ERROR_INVALID_STATE);
-	ret = ble_adv_start(&ble_adv, BLE_ADV_MODE_SLOW);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, ret);
+	nrf_err = ble_adv_start(&ble_adv, BLE_ADV_MODE_SLOW);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
 void setUp(void)

--- a/tests/lib/bluetooth/ble_qwr/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_qwr/src/unity_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <errno.h>
+#include <nrf_error.h>
 #include <unity.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -20,36 +20,36 @@ static uint16_t ble_qwr_evt_handler(struct ble_qwr *qwr, const struct ble_qwr_ev
 	return 0;
 }
 
-void test_ble_qwr_init_efault(void)
+void test_ble_qwr_init_error_null(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {0};
 
-	err = ble_qwr_init(&qwr, NULL);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_init(&qwr, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	err = ble_qwr_init(NULL, &qwr_config);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_init(NULL, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_qwr_init_eperm(void)
+void test_ble_qwr_init_error_invalid_state(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {0};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* Second attempt should fail */
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(-EPERM, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_qwr_init(void)
 {
-	int err;
+	uint32_t nrf_err;
 	uint8_t mem[10];
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {
@@ -60,8 +60,8 @@ void test_ble_qwr_init(void)
 		.evt_handler = ble_qwr_evt_handler,
 	};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_HANDLE_INVALID, qwr.conn_handle);
 	TEST_ASSERT_EQUAL(0, qwr.nb_registered_attr);
@@ -74,26 +74,26 @@ void test_ble_qwr_init(void)
 	TEST_ASSERT_EQUAL_PTR(ble_qwr_evt_handler, qwr.evt_handler);
 }
 
-void test_ble_qwr_attr_register_efault(void)
+void test_ble_qwr_attr_register_error_null(void)
 {
-	int err;
+	uint32_t nrf_err;
 
-	err = ble_qwr_attr_register(NULL, 1);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_attr_register(NULL, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_qwr_attr_register_eperm(void)
+void test_ble_qwr_attr_register_error_invalid_state(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 
-	err = ble_qwr_attr_register(&qwr, 1);
-	TEST_ASSERT_EQUAL(-EPERM, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
-void test_ble_qwr_attr_register_einval(void)
+void test_ble_qwr_attr_register_error_invalid_param(void)
 {
-	int err;
+	uint32_t nrf_err;
 	uint8_t mem[10];
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {
@@ -104,16 +104,16 @@ void test_ble_qwr_attr_register_einval(void)
 		.evt_handler = ble_qwr_evt_handler,
 	};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, BLE_GATT_HANDLE_INVALID);
-	TEST_ASSERT_EQUAL(-EINVAL, err);
+	nrf_err = ble_qwr_attr_register(&qwr, BLE_GATT_HANDLE_INVALID);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_qwr_attr_register_enomem(void)
+void test_ble_qwr_attr_register_error_no_mem(void)
 {
-	int err;
+	uint32_t nrf_err;
 	uint8_t mem[10];
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {
@@ -127,11 +127,11 @@ void test_ble_qwr_attr_register_enomem(void)
 	qwr_config.mem_buffer.p_mem = NULL;
 	qwr_config.mem_buffer.len = sizeof(mem);
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 1);
-	TEST_ASSERT_EQUAL(-ENOMEM, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, nrf_err);
 
 	/* Reset qwr so it can be initialized again */
 	qwr.initialized = 0;
@@ -139,11 +139,11 @@ void test_ble_qwr_attr_register_enomem(void)
 	qwr_config.mem_buffer.p_mem = mem;
 	qwr_config.mem_buffer.len = 0;
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 1);
-	TEST_ASSERT_EQUAL(-ENOMEM, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, nrf_err);
 
 	/* Reset qwr so it can be initialized again */
 	qwr.initialized = 0;
@@ -151,22 +151,22 @@ void test_ble_qwr_attr_register_enomem(void)
 	qwr_config.mem_buffer.p_mem = mem;
 	qwr_config.mem_buffer.len = sizeof(mem);
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 1);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 1);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 2);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 2);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 3);
-	TEST_ASSERT_EQUAL(-ENOMEM, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 3);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, nrf_err);
 }
 
 void test_ble_qwr_attr_register(void)
 {
-	int err;
+	uint32_t nrf_err;
 	uint8_t mem[10];
 	struct ble_qwr qwr;
 	struct ble_qwr_config qwr_config = {
@@ -177,51 +177,51 @@ void test_ble_qwr_attr_register(void)
 		.evt_handler = ble_qwr_evt_handler,
 	};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_attr_register(&qwr, 0xa1);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 0xa1);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(1, qwr.nb_registered_attr);
 	TEST_ASSERT_EQUAL(0xa1, qwr.attr_handles[0]);
 
-	err = ble_qwr_attr_register(&qwr, 0xa2);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_attr_register(&qwr, 0xa2);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(2, qwr.nb_registered_attr);
 	TEST_ASSERT_EQUAL(0xa2, qwr.attr_handles[1]);
 }
 
-void test_ble_qwr_value_get_efault(void)
+void test_ble_qwr_value_get_error_null(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr;
 	uint8_t mem[1];
 	uint16_t len = sizeof(mem);
 
-	err = ble_qwr_value_get(NULL, 1, mem, &len);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_value_get(NULL, 1, mem, &len);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	err = ble_qwr_value_get(&qwr, 1, NULL, &len);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_value_get(&qwr, 1, NULL, &len);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	err = ble_qwr_value_get(&qwr, 1, mem, NULL);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_value_get(&qwr, 1, mem, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_qwr_value_get_eperm(void)
+void test_ble_qwr_value_get_error_invalid_state(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 	uint8_t mem[1];
 	uint16_t len = sizeof(mem);
 
-	err = ble_qwr_value_get(&qwr, 1, mem, &len);
-	TEST_ASSERT_EQUAL(-EPERM, err);
+	nrf_err = ble_qwr_value_get(&qwr, 1, mem, &len);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_qwr_value_get(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 	/* mem is filled by softdevice, we do it here */
 	uint8_t mem[] = {
@@ -256,44 +256,44 @@ void test_ble_qwr_value_get(void)
 		0x15, 0x16,
 	};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_value_get(&qwr, 0xa1, buf, &buf_len);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_value_get(&qwr, 0xa1, buf, &buf_len);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(12, buf_len);
 	TEST_ASSERT_EQUAL_MEMORY(attr1_expected_val, buf, sizeof(attr1_expected_val));
 
-	err = ble_qwr_value_get(&qwr, 0xa2, buf, &buf_len);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_value_get(&qwr, 0xa2, buf, &buf_len);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(6, buf_len);
 	TEST_ASSERT_EQUAL_MEMORY(attr2_expected_val, buf, sizeof(attr2_expected_val));
 
-	err = ble_qwr_value_get(&qwr, 0xa3, buf, &buf_len);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_value_get(&qwr, 0xa3, buf, &buf_len);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(0, buf_len);
 }
 
-void test_ble_qwr_conn_handle_assign_efault(void)
+void test_ble_qwr_conn_handle_assign_error_null(void)
 {
-	int err;
+	uint32_t nrf_err;
 
-	err = ble_qwr_conn_handle_assign(NULL, 1);
-	TEST_ASSERT_EQUAL(-EFAULT, err);
+	nrf_err = ble_qwr_conn_handle_assign(NULL, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_qwr_conn_handle_assign_eperm(void)
+void test_ble_qwr_conn_handle_assign_error_invalid_state(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 
-	err = ble_qwr_conn_handle_assign(&qwr, 1);
-	TEST_ASSERT_EQUAL(-EPERM, err);
+	nrf_err = ble_qwr_conn_handle_assign(&qwr, 1);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_qwr_conn_handle_assign(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 	uint8_t mem[1];
 	struct ble_qwr_config qwr_config = {
@@ -304,11 +304,11 @@ void test_ble_qwr_conn_handle_assign(void)
 		.evt_handler = ble_qwr_evt_handler,
 	};
 
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(0xC044, qwr.conn_handle);
 }
@@ -326,7 +326,7 @@ void test_ble_qwr_on_ble_evt_do_nothing(void)
 
 void test_ble_qwr_on_ble_evt_mem_req_sd_busy(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 	uint8_t mem[16];
 	struct ble_qwr_config qwr_config = {
@@ -362,11 +362,11 @@ void test_ble_qwr_on_ble_evt_mem_req_sd_busy(void)
 	};
 
 	/* Initialize qwr */
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_sd_ble_user_mem_reply_ExpectAndReturn(0xC044, &qwr.mem_buffer, NRF_ERROR_BUSY);
 	ble_qwr_on_ble_evt(&ble_evt_mem_req, &qwr);
@@ -378,7 +378,7 @@ void test_ble_qwr_on_ble_evt_mem_req_sd_busy(void)
 
 void test_ble_qwr_on_ble_evt_mem_req(void)
 {
-	int err;
+	uint32_t nrf_err;
 	struct ble_qwr qwr = {0};
 	uint8_t mem[16];
 	struct ble_qwr_config qwr_config = {
@@ -414,11 +414,11 @@ void test_ble_qwr_on_ble_evt_mem_req(void)
 	};
 
 	/* Initialize qwr */
-	err = ble_qwr_init(&qwr, &qwr_config);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_init(&qwr, &qwr_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
-	TEST_ASSERT_EQUAL(0, err);
+	nrf_err = ble_qwr_conn_handle_assign(&qwr, 0xC044);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_sd_ble_user_mem_reply_ExpectAndReturn(0xC044, &qwr.mem_buffer, NRF_SUCCESS);
 	ble_qwr_on_ble_evt(&ble_evt_mem_req, &qwr);

--- a/tests/lib/bluetooth/ble_racp/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_racp/src/unity_test.c
@@ -4,42 +4,36 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <errno.h>
+#include <nrf_error.h>
 #include <unity.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <bm/bluetooth/ble_racp.h>
 
-void test_ble_racp_encode_efault(void)
-{
-	int ret;
-	const struct ble_racp_value racp_val = {0};
-	uint8_t data[5];
-
-	ret = ble_racp_encode(NULL, data, sizeof(data));
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
-
-	ret = ble_racp_encode(&racp_val, NULL, 0);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
-}
-
-void test_ble_racp_encode_einval(void)
+void test_ble_racp_encode_error_invalid(void)
 {
 	int ret;
 	struct ble_racp_value racp_val = {0};
 	uint8_t data[5];
 
+	ret = ble_racp_encode(NULL, data, sizeof(data));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = ble_racp_encode(&racp_val, NULL, 0);
+	TEST_ASSERT_EQUAL(0, ret);
+
 	ret = ble_racp_encode(&racp_val, data, 0);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, ret);
 
 	ret = ble_racp_encode(&racp_val, data, 1);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, ret);
 
 	racp_val.operand_len = 1;
 
 	ret = ble_racp_encode(&racp_val, data, 2);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, ret);
 }
+
 
 void test_ble_racp_encode(void)
 {
@@ -64,29 +58,29 @@ void test_ble_racp_encode(void)
 	TEST_ASSERT_EQUAL_MEMORY(data_expected, data, sizeof(data));
 }
 
-void test_ble_racp_decode_efault(void)
+void test_ble_racp_decode_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_racp_value racp_val = {0};
 	uint8_t data[5];
 
-	ret = ble_racp_decode(NULL, 0, &racp_val);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_racp_decode(NULL, 0, &racp_val);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_racp_decode(data, sizeof(data), NULL);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_racp_decode(data, sizeof(data), NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
 void test_ble_racp_decode(void)
 {
-	int ret;
+	uint32_t nrf_err;
 
 	uint8_t data[] = {RACP_OPCODE_REPORT_RECS, RACP_OPERATOR_LESS_OR_EQUAL, 3, 4, 5};
 
 	struct ble_racp_value racp_val;
 
-	ret = ble_racp_decode(data, sizeof(data), &racp_val);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_racp_decode(data, sizeof(data), &racp_val);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(RACP_OPCODE_REPORT_RECS, racp_val.opcode);
 	TEST_ASSERT_EQUAL(RACP_OPERATOR_LESS_OR_EQUAL, racp_val.operator);
@@ -95,8 +89,8 @@ void test_ble_racp_decode(void)
 
 	uint8_t empty[] = {0};
 
-	ret = ble_racp_decode(empty, 0, &racp_val);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_racp_decode(empty, 0, &racp_val);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(0xFF, racp_val.opcode);
 	TEST_ASSERT_EQUAL(0xFF, racp_val.operator);
@@ -105,8 +99,8 @@ void test_ble_racp_decode(void)
 
 	uint8_t opcode[] = {RACP_OPCODE_DELETE_RECS};
 
-	ret = ble_racp_decode(opcode, sizeof(opcode), &racp_val);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_racp_decode(opcode, sizeof(opcode), &racp_val);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(RACP_OPCODE_DELETE_RECS, racp_val.opcode);
 	TEST_ASSERT_EQUAL(0xFF, racp_val.operator);
@@ -115,8 +109,8 @@ void test_ble_racp_decode(void)
 
 	uint8_t opcode_operator[] = {RACP_OPCODE_DELETE_RECS, RACP_OPERATOR_RANGE};
 
-	ret = ble_racp_decode(opcode_operator, sizeof(opcode_operator), &racp_val);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_racp_decode(opcode_operator, sizeof(opcode_operator), &racp_val);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(RACP_OPCODE_DELETE_RECS, racp_val.opcode);
 	TEST_ASSERT_EQUAL(RACP_OPERATOR_RANGE, racp_val.operator);
@@ -125,8 +119,8 @@ void test_ble_racp_decode(void)
 
 	uint8_t opcode_operator_data[] = {RACP_OPCODE_DELETE_RECS, RACP_OPERATOR_RANGE, 0xA};
 
-	ret = ble_racp_decode(opcode_operator_data, sizeof(opcode_operator_data), &racp_val);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_racp_decode(opcode_operator_data, sizeof(opcode_operator_data), &racp_val);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	TEST_ASSERT_EQUAL(RACP_OPCODE_DELETE_RECS, racp_val.opcode);
 	TEST_ASSERT_EQUAL(RACP_OPERATOR_RANGE, racp_val.operator);

--- a/tests/subsys/bluetooth/services/ble_bas/src/unity_test.c
+++ b/tests/subsys/bluetooth/services/ble_bas/src/unity_test.c
@@ -179,14 +179,14 @@ static void ble_bas_evt_handler_notif_disable(struct ble_bas *bas, const struct 
 
 void bas_init(const struct ble_bas_config *cfg)
 {
-	int ret;
+	uint32_t nrf_err;
 
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add_success);
 	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_sd_ble_gatts_characteristic_add_success);
 	__cmock_sd_ble_gatts_descriptor_add_Stub(stub_sd_ble_gatts_descriptor_add_success);
 
-	ret = ble_bas_init(&ble_bas, cfg);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_init(&ble_bas, cfg);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void test_ble_bas_on_ble_evt(void)
@@ -231,46 +231,46 @@ void test_ble_bas_on_ble_evt(void)
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
 
-void test_ble_bas_init_efault(void)
+void test_ble_bas_init_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_bas_config bas_config = { .evt_handler = ble_bas_evt_handler };
 
-	ret = ble_bas_init(NULL, &bas_config);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_bas_init(NULL, &bas_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 	TEST_ASSERT_NOT_EQUAL(bas_config.evt_handler, ble_bas.evt_handler);
 
-	ret = ble_bas_init(&ble_bas, NULL);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_bas_init(&ble_bas, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 	TEST_ASSERT_NOT_EQUAL(bas_config.evt_handler, ble_bas.evt_handler);
 }
 
-void test_ble_bas_init_einval(void)
+void test_ble_bas_init_error_invalid_param(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_bas_config bas_config = { .evt_handler = ble_bas_evt_handler };
 
 	bas_config.report_ref = (void *)&report_ref;
 
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_bas_init(&ble_bas, &bas_config);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_bas_init(&ble_bas, &bas_config);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_descriptor_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_bas_init(&ble_bas, &bas_config);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_init(&ble_bas, &bas_config);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
 void test_ble_bas_init_success(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
 	bas_cfg.evt_handler = ble_bas_evt_handler;
@@ -280,25 +280,25 @@ void test_ble_bas_init_success(void)
 	__cmock_sd_ble_gatts_descriptor_add_Stub(stub_sd_ble_gatts_descriptor_add_success);
 	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_param_check);
 
-	ret = ble_bas_init(&ble_bas, &bas_cfg);
-	TEST_ASSERT_EQUAL(0, ret);
-	ret = ble_bas_battery_level_notify(&ble_bas, SERVICE_HANDLE);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_init(&ble_bas, &bas_cfg);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, SERVICE_HANDLE);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(1, hvx_stub_called);
 }
 
-void test_ble_bas_battery_level_update_efault(void)
+void test_ble_bas_battery_level_update_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 
-	ret = ble_bas_battery_level_update(NULL, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_bas_battery_level_update(NULL, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_bas_battery_level_update_einval(void)
+void test_ble_bas_battery_level_update_error_invalid_param(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
@@ -306,20 +306,20 @@ void test_ble_bas_battery_level_update_einval(void)
 	bas_cfg.can_notify = false;
 	bas_init(&bas_cfg);
 	__cmock_sd_ble_gatts_value_set_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	bas_cfg.can_notify = true;
 	bas_init(&bas_cfg);
 	__cmock_sd_ble_gatts_value_set_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_TIMEOUT);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_bas_battery_level_update_enotconn(void)
+void test_ble_bas_battery_level_update_error_not_found(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
@@ -329,13 +329,13 @@ void test_ble_bas_battery_level_update_enotconn(void)
 
 	__cmock_sd_ble_gatts_value_set_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(BLE_ERROR_INVALID_CONN_HANDLE);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(-ENOTCONN, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NOT_FOUND, nrf_err);
 }
 
-void test_ble_bas_battery_level_update_epipe(void)
+void test_ble_bas_battery_level_update_error_invalid_state(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
@@ -344,13 +344,13 @@ void test_ble_bas_battery_level_update_epipe(void)
 	bas_init(&bas_cfg);
 	__cmock_sd_ble_gatts_value_set_Stub(stub_sd_ble_gatts_value_set_check);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_STATE);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(-EPIPE, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_bas_battery_level_update_success(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
@@ -358,82 +358,82 @@ void test_ble_bas_battery_level_update_success(void)
 	bas_init(&bas_cfg);
 
 	/* Battery level hasn't changed 'Nothing to do' */
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* Change battery level, and ble_bas should update but not notify */
 	battery_level = 42;
 	__cmock_sd_ble_gatts_value_set_Stub(stub_sd_ble_gatts_value_set_check);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* Change battery level, and ble_bas should update and notify */
 	battery_level = 84;
 	bas_cfg.can_notify = true;
 	bas_init(&bas_cfg);
 	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_param_check);
-	ret = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL(1, hvx_stub_called);
 }
 
-void test_ble_bas_battery_level_notify_efault(void)
+void test_ble_bas_battery_level_notify_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 
-	ret = ble_bas_battery_level_notify(NULL, conn_handle);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_bas_battery_level_notify(NULL, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_bas_battery_level_notify_einval(void)
+void test_ble_bas_battery_level_notify_error_invalid_param(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
 	bas_cfg.can_notify = false;
 	bas_init(&bas_cfg);
 
-	ret = ble_bas_battery_level_notify(&ble_bas, conn_handle);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	bas_cfg.can_notify = true;
 	bas_init(&bas_cfg);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_TIMEOUT);
-	ret = ble_bas_battery_level_notify(&ble_bas, conn_handle);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_bas_battery_level_notify_enotconn(void)
+void test_ble_bas_battery_level_notify_error_not_found(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
 	bas_init(&bas_cfg);
 
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(BLE_ERROR_INVALID_CONN_HANDLE);
-	ret = ble_bas_battery_level_notify(&ble_bas, conn_handle);
-	TEST_ASSERT_EQUAL(-ENOTCONN, ret);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NOT_FOUND, nrf_err);
 }
 
-void test_ble_bas_battery_level_notify_epipe(void)
+void test_ble_bas_battery_level_notify_error_invalid_state(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
 	bas_init(&bas_cfg);
 
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_STATE);
-	ret = ble_bas_battery_level_notify(&ble_bas, conn_handle);
-	TEST_ASSERT_EQUAL(-EPIPE, ret);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_bas_battery_level_notify_success(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint16_t conn_handle = 0x0001;
 	struct ble_bas_config bas_cfg = bas_cfg_template;
 
@@ -441,8 +441,8 @@ void test_ble_bas_battery_level_notify_success(void)
 
 	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_param_check);
 
-	ret = ble_bas_battery_level_notify(&ble_bas, conn_handle);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_bas_battery_level_notify(&ble_bas, conn_handle);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void setUp(void)

--- a/tests/subsys/bluetooth/services/ble_dis/src/unity_test.c
+++ b/tests/subsys/bluetooth/services/ble_dis/src/unity_test.c
@@ -148,32 +148,32 @@ uint32_t stub_sd_ble_gatts_characteristic_add(
 	return NRF_SUCCESS;
 }
 
-void test_ble_dis_init_einval(void)
+void test_ble_dis_init_error_invalid_param(void)
 {
-	int err;
+	uint32_t nrf_err;
 
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add_invalid_param);
 
-	err = ble_dis_init();
-	TEST_ASSERT_EQUAL(-EINVAL, err);
+	nrf_err = ble_dis_init();
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
 	__cmock_sd_ble_gatts_characteristic_add_Stub(
 		stub_sd_ble_gatts_characteristic_add_invalid_param);
 
-	err = ble_dis_init();
-	TEST_ASSERT_EQUAL(-EINVAL, err);
+	nrf_err = ble_dis_init();
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
 void test_ble_dis_init(void)
 {
-	int err;
+	uint32_t nrf_err;
 
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
 	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_sd_ble_gatts_characteristic_add);
 
-	err = ble_dis_init();
-	TEST_ASSERT_EQUAL(NRF_SUCCESS, err);
+	nrf_err = ble_dis_init();
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 extern int unity_main(void);

--- a/tests/subsys/bluetooth/services/ble_nus/src/unity_test.c
+++ b/tests/subsys/bluetooth/services/ble_nus/src/unity_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <errno.h>
+#include <nrf_error.h>
 #include <unity.h>
 #include <stdint.h>
 #include <string.h>
@@ -131,7 +131,7 @@ static void ble_nus_evt_handler_on_hvx_tx_complete(const struct ble_nus_evt *evt
 
 static void nus_init(struct ble_nus_config *nus_cfg)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint8_t expected_uuid_type = 123;
 
 	__cmock_sd_ble_uuid_vs_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
@@ -139,8 +139,8 @@ static void nus_init(struct ble_nus_config *nus_cfg)
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
 	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_sd_ble_gatts_characteristic_add);
 
-	ret = ble_nus_init(&ble_nus, nus_cfg);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_nus_init(&ble_nus, nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL_PTR(nus_cfg->evt_handler, ble_nus.evt_handler);
 }
 
@@ -159,49 +159,49 @@ static void setup_with_notif_enabled(uint16_t conn_handle)
 	TEST_ASSERT_TRUE(evt_handler_called);
 }
 
-void test_ble_nus_init_efault(void)
+void test_ble_nus_init_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_nus_config nus_cfg = {0};
 
-	ret = ble_nus_init(NULL, &nus_cfg);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_init(NULL, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_nus_init(&ble_nus, NULL);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_init(&ble_nus, NULL);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_nus_init_einval(void)
+void test_ble_nus_init_error_invalid_param(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_nus_config nus_cfg = {0};
 
 	__cmock_sd_ble_uuid_vs_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_nus_init(&ble_nus, &nus_cfg);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_uuid_vs_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_nus_init(&ble_nus, &nus_cfg);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_uuid_vs_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_nus_init(&ble_nus, &nus_cfg);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	__cmock_sd_ble_uuid_vs_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_nus_init(&ble_nus, &nus_cfg);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
 void test_ble_nus_init_success(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	struct ble_nus_config nus_cfg = {0};
 	uint8_t expected_uuid_type = 123;
 
@@ -211,7 +211,8 @@ void test_ble_nus_init_success(void)
 	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
 	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_sd_ble_gatts_characteristic_add);
 
-	ret = ble_nus_init(&ble_nus, &nus_cfg);
+	nrf_err = ble_nus_init(&ble_nus, &nus_cfg);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void test_ble_nus_on_ble_evt_gap_evt_do_nothing(void)
@@ -321,6 +322,7 @@ void test_ble_nus_on_ble_evt_gap_evt_on_write(void)
 	TEST_ASSERT_TRUE(evt_handler_called);
 
 	evt_handler_called = false;
+	ble_nus.evt_handler = ble_nus_evt_handler_on_write_indica;
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, -1);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
@@ -371,28 +373,28 @@ void test_ble_nus_on_hvx_tx_complete(void)
 	TEST_ASSERT_TRUE(evt_handler_called);
 }
 
-void test_ble_nus_data_send_efault(void)
+void test_ble_nus_data_send_error_null(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint8_t data[2];
 	uint16_t length = sizeof(data);
 
-	ret = ble_nus_data_send(NULL, NULL, NULL, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_data_send(NULL, NULL, NULL, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_nus_data_send(&ble_nus, data, NULL, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, NULL, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_nus_data_send(&ble_nus, NULL, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, NULL, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	ret = ble_nus_data_send(NULL, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EFAULT, ret);
+	nrf_err = ble_nus_data_send(NULL, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_nus_data_send_einval(void)
+void test_ble_nus_data_send_error_invalid_param(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint8_t data[2];
 	uint16_t length = sizeof(data);
 	ble_evt_t ble_evt = {
@@ -419,34 +421,20 @@ void test_ble_nus_data_send_einval(void)
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 	TEST_ASSERT_TRUE(evt_handler_called);
 
-	/* Test for -EINVAL */
+	/* Test for invalid parameter */
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 
 	length = (BLE_NUS_MAX_DATA_LEN + 1);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_nus_data_send_enoent(void)
+
+void test_ble_nus_data_send_error_invalid_param_hvx(void)
 {
-	int ret;
-	uint8_t data[2];
-	uint16_t length = sizeof(data);
-	uint16_t conn_handle_inval = BLE_CONN_HANDLE_INVALID;
-
-	ret = ble_nus_data_send(&ble_nus, data, &length, conn_handle_inval);
-	TEST_ASSERT_EQUAL(-ENOENT, ret);
-
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, -1);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-ENOENT, ret);
-}
-
-void test_ble_nus_data_send_eio(void)
-{
-	int ret;
+	uint32_t nrf_err;
 	uint8_t data[2];
 	uint16_t length = sizeof(data);
 	struct ble_nus_config nus_cfg = { .evt_handler = ble_nus_evt_handler_on_connect };
@@ -456,13 +444,28 @@ void test_ble_nus_data_send_eio(void)
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EIO, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_nus_data_send_enotconn(void)
+void test_ble_nus_data_send_error_not_found(void)
 {
-	int ret;
+	uint32_t nrf_err;
+	uint8_t data[2];
+	uint16_t length = sizeof(data);
+	uint16_t conn_handle_inval = BLE_CONN_HANDLE_INVALID;
+
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, conn_handle_inval);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NOT_FOUND, nrf_err);
+
+	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, -1);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NOT_FOUND, nrf_err);
+}
+
+void test_ble_nus_data_send_error_invalid_conn_handle(void)
+{
+	uint32_t nrf_err;
 	uint8_t data[2];
 	uint16_t length = sizeof(data);
 	struct ble_nus_config nus_cfg = { .evt_handler = ble_nus_evt_handler_on_connect };
@@ -472,13 +475,13 @@ void test_ble_nus_data_send_enotconn(void)
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(BLE_ERROR_INVALID_CONN_HANDLE);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-ENOTCONN, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(BLE_ERROR_INVALID_CONN_HANDLE, nrf_err);
 }
 
-void test_ble_nus_data_send_epipe(void)
+void test_ble_nus_data_send_error_invalid_state(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint8_t data[2];
 	uint16_t length = sizeof(data);
 	struct ble_nus_config nus_cfg = { .evt_handler = ble_nus_evt_handler_on_connect };
@@ -488,45 +491,13 @@ void test_ble_nus_data_send_epipe(void)
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_STATE);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EPIPE, ret);
-}
-
-void test_ble_nus_data_send_ebadf(void)
-{
-	int ret;
-	uint8_t data[2];
-	uint16_t length = sizeof(data);
-	struct ble_nus_config nus_cfg = { .evt_handler = ble_nus_evt_handler_on_connect };
-
-	nus_init(&nus_cfg);
-	setup_with_notif_enabled(test_case_conn_handle);
-
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
-	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_NOT_FOUND);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EBADF, ret);
-}
-
-void test_ble_nus_data_send_eagain(void)
-{
-	int ret;
-	uint8_t data[2];
-	uint16_t length = sizeof(data);
-	struct ble_nus_config nus_cfg = { .evt_handler = ble_nus_evt_handler_on_connect };
-
-	nus_init(&nus_cfg);
-	setup_with_notif_enabled(test_case_conn_handle);
-
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
-	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(NRF_ERROR_RESOURCES);
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(-EAGAIN, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_nus_data_send_success(void)
 {
-	int ret;
+	uint32_t nrf_err;
 	uint8_t data[2] = {0x01, 0x02};
 	uint16_t length = sizeof(data);
 	ble_gatts_hvx_params_t expected_hvx_params = {
@@ -543,8 +514,8 @@ void test_ble_nus_data_send_success(void)
 	__cmock_sd_ble_gatts_hvx_ExpectAndReturn(test_case_conn_handle,
 					  &expected_hvx_params, NRF_SUCCESS);
 
-	ret = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
-	TEST_ASSERT_EQUAL(0, ret);
+	nrf_err = ble_nus_data_send(&ble_nus, data, &length, test_case_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void setUp(void)


### PR DESCRIPTION
Change error codes to nrf_errors.
Moving forward all non-BLE libraries and components will return errnos, while BLE related code as BLE services, libraries and the SoftDevice will return nrf_errors.