### PR TITLE
sysbuild: Add bootconf image (rebased on latest main)

### DIFF
--- a/cmake/bootconf/CMakeLists.txt
+++ b/cmake/bootconf/CMakeLists.txt
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr
+  COMPONENTS zephyr_default:dts,kconfig
+  REQUIRED HINTS $ENV{ZEPHYR_BASE}
+)
+
+project(bootconf)
+
+# Manually include board configuration to enable automatic runners.yaml generation
+include(${BOARD_DIR}/board.cmake OPTIONAL)
+
+# Create the runners_yaml_props_target that flash system expects
+add_custom_target(runners_yaml_props_target)
+
+# Set hex_file property to point to zephyr.hex in this directory
+set_target_properties(runners_yaml_props_target PROPERTIES
+  hex_file "${CMAKE_BINARY_DIR}/bootconf.hex"
+)
+
+# Override the runners.yaml path to use CMAKE_CURRENT_BINARY_DIR/zephyr instead of
+# PROJECT_BINARY_DIR, this ensures runners.yaml is generated at <build>/softdevice/zephyr where
+# west expects it
+set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
+
+# Include flash support to automatically generate runners.yaml
+include(${ZEPHYR_BASE}/cmake/flash/CMakeLists.txt)
+
+# Generate bootconf file
+add_custom_target(bootconf_target
+  ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/bootconf.hex
+)
+
+dt_nodelabel(boot_partition_node_full_path NODELABEL "boot_partition")
+dt_reg_size(boot_partition_node_size PATH "${boot_partition_node_full_path}")
+
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/bootconf.hex
+  COMMAND ${Python3_EXECUTABLE}
+    ${ZEPHYR_NRF_MODULE_DIR}/scripts/reglock.py
+    --output ${CMAKE_BINARY_DIR}/bootconf.hex
+    --size ${boot_partition_node_size}
+    --soc ${CONFIG_SOC}
+  VERBATIM
+  DEPENDS ${dts_files}
+)
+
+if(${boot_partition_node_size} GREATER 0x7c00)
+  message(WARNING
+    "boot_partition doesn't fit into protection region. "
+    "Protection will be applied over maximum allowed span."
+  )
+endif()
+
+set(BYPRODUCT_HEX_NAME
+  "${CMAKE_BINARY_DIR}/bootconf.hex"
+  CACHE FILEPATH "MCUboot with signed softdevice and flash metadata hex file" FORCE
+)

--- a/cmake/bootconf/prj.conf
+++ b/cmake/bootconf/prj.conf
@@ -1,0 +1,1 @@
+# Nothing here

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 function(bm_install_setup)
-  if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE)
+  if(NOT SB_CONFIG_BM_BOOTLOADER_NONE)
     ExternalZephyrProject_Add(
       APPLICATION ${SB_CONFIG_BM_BOOTLOADER_IMAGE_NAME}
       SOURCE_DIR ${SB_CONFIG_BM_BOOTLOADER_IMAGE_PATH}
@@ -15,7 +15,14 @@ function(bm_install_setup)
     sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} ${SB_CONFIG_BM_BOOTLOADER_IMAGE_NAME})
     sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} ${SB_CONFIG_BM_BOOTLOADER_IMAGE_NAME})
 
