### PR TITLE
mgmt: mcumgr: grp: settings_mgmt: fix pathlength issue

### DIFF
--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Settings management group public API is exposed by MCUmgr API
 # interface, when settings management is enabled.
-zephyr_library()
+zephyr_library_named(mgmt_mcumgr_grp_settings)
 zephyr_library_sources(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c)
 
 if(CONFIG_MCUMGR_GRP_SETTINGS AND NOT CONFIG_MCUMGR_GRP_SETTINGS_ACCESS_HOOK)


### PR DESCRIPTION
This fixes a pathlength issue where the application would fail to compile due to the pathlength exceeding 260 characters.

Might be a better place for the changelog entry. 