### PR TITLE
storage: bm_storage: fix divide by zero error

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -224,6 +224,8 @@ Libraries
     * To use errno instead of nrf_errors.
     * The :c:func:`bm_storage_init` function to expect an additional input parameter of type pointer to struct :c:struct:`bm_storage_config` for configuring the storage instance that is being initialized.
 
+  * Fixed an issue where the :c:func:`bm_storage_erase` function caused a division-by-0 fault using the SD or RRAM backend.
+
 Bluetooth LE Services
 ---------------------
 

--- a/include/bm/storage/bm_storage.h
+++ b/include/bm/storage/bm_storage.h
@@ -247,6 +247,7 @@ int bm_storage_write(const struct bm_storage *storage, uint32_t dest, const void
  * @retval -EINVAL If @p len is zero or not a multiple of @ref bm_storage_info.erase_unit.
  * @retval -EBUSY If the implementation-specific backend is busy with an ongoing operation.
  * @retval -ENOTSUP If the implementation-specific backend does not implement this function.
+ * @retval -EIO If an implementation-specific internal error occurred.
  */
 int bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t len, void *ctx);
 

--- a/subsys/storage/bm_storage/bm_storage.c
+++ b/subsys/storage/bm_storage/bm_storage.c
@@ -41,6 +41,10 @@ int bm_storage_init(struct bm_storage *storage, const struct bm_storage_config *
 		return -EFAULT;
 	}
 
+	if (bm_storage_info.program_unit == 0) {
+		return -EIO;
+	}
+
 	storage->nvm_info = &bm_storage_info;
 	storage->evt_handler = config->evt_handler;
 	storage->start_addr = config->start_addr;
@@ -131,6 +135,14 @@ int bm_storage_erase(const struct bm_storage *storage, uint32_t addr, uint32_t l
 
 	if (!storage->initialized || !storage->nvm_info) {
 		return -EPERM;
+	}
+
+	if (storage->nvm_info->no_explicit_erase) {
+		return -ENOTSUP;
+	}
+
+	if (storage->nvm_info->erase_unit == 0) {
+		return -EIO;
 	}
 
 	if (len == 0 || len % storage->nvm_info->erase_unit != 0) {

--- a/tests/subsys/storage/bm_storage/src/unity_test.c
+++ b/tests/subsys/storage/bm_storage/src/unity_test.c
@@ -53,7 +53,7 @@ bool bm_storage_backend_is_busy(const struct bm_storage *storage)
 const struct bm_storage_info bm_storage_info = {
 	.erase_unit = BLOCK_SIZE,
 	.program_unit = BLOCK_SIZE,
-	.no_explicit_erase = true
+	.no_explicit_erase = false
 };
 
 static void bm_storage_evt_handler(struct bm_storage_evt *evt)


### PR DESCRIPTION
Fix potential divide by zero error in erase and write.