### PR TITLE
doc: s145: remove USE_MDFILE_AS_MAINPAGE to align with S115

### DIFF
--- a/doc/s145/s145.doxyfile.in
+++ b/doc/s145/s145.doxyfile.in
@@ -1124,7 +1124,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = YES
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
Remove USE_MDFILE_AS_MAINPAGE to align with S115.