### PR TITLE
tests: lib: bluetooth: ble_adv: fix Kconfig

### DIFF
--- a/tests/lib/bluetooth/ble_adv/Kconfig
+++ b/tests/lib/bluetooth/ble_adv/Kconfig
@@ -1,6 +1,9 @@
-# Redefine this symbol without dependencies, so that tests
-# can enable it without having to enable the dependencies too.
+# Redefine these symbols without dependencies, so that tests
+# can enable them without having to enable the dependencies too.
 config BLE_ADV
+	default y
+
+config BLE_ADV_DATA
 	default y
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
BLE_ADV_DATA is moved out of BLE_ADV and must be enabled manually.

This fixes a unit test issue. 
Tests were not rerun between this and merging #522.