-    if(NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
+    if(SB_CONFIG_BM_BOOT_BOOTCONF_LOCK_WRITES)
+      ExternalZephyrProject_Add(
+        APPLICATION bootconf
+        SOURCE_DIR ${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/bootconf
+      )
+    endif()
+
+    if(NOT SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
       ExternalZephyrProject_Add(
         APPLICATION ${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME}
         SOURCE_DIR ${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_PATH}
@@ -118,7 +125,7 @@ endfunction()
 function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   cmake_parse_arguments(PRE_CMAKE "" "" "IMAGES" ${ARGN})
 
-  if(NOT DEFINED SB_CONFIG_NCS_BM)
+  if(NOT SB_CONFIG_NCS_BM)
     # Disable bare-metal on all images
     foreach(image ${PRE_CMAKE_IMAGES})
       set_config_int(${image} CONFIG_NCS_BM n)
@@ -127,10 +134,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
     return()
   endif()
 
-  if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE)
+  if(NOT SB_CONFIG_BM_BOOTLOADER_NONE)
     set(bm_install_images 1)
 
-    if(NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
+    if(NOT SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
       # Firmware loader present
       set_target_properties(${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME} PROPERTIES
         IMAGE_CONF_SCRIPT ${ZEPHYR_NRF_BM_MODULE_DIR}/sysbuild/image_configurations/MAIN_image_default.cmake
@@ -192,7 +199,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       set_config_int(${image} CONFIG_BM_METADATA_WRITE n)
     endif()
 
-    if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE AND NOT image STREQUAL "mcuboot")
+    if(NOT SB_CONFIG_BM_BOOTLOADER_NONE AND NOT image STREQUAL "mcuboot")
       if(SB_CONFIG_SOC_SERIES_NRF54LX)
         set_config_int(installer CONFIG_ROM_START_OFFSET 0x800)
       else()
@@ -204,7 +211,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   if(SB_CONFIG_SOFTDEVICE_NONE)
     set_config_bool(${DEFAULT_IMAGE} CONFIG_SOFTDEVICE n)
 
-    if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE AND NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
+    if(NOT SB_CONFIG_BM_BOOTLOADER_NONE AND NOT SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
       set_config_bool(${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME} CONFIG_SOFTDEVICE n)
     endif()
   else()
@@ -212,7 +219,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       if(SB_CONFIG_${option})
         set_config_bool(${DEFAULT_IMAGE} CONFIG_${option} y)
 
-        if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE AND NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_NONE AND NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_UART_MCUMGR)
+        if(NOT SB_CONFIG_BM_BOOTLOADER_NONE AND NOT SB_CONFIG_BM_FIRMWARE_LOADER_NONE AND NOT SB_CONFIG_BM_FIRMWARE_LOADER_UART_MCUMGR)
           set_config_bool(${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME} CONFIG_${option} y)
         endif()
         break()
@@ -222,38 +229,50 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 endfunction()
 
 function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
-  if(NOT DEFINED SB_CONFIG_NCS_BM)
+  if(NOT SB_CONFIG_NCS_BM)
     return()
   endif()
 
   cmake_parse_arguments(PRE_CMAKE "" "" "IMAGES" ${ARGN})
 
-  if(NOT DEFINED SB_CONFIG_BM_BOOTLOADER_NONE)
+  if(NOT SB_CONFIG_BM_BOOTLOADER_NONE)
     set(check_targets mcuboot;${DEFAULT_IMAGE})
     set(dependency_targets ${SB_CONFIG_SOFTDEVICE_FILE})
     set(production_targets mcuboot;${DEFAULT_IMAGE})
     set(production_files)
 
-    if(NOT DEFINED SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
+    if(NOT SB_CONFIG_BM_FIRMWARE_LOADER_NONE)
       list(APPEND check_targets installer)
       list(APPEND check_targets ${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME})
       list(APPEND production_targets ${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME})
     endif()
 
+    if(SB_CONFIG_BM_BOOT_BOOTCONF_LOCK_WRITES)
+      list(APPEND check_targets bootconf)
+      list(APPEND dependency_targets bootconf)
+      list(APPEND production_targets bootconf)
+    endif()
+
     foreach(image ${check_targets})
-      sysbuild_get(${image}_kernel_bin_name IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
       sysbuild_get(${image}_binary_dir IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
 
       list(APPEND dependency_targets
         ${image}_extra_byproducts
         ${${image}_binary_dir}/zephyr/.config
-        ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.bin
       )
 
-      if("${image}" STREQUAL "${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME}")
+      if(NOT "${image}" STREQUAL "bootconf")
+        sysbuild_get(${image}_kernel_bin_name IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
+
         list(APPEND dependency_targets
-          ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.signed.bin
+          ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.bin
         )
+
+        if("${image}" STREQUAL "${SB_CONFIG_BM_FIRMWARE_LOADER_IMAGE_NAME}")
+          list(APPEND dependency_targets
+            ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.signed.bin
+          )
+        endif()
       endif()
     endforeach()
 
@@ -280,15 +299,24 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
     endif()
 
     foreach(image ${production_targets})
-      sysbuild_get(${image}_kernel_bin_name IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
       sysbuild_get(${image}_binary_dir IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
 
-      if("${image}" STREQUAL "mcuboot")
+      if("${image}" STREQUAL "bootconf")
         list(APPEND production_files
-          ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}_signed_softdevice_flash_metadata.hex)
+          ${${image}_binary_dir}/bootconf.hex
+        )
       else()
-        list(APPEND production_files
-          ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.signed.hex)
+        sysbuild_get(${image}_kernel_bin_name IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
+
+        if("${image}" STREQUAL "mcuboot")
+          list(APPEND production_files
+            ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}_signed_softdevice_flash_metadata.hex
+          )
+        else()
+          list(APPEND production_files
+            ${${image}_binary_dir}/zephyr/${${image}_kernel_bin_name}.signed.hex
+          )
+        endif()
       endif()
     endforeach()
 

--- a/sysbuild/Kconfig.bm
+++ b/sysbuild/Kconfig.bm
@@ -106,6 +106,12 @@ config BM_BOOT_IMG_HASH_ALG_PURE
 
 endchoice
 
+config BM_BOOT_BOOTCONF_LOCK_WRITES
+	bool "Protect bootloader's NVM from writes"
+	depends on SOC_NRF54L15_CPUAPP || SOC_NRF54L10_CPUAPP || SOC_NRF54L05_CPUAPP
+	help
+	  Sets RRAMC's BOOTCONF region protection to disable writes.
+
 endmenu
 
 endif # BM_BOOTLOADER_MCUBOOT


### PR DESCRIPTION
Adds a semi-zephyr project which will lock the bootconf area on supported devices. Generates and flashes a seprate hex file which is also added into the production hex file. Some issues with CMake have also been tidied up to improve readability

Same as https://github.com/nrfconnect/sdk-nrf-bm/pull/493, rebased on latest main with default n for BM_BOOT_BOOTCONF_LOCK_WRITES.