### PR TITLE
doc: nrf-bm: updates to migration guide

### DIFF
--- a/doc/nrf-bm/links.txt
+++ b/doc/nrf-bm/links.txt
@@ -89,7 +89,8 @@
 
 .. ### Release notes and migration
 
-.. _`nrfx migration guides`: https://github.com/NordicSemiconductor/nrfx/wiki/nrfx-2.11.0-to-3.0.0
+.. _`nrfx 3.0 migration guide`: https://github.com/NordicSemiconductor/nrfx/wiki/nrfx-2.11.0-to-3.0.0
+.. _`nrfx 4.0 migration guide`: https://github.com/NordicSemiconductor/nrfx/wiki/nrfx-3.14.0-to-4.0.0
 .. _`Migration notes - nRF5 SDK to nRF Connect SDK Bare Metal option`: https://docs.nordicsemi.com/bundle/nrf-bm-latest/page/migration/nrf5_bm_migration.html
 .. _`S115 9.0.0-3.prototype API reference`: https://docs.nordicsemi.com/bundle/s115_9.0.0-3.prototype_api/page/topics.html
 .. _`nRF5 SDK DFU memory layout`: https://docs.nordicsemi.com/bundle/sdk_nrf5_v17.1.0/page/lib_bootloader.html

--- a/doc/nrf-bm/migration/nrf5_bm_migration.rst
+++ b/doc/nrf-bm/migration/nrf5_bm_migration.rst
@@ -313,4 +313,5 @@ The desktop and mobile tools available for the |NCS| are also compatible with th
 Drivers
 *******
 
-For migration of nrfx drivers, see `nrfx migration guides`_.
+For migration of nrfx drivers, see the `nrfx 3.0 migration guide`_ and the `nrfx 4.0 migration guide`_.
+|BMshort| is using nRFX 4.0, though details from `nrfx 3.0 migration guide`_ might be required when migrating from nRF5.


### PR DESCRIPTION
* Corrections of supported BLE services and libraries
* Explanation of error code use in BM repo.