### PR TITLE
fix wrong variable names in assertion checks

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -52,7 +52,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
 	int err;
 
-	__ASSERT(ble_evt, "BLE event is NULL");
+	__ASSERT(evt, "BLE event is NULL");
 
 	if (evt == NULL) {
 		return;

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -45,7 +45,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 {
 	int err;
 
-	__ASSERT(ble_evt, "BLE event is NULL");
+	__ASSERT(evt, "BLE event is NULL");
 
 	if (evt == NULL) {
 		return;


### PR DESCRIPTION
Fix wrong variable name in assertion checks in firmware_loader application, mcuboot_recover_entry sample and in the ble_mcumgr module.