### PR TITLE
storage: bm_storage: use errno instead of nrf_error

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -118,6 +118,10 @@ Libraries
      * All instances of ``pm_failure_evt_t`` to struct :c:struct:`pm_failure_evt` and removed the ``pm_failure_evt_t`` type.
      * All instances of ``pm_evt_t`` to struct :c:struct:`pm_evt` and removed the ``pm_evt_t`` type.
 
+* Storage library:
+
+  * Updated to use errno instead of nrf_errors.
+
 Samples
 =======
 

--- a/include/bm/storage/bm_storage.h
+++ b/include/bm/storage/bm_storage.h
@@ -52,10 +52,10 @@ struct bm_storage_evt {
 	/* Specifies if the operation was performed synchronously or asynchronously. */
 	enum bm_storage_evt_dispatch_type dispatch_type;
 	/* Result of the operation.
-	 * NRF_SUCCESS on success.
-	 * A positive NRF error otherwise.
+	 * 0 on success.
+	 * A negative errno otherwise.
 	 */
-	uint32_t result;
+	int result;
 	/* Destination address where the operation was performed. */
 	uint32_t addr;
 	/* Pointer to the data that was written to non-volatile memory.
@@ -143,12 +143,12 @@ struct bm_storage {
  *
  * @param[in] storage Storage instance to initialize.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_NULL If @p storage is @c NULL.
- * @retval NRF_ERROR_BUSY If the implementation-specific resource is busy.
- * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ * @retval 0 on success.
+ * @retval -EFAULT If @p storage is @c NULL.
+ * @retval -EBUSY If the implementation-specific resource is busy.
+ * @retval -EIO If an implementation-specific internal error occurred.
  */
-uint32_t bm_storage_init(struct bm_storage *storage);
+int bm_storage_init(struct bm_storage *storage);
 
 /**
  * @brief Uninitialize a storage instance.
@@ -158,13 +158,13 @@ uint32_t bm_storage_init(struct bm_storage *storage);
  *
  * @param[in] storage Storage instance to uninitialize.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_NULL If @p storage is @c NULL.
- * @retval NRF_ERROR_INVALID_STATE If @p storage is in an invalid state.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support uninitialization.
+ * @retval 0 on success.
+ * @retval -EFAULT If @p storage is @c NULL.
+ * @retval -EPERM If @p storage is in an invalid state.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -ENOTSUP If the backend does not support uninitialization.
  */
-uint32_t bm_storage_uninit(struct bm_storage *storage);
+int bm_storage_uninit(struct bm_storage *storage);
 
 /**
  * @brief Read data from a storage instance.
@@ -174,16 +174,14 @@ uint32_t bm_storage_uninit(struct bm_storage *storage);
  * @param[out] dest Destination where the data will be copied to.
  * @param[in] len Length of the data to copy (in bytes).
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_NULL If @p storage is @c NULL.
- * @retval NRF_ERROR_INVALID_STATE If @p storage is in an invalid state.
- * @retval NRF_ERROR_INVALID_LENGTH If @p len is zero or not a multiple of
- *                                  @ref bm_storage_info.program_unit.
- * @retval NRF_ERROR_INVALID_ADDR If @p dest or @p src are not 32-bit word aligned, or if they are
- *                                outside the bounds of the memory region configured in @p storage.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
+ * @retval 0 on success.
+ * @retval -EFAULT If @p storage is @c NULL or if @p dest or @p src are not 32-bit word aligned,
+ *                 or if they are outside the bounds of the memory region configured in @p storage.
+ * @retval -EPERM If @p storage is in an invalid state or if the implementation-specific backend
+ *                has not been initialized.
+ * @retval -EINVAL If @p len is zero or not a multiple of @ref bm_storage_info.program_unit.
  */
-uint32_t bm_storage_read(const struct bm_storage *storage, uint32_t src, void *dest, uint32_t len);
+int bm_storage_read(const struct bm_storage *storage, uint32_t src, void *dest, uint32_t len);
 
 /**
  * @brief Write data to a storage instance.
@@ -195,19 +193,17 @@ uint32_t bm_storage_read(const struct bm_storage *storage, uint32_t src, void *d
  * @param[in] ctx Pointer to user data, passed to the implementation-specific API function call.
  *                Can be NULL.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_NULL If @p storage is @c NULL.
- * @retval NRF_ERROR_INVALID_STATE If @p storage is in an invalid state.
- * @retval NRF_ERROR_INVALID_LENGTH If @p len is zero or not a multiple of
- *                                  @ref bm_storage_info.program_unit.
- * @retval NRF_ERROR_INVALID_ADDR If @p dest or @p src are not 32-bit word aligned, or if they are
- *                                outside the bounds of the memory region configured in @p storage.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ * @retval 0 on success.
+ * @retval -EFAULT If @p storage is @c NULL or if @p dest or @p src are not 32-bit word aligned,
+ *                 or if they are outside the bounds of the memory region configured in @p storage.
+ * @retval -EPERM If @p storage is in an invalid state or if the implementation-specific backend
+ *                has not been initialized.
+ * @retval -EINVAL If @p len is zero or not a multiple of @ref bm_storage_info.program_unit.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -EIO If an implementation-specific internal error occurred.
  */
-uint32_t bm_storage_write(const struct bm_storage *storage, uint32_t dest, const void *src,
-			  uint32_t len, void *ctx);
+int bm_storage_write(const struct bm_storage *storage, uint32_t dest, const void *src,
+		     uint32_t len, void *ctx);
 
 /**
  * @brief Erase data in a storage instance.
@@ -216,19 +212,16 @@ uint32_t bm_storage_write(const struct bm_storage *storage, uint32_t dest, const
  * @param[in] ctx Pointer to user data, passed to the implementation-specific API function call.
  *                Can be NULL.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_NULL If @p storage is @c NULL.
- * @retval NRF_ERROR_INVALID_STATE If @p storage is in an invalid state.
- * @retval NRF_ERROR_INVALID_LENGTH If @p len is zero or not a multiple of
- *                                  @ref bm_storage_info.erase_unit.
- * @retval NRF_ERROR_INVALID_ADDR If @p addr is outside the bounds of the memory region configured
- *                                in @p storage.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_NOT_SUPPORTED If the implementation-specific backend does not implement this
- *                                 function.
+ * @retval 0 on success.
+ * @retval -EFAULT If @p storage is @c NULL or if @p addr is outside the bounds of the memory region
+ *                 configured in @p storage.
+ * @retval -EPERM If @p storage is in an invalid state or if the implementation-specific backend
+ *                has not been initialized.
+ * @retval -EINVAL If @p len is zero or not a multiple of @ref bm_storage_info.erase_unit.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -ENOTSUP If the implementation-specific backend does not implement this function.
  */
-uint32_t bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx);
+int bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx);
 
 /**
  * @brief Query the status of a storage instance.

--- a/include/bm/storage/bm_storage_backend.h
+++ b/include/bm/storage/bm_storage_backend.h
@@ -24,57 +24,59 @@ extern "C" {
  *
  * @note This function must be defined by the backend.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_BUSY If the implementation-specific resource is busy.
- * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ * @retval 0 on success.
+ * @retval -EBUSY If the implementation-specific resource is busy.
+ * @retval -EIO If an implementation-specific internal error occurred.
  */
