### PR TITLE
samples: bluetooth: ble_hids_mouse: fix issue on entering boot mode

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -98,6 +98,10 @@ Bluetooth LE samples
 
    * Added support for boot mode.
 
+* :ref:`ble_hids_mouse_sample`:
+
+   * Fixed an issue where the sample did not enter or exit boot mode properly based on the HID events.
+
 * :ref:`ble_pwr_profiling_sample`:
 
    * Updated to use a dedicated variable to hold the service attribute handle instead of incorrectly using the connection handle variable for this during service initialization.

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -239,9 +239,11 @@ static void on_hids_evt(struct ble_hids *hids, const struct ble_hids_evt *hids_e
 		break;
 	case BLE_HIDS_EVT_BOOT_MODE_ENTERED:
 		LOG_DBG("Entered boot mode");
+		boot_mode = true;
 		break;
 	case BLE_HIDS_EVT_REPORT_MODE_ENTERED:
 		LOG_DBG("Entered report mode");
+		boot_mode = false;
 		break;
 	case BLE_HIDS_EVT_REPORT_READ:
 		LOG_DBG("Read report event");


### PR DESCRIPTION
The boot mode was not set based on the BLE_HIDS_EVT_BOOT_MODE_ENTERED and BLE_HIDS_EVT_REPORT_MODE_ENTERED events.