### PR TITLE
boards: nordic: bm_nrf54l15dk: Fix reserved memory location

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
@@ -21,26 +21,24 @@
 	};
 
 	soc {
-		reserved-memory@20000000 {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			reg = <0x20000000 0x80>;
-			ranges;
-
-			nrf_kmu_reserved_push_area: memory@20000000 {
-				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x20000000 0x80>;
-				zephyr,memory-region = "nrf_kmu_reserved_push_area";
-				status = "okay";
-			};
-		};
-
 		cpuapp_sram: memory@20000080 {
 			compatible = "mmio-sram";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x20000080 (DT_SIZE_K(96) - 0x80)>;
 			ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x80)>;
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		nrf_kmu_reserved_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x80>;
+			zephyr,memory-region = "nrf_kmu_reserved_push_area";
 		};
 	};
 };

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -21,26 +21,24 @@
 	};
 
 	soc {
-		reserved-memory@20000000 {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			reg = <0x20000000 0x80>;
-			ranges;
-
-			nrf_kmu_reserved_push_area: memory@20000000 {
-				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x20000000 0x80>;
-				zephyr,memory-region = "nrf_kmu_reserved_push_area";
-				status = "okay";
-			};
-		};
-
 		cpuapp_sram: memory@20000080 {
 			compatible = "mmio-sram";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x20000080 (DT_SIZE_K(192) - 0x80)>;
 			ranges = <0x0 0x20000080 (DT_SIZE_K(192) - 0x80)>;
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		nrf_kmu_reserved_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x80>;
+			zephyr,memory-region = "nrf_kmu_reserved_push_area";
 		};
 	};
 };

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -21,26 +21,24 @@
 	};
 
 	soc {
-		reserved-memory@20000000 {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			reg = <0x20000000 0x80>;
-			ranges;
-
-			nrf_kmu_reserved_push_area: memory@20000000 {
-				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x20000000 0x80>;
-				zephyr,memory-region = "nrf_kmu_reserved_push_area";
-				status = "okay";
-			};
-		};
-
 		cpuapp_sram: memory@20000080 {
 			compatible = "mmio-sram";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x20000080 (DT_SIZE_K(256) - 0x80)>;
 			ranges = <0x0 0x20000080 (DT_SIZE_K(256) - 0x80)>;
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		nrf_kmu_reserved_push_area: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 0x80>;
+			zephyr,memory-region = "nrf_kmu_reserved_push_area";
 		};
 	};
 };


### PR DESCRIPTION
Moves these to the root node instead of being under the soc node