-uint32_t bm_storage_backend_init(struct bm_storage *storage);
+int bm_storage_backend_init(struct bm_storage *storage);
 /**
  * @brief Uninitialize the storage peripheral.
  *
  * @note This function is optional. If not defined in the backend, a weak implementation will return
- * NRF_ERROR_NOT_SUPPORTED.
+ * -ENOTSUP.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support uninitialization.
+ * @retval 0 on success.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -ENOTSUP If the backend does not support uninitialization.
  */
-uint32_t bm_storage_backend_uninit(struct bm_storage *storage);
+int bm_storage_backend_uninit(struct bm_storage *storage);
 /**
  * @brief Read data from non-volatile memory.
  *
  * @note This function must be defined by the backend.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
+ * @retval 0 on success.
+ * @retval -EPERM If the implementation-specific backend has not been initialized.
+ * @retval -EFAULT if @p src is not 32-bit aligned.
  */
-uint32_t bm_storage_backend_read(const struct bm_storage *storage, uint32_t src, void *dest,
-				 uint32_t len);
+int bm_storage_backend_read(const struct bm_storage *storage, uint32_t src, void *dest,
+			    uint32_t len);
 /**
  * @brief Write bytes to non-volatile memory.
  *
  * @note This function must be defined by the backend.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_INTERNAL If an implementation-specific internal error occurred.
+ * @retval 0 on success.
+ * @retval -EPERM If the implementation-specific backend has not been initialized.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -EIO If an implementation-specific internal error occurred.
+ * @retval -EFAULT if @p src is not 32-bit aligned.
  */
