### PR TITLE
doc: nrf-bm: lib: bluetooth: services: add ble HRS central

### DIFF
--- a/doc/nrf-bm/api/api.rst
+++ b/doc/nrf-bm/api/api.rst
@@ -195,6 +195,13 @@ Heart Rate Service
 
 .. doxygengroup:: ble_hrs
 
+.. _api_ble_hrs_central:
+
+Heart Rate Service Central
+==========================
+
+.. doxygengroup:: ble_hrs_central
+
 .. _api_human_interface_device_service:
 
 Human Interface Device Service

--- a/doc/nrf-bm/libraries/bluetooth/ble_adv.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_adv.rst
@@ -148,7 +148,6 @@ The application must reply to the :c:enum:`BLE_ADV_EVT_PEER_ADDR_REQUEST` event 
 
    When setting connection-specific configurations using the :c:func:`sd_ble_cfg_set` function, you must create a tag for each configuration.
    This tag must be provided when calling the :c:func:`sd_ble_gap_adv_start` function and the :c:func:`sd_ble_gap_connect` function.
-   If your application uses the advertising library, you must call the :c:func:`ble_advertising_conn_cfg_tag_set` function before starting advertising.
 
 Dependencies
 ************

--- a/doc/nrf-bm/libraries/bluetooth/services/ble_hrs.rst
+++ b/doc/nrf-bm/libraries/bluetooth/services/ble_hrs.rst
@@ -7,13 +7,13 @@ Heart Rate Service (HRS)
    :local:
    :depth: 2
 
-This module implements the Heart Rate Service with the Heart Rate Measurement, Body Sensor Location, and Heart Rate Control Point characteristics.
+This module implements the Heart Rate Service with the Heart Rate Measurement and Body Sensor Location characteristics.
 
 Overview
 ********
 
-During initialization, the module adds the Heart Rate Service and Heart Rate Measurement characteristic to the Bluetooth LE stack database.
-Optionally, it also adds the Body Sensor Location and Heart Rate Control Point characteristics.
+During initialization, the module adds the Heart Rate Service, the Heart Rate Measurement and Body Sensor Location characteristics to the Bluetooth LE stack database.
+Optionally, it also adds the Body Sensor Location characteristics.
 
 If enabled, a notification of the Heart Rate Measurement characteristic is sent when the application calls the :c:func:`ble_hrs_heart_rate_measurement_send` function.
 

--- a/doc/nrf-bm/libraries/bluetooth/services/ble_hrs_central.rst
+++ b/doc/nrf-bm/libraries/bluetooth/services/ble_hrs_central.rst
@@ -1,0 +1,60 @@
+.. _lib_ble_service_hrs_client:
+
+Heart Rate Service (HRS) Client
+###############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This module implements the Heart Rate Service Client to retrieve Heart Rate Measurements and Body Sensor Location from a peripheral device with the :ref:`lib_ble_service_hrs`.
+
+Overview
+********
+
+The HRS Client retrieves information such as the sensor location from a device that provides the Heart Rate Service.
+
+Configuration
+*************
+
+Set the :kconfig:option:`CONFIG_BLE_HRS_CENTRAL` Kconfig option to enable the service.
+
+Set the maximum number of RR intervals for each HRM notification using the :kconfig:option:`CONFIG_BLE_HRS_CENTRAL_RR_INTERVALS_MAX_COUNT` Kconfig option.
+
+Initialization
+==============
+
+The service instance is declared using the :c:macro:`BLE_HRS_CENTRAL_DEF` macro, specifying the name of the instance.
+To initialize the service, call the :c:func:`ble_hrs_central_init` function.
+See the :c:struct:`ble_hrs_central_config` structure for configuration details, in addition to the HRS specification.
+
+Usage
+*****
+
+Applications can use the :ref:`lib_ble_scan` library for detecting advertising devices that support the Heart Rate Service.
+
+Upon connection, the application can use the :ref:`lib_ble_db_discovery` library to discover the peer's database.
+Call the :c:func:`ble_hrs_on_db_disc_evt` function on callback events from the Database Discovery library.
+This function sends the :c:enumerator:`BLE_HRS_CENTRAL_EVT_DISCOVERY_COMPLETE` event to the application if the Heart Rate Service is discovered in the peer's database.
+The application must call the :c:func:`ble_hrs_central_handles_assign` function to associate the link with the HRS Client instance.
+
+Upon Heart Rate Service discovery, the application can call the :c:func:`ble_hrs_central_hrm_notif_enable` function to request the peer to start sending Heart Rate Measurement notifications.
+
+Dependencies
+************
+
+This library uses the following |BMshort| libraries:
+
+* SoftDevice - :kconfig:option:`CONFIG_SOFTDEVICE`
+* :ref:`lib_nrf_sdh` - :kconfig:option:`CONFIG_NRF_SDH`
+* :ref:`lib_ble_db_discovery` - :kconfig:option:`CONFIG_BLE_DB_DISCOVERY`
+
+The library is expected to be used with the :ref:`lib_ble_scan` |BMshort| library - :kconfig:option:`CONFIG_BLE_SCAN`.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bm/bluetooth/services/ble_hrs_central.h`
+| Source files: :file:`subsys/bluetooth/services/ble_hrs_central/`
+
+:ref:`Heart Rate Service API reference <api_ble_hrs_central>`

--- a/include/bm/bluetooth/services/ble_hrs_central.h
+++ b/include/bm/bluetooth/services/ble_hrs_central.h
@@ -159,15 +159,14 @@ struct ble_hrs_central_config {
  *          when a discovery is started.
  *
  * @param[in] ble_hrs_central Heart Rate Client structure.
- * @param[in] ble_hrs_central_init Heart Rate initialization structure that
- * contains the initialization information.
+ * @param[in] ble_hrs_central_config Heart rate service central configuration.
  *
  * @retval NRF_SUCCESS On successful initialization.
  * @return Otherwise, this function propagates the error code returned by the
  *         Database Discovery module API @ref ble_db_discovery_service_register.
  */
 uint32_t ble_hrs_central_init(struct ble_hrs_central *ble_hrs_central,
-			      struct ble_hrs_central_config *ble_hrs_central_init);
+			      struct ble_hrs_central_config *ble_hrs_central_config);
 
 /**
  * @brief Handle Bluetooth LE events from the SoftDevice.


### PR DESCRIPTION
Add documentation for Bluetooth LE HRS Central.
Correct ble_advertising_conn_cfg_tag_set -> ble_adv_conn_cfg_tag_set.