### PR TITLE
treewide: align struct initialization to zero

### DIFF
--- a/lib/bluetooth/ble_qwr/ble_qwr.c
+++ b/lib/bluetooth/ble_qwr/ble_qwr.c
@@ -210,8 +210,8 @@ static void on_user_mem_release(struct ble_qwr *qwr, ble_common_evt_t const *evt
 static void on_prepare_write(struct ble_qwr *qwr, ble_gatts_evt_write_t const *write_evt)
 {
 	int err;
-	ble_gatts_rw_authorize_reply_params_t auth_reply = {};
-	struct ble_qwr_evt evt = {};
+	ble_gatts_rw_authorize_reply_params_t auth_reply = {0};
+	struct ble_qwr_evt evt = {0};
 
 	auth_reply.params.write.gatt_status = BLE_QWR_REJ_REQUEST_ERR_CODE;
 	auth_reply.type = BLE_GATTS_AUTHORIZE_TYPE_WRITE;
@@ -258,7 +258,7 @@ static void on_execute_write(struct ble_qwr *qwr, ble_gatts_evt_write_t const *w
 {
 	uint32_t err;
 	uint16_t ret_val;
-	ble_gatts_rw_authorize_reply_params_t auth_reply = {};
+	ble_gatts_rw_authorize_reply_params_t auth_reply = {0};
 	struct ble_qwr_evt evt;
 
 	auth_reply.params.write.gatt_status = BLE_GATT_STATUS_SUCCESS;
@@ -319,7 +319,7 @@ static void on_execute_write(struct ble_qwr *qwr, ble_gatts_evt_write_t const *w
 static void on_cancel_write(struct ble_qwr *qwr, ble_gatts_evt_write_t const *write_evt)
 {
 	uint32_t err;
-	ble_gatts_rw_authorize_reply_params_t auth_reply = {};
+	ble_gatts_rw_authorize_reply_params_t auth_reply = {0};
 	struct ble_qwr_evt evt;
 
 	auth_reply.type = BLE_GATTS_AUTHORIZE_TYPE_WRITE;
@@ -347,7 +347,7 @@ static void on_rw_authorize_request(struct ble_qwr *qwr, ble_gatts_evt_t const *
 #if (CONFIG_BLE_QWR_MAX_ATTR == 0)
 	uint32_t err;
 	ble_gatts_rw_authorize_reply_params_t auth_reply = {0};
-	struct ble_qwr_evt qwr_evt = {};
+	struct ble_qwr_evt qwr_evt = {0};
 #endif
 
 	if (evt->conn_handle != qwr->conn_handle) {

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -463,7 +463,7 @@ static void adv_data_update_and_start(enum adv_mode adv_mode)
 		.name_type = BLE_ADV_DATA_FULL_NAME,
 		.flags = BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE,
 	};
-	struct ble_adv_data sr_data = {};
+	struct ble_adv_data sr_data = {0};
 
 	if (adv_mode_current != ADV_MODE_IDLE) {
 		err = sd_ble_gap_adv_stop(adv_handle);

--- a/subsys/bluetooth/services/ble_cgms/cgms_meas.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_meas.c
@@ -72,7 +72,7 @@ uint32_t cgms_meas_char_add(struct ble_cgms *cgms)
 	uint32_t err;
 	uint16_t num_recs;
 	uint8_t encoded_cgms_meas[BLE_CGMS_MEAS_LEN_MAX];
-	struct ble_cgms_rec initial_cgms_rec_value = {};
+	struct ble_cgms_rec initial_cgms_rec_value = {0};
 
 	num_recs = cgms_db_num_records_get();
 	if (num_recs > 0) {

--- a/subsys/bluetooth/services/ble_cgms/cgms_socp.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_socp.c
@@ -387,7 +387,7 @@ static void on_socp_value_write(struct ble_cgms *cgms, const ble_gatts_evt_write
 	uint32_t err;
 	struct ble_cgms_socp_value socp_request;
 	struct ble_cgms_evt evt;
-	struct ble_cgms_sst sst = {};
+	struct ble_cgms_sst sst = {0};
 
 	/* Decode request. */
 	ble_socp_decode(evt_write->len, evt_write->data, &socp_request);

--- a/subsys/bluetooth/services/ble_cgms/cgms_sst.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_sst.c
@@ -92,7 +92,7 @@ static uint8_t sst_encode(struct ble_cgms_sst *sst, uint8_t *sst_encoded)
 static uint32_t cgm_update_sst(struct ble_cgms *cgms, const ble_gatts_evt_write_t *evt_write)
 {
 	uint32_t err;
-	struct ble_cgms_sst sst = {};
+	struct ble_cgms_sst sst = {0};
 	struct tm c_time_and_date;
 
 	err = sst_decode(&sst, evt_write->data, evt_write->len);

--- a/subsys/bluetooth/services/ble_hids/hids.c
+++ b/subsys/bluetooth/services/ble_hids/hids.c
@@ -654,7 +654,7 @@ static uint32_t rep_char_add(struct ble_hids *hids, ble_gatt_char_props_t *prope
 		.p_attr_md = &attr_md,
 		.max_len = len,
 	};
-	ble_gatts_attr_md_t cccd_md = {};
+	ble_gatts_attr_md_t cccd_md = {0};
 
 	attr_md.read_perm = char_sec->read;
 	attr_md.write_perm = char_sec->write;

--- a/tests/lib/bluetooth/ble_conn_state/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_conn_state/src/unity_test.c
@@ -775,7 +775,7 @@ void test_ble_conn_state_user_flag_acquire(void)
 void test_ble_conn_state_user_flag_set_get(void)
 {
 	bool flag_state;
-	uint32_t acquired_ids[CONFIG_BLE_CONN_STATE_USER_FLAG_COUNT] = {};
+	uint32_t acquired_ids[CONFIG_BLE_CONN_STATE_USER_FLAG_COUNT] = {0};
 
 	uint16_t conn_handles[BLE_CONN_STATE_MAX_CONNECTIONS];
 	uint16_t invalid_conn_handle = 35354;

--- a/tests/lib/bluetooth/ble_qwr/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_qwr/src/unity_test.c
@@ -24,7 +24,7 @@ void test_ble_qwr_init_efault(void)
 {
 	int err;
 	struct ble_qwr qwr;
-	struct ble_qwr_config qwr_config = {};
+	struct ble_qwr_config qwr_config = {0};
 
 	err = ble_qwr_init(&qwr, NULL);
 	TEST_ASSERT_EQUAL(-EFAULT, err);
@@ -37,7 +37,7 @@ void test_ble_qwr_init_eperm(void)
 {
 	int err;
 	struct ble_qwr qwr;
-	struct ble_qwr_config qwr_config = {};
+	struct ble_qwr_config qwr_config = {0};
 
 	err = ble_qwr_init(&qwr, &qwr_config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -85,7 +85,7 @@ void test_ble_qwr_attr_register_efault(void)
 void test_ble_qwr_attr_register_eperm(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 
 	err = ble_qwr_attr_register(&qwr, 1);
 	TEST_ASSERT_EQUAL(-EPERM, err);
@@ -211,7 +211,7 @@ void test_ble_qwr_value_get_efault(void)
 void test_ble_qwr_value_get_eperm(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 	uint8_t mem[1];
 	uint16_t len = sizeof(mem);
 
@@ -222,7 +222,7 @@ void test_ble_qwr_value_get_eperm(void)
 void test_ble_qwr_value_get(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 	/* mem is filled by softdevice, we do it here */
 	uint8_t mem[] = {
 		0xa1, 0x00, 0x00, 0x00, /* attr_handle (little endian), val_offset */
@@ -285,7 +285,7 @@ void test_ble_qwr_conn_handle_assign_efault(void)
 void test_ble_qwr_conn_handle_assign_eperm(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 
 	err = ble_qwr_conn_handle_assign(&qwr, 1);
 	TEST_ASSERT_EQUAL(-EPERM, err);
@@ -294,7 +294,7 @@ void test_ble_qwr_conn_handle_assign_eperm(void)
 void test_ble_qwr_conn_handle_assign(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 	uint8_t mem[1];
 	struct ble_qwr_config qwr_config = {
 		.mem_buffer = {
@@ -315,8 +315,8 @@ void test_ble_qwr_conn_handle_assign(void)
 
 void test_ble_qwr_on_ble_evt_do_nothing(void)
 {
-	ble_evt_t const ble_evt = {};
-	struct ble_qwr qwr = {};
+	ble_evt_t const ble_evt = {0};
+	struct ble_qwr qwr = {0};
 
 	/* We expect these to return immediately */
 	ble_qwr_on_ble_evt(&ble_evt, NULL);
@@ -327,7 +327,7 @@ void test_ble_qwr_on_ble_evt_do_nothing(void)
 void test_ble_qwr_on_ble_evt_mem_req_sd_busy(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 	uint8_t mem[16];
 	struct ble_qwr_config qwr_config = {
 		.mem_buffer = {
@@ -379,7 +379,7 @@ void test_ble_qwr_on_ble_evt_mem_req_sd_busy(void)
 void test_ble_qwr_on_ble_evt_mem_req(void)
 {
 	int err;
-	struct ble_qwr qwr = {};
+	struct ble_qwr qwr = {0};
 	uint8_t mem[16];
 	struct ble_qwr_config qwr_config = {
 		.mem_buffer = {

--- a/tests/lib/bluetooth/ble_racp/src/unity_test.c
+++ b/tests/lib/bluetooth/ble_racp/src/unity_test.c
@@ -13,7 +13,7 @@
 void test_ble_racp_encode_efault(void)
 {
 	int ret;
-	const struct ble_racp_value racp_val = {};
+	const struct ble_racp_value racp_val = {0};
 	uint8_t data[5];
 
 	ret = ble_racp_encode(NULL, data, sizeof(data));
@@ -26,7 +26,7 @@ void test_ble_racp_encode_efault(void)
 void test_ble_racp_encode_einval(void)
 {
 	int ret;
-	struct ble_racp_value racp_val = {};
+	struct ble_racp_value racp_val = {0};
 	uint8_t data[5];
 
 	ret = ble_racp_encode(&racp_val, data, 0);
@@ -67,7 +67,7 @@ void test_ble_racp_encode(void)
 void test_ble_racp_decode_efault(void)
 {
 	int ret;
-	struct ble_racp_value racp_val = {};
+	struct ble_racp_value racp_val = {0};
 	uint8_t data[5];
 
 	ret = ble_racp_decode(NULL, 0, &racp_val);
@@ -93,7 +93,7 @@ void test_ble_racp_decode(void)
 	TEST_ASSERT_EQUAL_PTR(&data[2], racp_val.operand);
 	TEST_ASSERT_EQUAL(3, racp_val.operand_len);
 
-	uint8_t empty[] = {};
+	uint8_t empty[] = {0};
 
 	ret = ble_racp_decode(empty, 0, &racp_val);
 	TEST_ASSERT_EQUAL(0, ret);

--- a/tests/subsys/bluetooth/services/ble_nus/src/unity_test.c
+++ b/tests/subsys/bluetooth/services/ble_nus/src/unity_test.c
@@ -216,10 +216,10 @@ void test_ble_nus_init_success(void)
 
 void test_ble_nus_on_ble_evt_gap_evt_do_nothing(void)
 {
-	ble_evt_t const ble_evt = {};
-	struct ble_nus nus_ctx = {};
-	ble_evt_t empty_ble_evt = {};
-	struct ble_nus empty_nus_ctx = {};
+	ble_evt_t const ble_evt = {0};
+	struct ble_nus nus_ctx = {0};
+	ble_evt_t empty_ble_evt = {0};
+	struct ble_nus empty_nus_ctx = {0};
 
 	ble_nus_on_ble_evt(NULL, &nus_ctx);
 	ble_nus_on_ble_evt(&ble_evt, NULL);


### PR DESCRIPTION
Using struct abc = {} is a C23 extension. Use struct abc = {0} instead.