-uint32_t bm_storage_backend_write(const struct bm_storage *storage, uint32_t dest, const void *src,
-				  uint32_t len, void *ctx);
+int bm_storage_backend_write(const struct bm_storage *storage, uint32_t dest, const void *src,
+			     uint32_t len, void *ctx);
 /**
  * @brief Erase the non-volatile memory.
  *
  * @note This function is optional. If not defined in the backend, a weak implementation will return
- * NRF_ERROR_NOT_SUPPORTED.
+ * -ENOTSUP.
  *
- * @retval NRF_SUCCESS on success.
- * @retval NRF_ERROR_FORBIDDEN If the implementation-specific backend has not been initialized.
- * @retval NRF_ERROR_BUSY If the implementation-specific backend is busy with an ongoing operation.
- * @retval NRF_ERROR_NOT_SUPPORTED If the backend does not support erase.
+ * @retval 0 on success.
+ * @retval -EPERM If the implementation-specific backend has not been initialized.
+ * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
+ * @retval -ENOTSUP If the backend does not support erase.
  */
-uint32_t bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len,
-				  void *ctx);
+int bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len,
+			     void *ctx);
 /**
  * @brief Check if there are any pending operations.
  *

--- a/lib/bluetooth/ble_adv/ble_adv_data.c
+++ b/lib/bluetooth/ble_adv/ble_adv_data.c
@@ -391,9 +391,7 @@ static uint32_t manuf_specific_data_encode(const struct ble_adv_data_manufacture
 		return NRF_ERROR_DATA_SIZE;
 	}
 
-	/* There is only 1 byte intended to encode length which is
-	 * (data_size + AD_TYPE_FIELD_SIZE)
-	 */
+	/* There is only 1 byte intended to encode length which is (data_size + AD_TYPE_FIELD_SIZE) */
 	if (data_size > (0x00FF - AD_TYPE_FIELD_SIZE)) {
 		return NRF_ERROR_DATA_SIZE;
 	}

--- a/lib/bluetooth/ble_adv/ble_adv_data.c
+++ b/lib/bluetooth/ble_adv/ble_adv_data.c
@@ -391,7 +391,9 @@ static uint32_t manuf_specific_data_encode(const struct ble_adv_data_manufacture
 		return NRF_ERROR_DATA_SIZE;
 	}
 
-	/* There is only 1 byte intended to encode length which is (data_size + AD_TYPE_FIELD_SIZE) */
+	/* There is only 1 byte intended to encode length which is
+	 * (data_size + AD_TYPE_FIELD_SIZE)
+	 */
 	if (data_size > (0x00FF - AD_TYPE_FIELD_SIZE)) {
 		return NRF_ERROR_DATA_SIZE;
 	}

--- a/subsys/fs/bm_zms/bm_zms.c
+++ b/subsys/fs/bm_zms/bm_zms.c
@@ -138,7 +138,7 @@ static void queue_process(void)
 			NRFX_CRITICAL_SECTION_ENTER();
 			rc = ring_buf_get(&zms_fifo, (uint8_t *)&cur_op, sizeof(zms_op_t));
 			NRFX_CRITICAL_SECTION_EXIT();
-			if (rc < 0) {
+			if (rc != sizeof(zms_op_t)) {
 				result = -EIO;
 				goto completed;
 			}

--- a/subsys/storage/bm_storage/Kconfig
+++ b/subsys/storage/bm_storage/Kconfig
@@ -36,7 +36,7 @@ config BM_STORAGE_BACKEND_SD_MAX_RETRIES
 	int "Maximum number of attempts at executing an operation when the SoftDevice is busy"
 	default 8
 	help
-	  Increase this value if events frequently return the @ref NRF_ERROR_TIMEOUT error.
+	  Increase this value if events frequently return -ETIMEDOUT.
 	  The SoftDevice might fail to schedule flash access due to high BLE activity.
 
 endif # BM_STORAGE_BACKEND_SD

--- a/subsys/storage/bm_storage/bm_storage.c
+++ b/subsys/storage/bm_storage/bm_storage.c
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_error.h>
+#include <errno.h>
 #include <zephyr/kernel.h>
 #include <sys/types.h>
 #include <bm/storage/bm_storage.h>
 #include <bm/storage/bm_storage_backend.h>
 
-__weak uint32_t bm_storage_backend_uninit(struct bm_storage *storage)
+__weak int bm_storage_backend_uninit(struct bm_storage *storage)
 {
-	return NRF_ERROR_NOT_SUPPORTED;
+	return -ENOTSUP;
 }
 
-__weak uint32_t bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr,
+__weak int bm_storage_backend_erase(const struct bm_storage *storage, uint32_t addr,
 					uint32_t len, void *ctx)
 {
-	return NRF_ERROR_NOT_SUPPORTED;
+	return -ENOTSUP;
 }
 
 __weak bool bm_storage_backend_is_busy(const struct bm_storage *storage)
@@ -33,41 +33,41 @@ static inline bool is_within_bounds(off_t addr, size_t len, off_t boundary_start
 		(len <= (boundary_start + boundary_size - addr)));
 }
 
