### PR TITLE
softdevice_handler: correct return type of sdh_state_evt_observer_notify

### DIFF
--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(nrf_sdh, CONFIG_NRF_SDH_LOG_LEVEL);
 BUILD_ASSERT(PERIPHERAL_LINKS + CENTRAL_LINKS <= CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT,
 	     "Invalid link configuration");
 
-extern int sdh_state_evt_observer_notify(enum nrf_sdh_state_evt state);
+extern bool sdh_state_evt_observer_notify(enum nrf_sdh_state_evt state);
 
 const char *nrf_sdh_ble_evt_to_str(uint32_t evt)
 {


### PR DESCRIPTION
Correct return type of sdh_state_evt_observer_notify extern in nrf_sdh_ble.c

Thanks to @nvlsianpu for reporting. 