### PR TITLE
doc: zoomin: correct ncs-bm to nrf-bm

### DIFF
--- a/doc/_zoomin/nrf-bm.apis.custom.properties
+++ b/doc/_zoomin/nrf-bm.apis.custom.properties
@@ -1,2 +1,2 @@
-manual.name=ncs-bm-apis-__VERSION__
+manual.name=nrf-bm-apis-__VERSION__
 booktitle=nRF Connect SDK Bare Metal APIs - __VERSION__

--- a/doc/_zoomin/nrf-bm.custom.properties
+++ b/doc/_zoomin/nrf-bm.custom.properties
@@ -1,2 +1,2 @@
-manual.name=ncs-bm-__VERSION__
+manual.name=nrf-bm-__VERSION__
 booktitle=nRF Connect SDK Bare Metal - __VERSION__


### PR DESCRIPTION
Correct manual.name=ncs-bm-apis-__VERSION__ to
manual.name=nrf-bm-apis-__VERSION__