-uint32_t bm_storage_init(struct bm_storage *storage)
+int bm_storage_init(struct bm_storage *storage)
 {
-	uint32_t err;
+	int err;
 
 	if (!storage) {
-		return NRF_ERROR_NULL;
+		return -EFAULT;
 	}
 
 	storage->nvm_info = &bm_storage_info;
 
 	err = bm_storage_backend_init(storage);
-	if (err != NRF_SUCCESS) {
+	if (err) {
 		return err;
 	}
 
 	storage->initialized = true;
 
-	return NRF_SUCCESS;
+	return 0;
 }
 
-uint32_t bm_storage_uninit(struct bm_storage *storage)
+int bm_storage_uninit(struct bm_storage *storage)
 {
-	uint32_t err;
+	int err;
 
 	if (!storage) {
-		return NRF_ERROR_NULL;
+		return -EFAULT;
 	}
 
 	if (!storage->initialized) {
-		return NRF_ERROR_INVALID_STATE;
+		return -EPERM;
 	}
 
 	err = bm_storage_backend_uninit(storage);
 
-	if (err == NRF_SUCCESS) {
+	if (err == 0) {
 		storage->initialized = false;
 		storage->nvm_info = NULL;
 	}
@@ -75,68 +75,68 @@ uint32_t bm_storage_uninit(struct bm_storage *storage)
 	return err;
 }
 
-uint32_t bm_storage_read(const struct bm_storage *storage, uint32_t src, void *dest, uint32_t len)
+int bm_storage_read(const struct bm_storage *storage, uint32_t src, void *dest, uint32_t len)
 {
 	if (!storage || !dest) {
-		return NRF_ERROR_NULL;
+		return -EFAULT;
 	}
 
 	if (!storage->initialized || !storage->nvm_info) {
-		return NRF_ERROR_INVALID_STATE;
+		return -EPERM;
 	}
 
 	if (len == 0) {
-		return NRF_ERROR_INVALID_LENGTH;
+		return -EINVAL;
 	}
 
 	if (!is_within_bounds(src, len, storage->start_addr,
 		storage->end_addr - storage->start_addr)) {
-		return NRF_ERROR_INVALID_ADDR;
+		return -EFAULT;
 	}
 
 	return bm_storage_backend_read(storage, src, dest, len);
 }
 
-uint32_t bm_storage_write(const struct bm_storage *storage, uint32_t dest, const void *src,
-			  uint32_t len, void *ctx)
+int bm_storage_write(const struct bm_storage *storage, uint32_t dest, const void *src,
+		     uint32_t len, void *ctx)
 {
 	if (!storage || !src) {
-		return NRF_ERROR_NULL;
+		return -EFAULT;
 	}
 
 	if (!storage->initialized || !storage->nvm_info) {
-		return NRF_ERROR_INVALID_STATE;
+		return -EPERM;
 	}
 
 	if (len == 0 || len % storage->nvm_info->program_unit != 0) {
-		return NRF_ERROR_INVALID_LENGTH;
+		return -EINVAL;
 	}
 
 	if (!is_within_bounds(dest, len, storage->start_addr,
 		storage->end_addr - storage->start_addr)) {
-		return NRF_ERROR_INVALID_ADDR;
+		return -EFAULT;
 	}
 
 	return bm_storage_backend_write(storage, dest, src, len, ctx);
 }
 
-uint32_t bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx)
+int bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx)
 {
 	if (!storage) {
-		return NRF_ERROR_NULL;
+		return -EFAULT;
 	}
 
 	if (!storage->initialized || !storage->nvm_info) {
-		return NRF_ERROR_INVALID_STATE;
+		return -EPERM;
 	}
 
 	if (len == 0 || len % storage->nvm_info->erase_unit != 0) {
-		return NRF_ERROR_INVALID_LENGTH;
+		return -EINVAL;
 	}
 
 	if (!is_within_bounds(addr, len, storage->start_addr,
 			      storage->end_addr - storage->start_addr)) {
-		return NRF_ERROR_INVALID_ADDR;
+		return -EFAULT;
 	}
 
 	return bm_storage_backend_erase(storage, addr, len, ctx);


### PR DESCRIPTION
Use errnos for BM storage as it is not a BLE library or BLE subsystem.