### PR TITLE
include: bm: bluetooth: services: ble_hids: add missing char sec default

### DIFF
--- a/include/bm/bluetooth/services/ble_hids.h
+++ b/include/bm/bluetooth/services/ble_hids.h
@@ -47,6 +47,7 @@ extern "C" {
 #define BLE_HIDS_CONFIG_SEC_MODE_DEFAULT_MOUSE                                                     \
 	{                                                                                          \
 		.hid_info_char.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                           \
+		.report_map_char.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                         \
 		.protocol_mode_char = {                                                            \
 			.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                                 \
 			.write = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                                \
@@ -65,6 +66,7 @@ extern "C" {
 #define BLE_HIDS_CONFIG_SEC_MODE_DEFAULT_KEYBOARD                                                  \
 	{                                                                                          \
 		.hid_info_char.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                           \
+		.report_map_char.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                         \
 		.protocol_mode_char = {                                                            \
 			.read = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                                 \
 			.write = BLE_GAP_CONN_SEC_MODE_ENC_NO_MITM,                                \


### PR DESCRIPTION
Add report map default security. This is required for the device to be recognized as a HID device.