### PR TITLE
samples: bluetooth: ble_hrs_central: remove call to ble_scan_params_set

### DIFF
--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -524,13 +524,6 @@ static uint32_t scan_init(void)
 		.evt_handler = scan_evt_handler,
 	};
 
-	ble_gap_scan_params_t scan_params = BLE_SCAN_SCAN_PARAMS_DEFAULT;
-
-	nrf_err = ble_scan_params_set(&ble_scan, &scan_params);
-	if (nrf_err) {
-		LOG_ERR("nrf_ble_scan_params_set failed, nrf_error %#x", nrf_err);
-	}
-
 	nrf_err = ble_scan_init(&ble_scan, &scan_cfg);
 	if (nrf_err) {
 		LOG_ERR("nrf_ble_scan_init failed, nrf_error %#x", nrf_err);


### PR DESCRIPTION
The call to ble_scan_init will set the scan parameters based on the scan_cfg input argument. The call to ble_scan_params_set before that is useless as it is immediately overwritten.

Thanks to Marenges for the find.