### PR TITLE
workflows: checkpatch: exclude BinaryFiles

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -75,6 +75,7 @@ jobs:
           -e KconfigBasicNoModules -e ClangFormat \
           -e SysbuildKconfigBasicNoModules \
           -e LicenseAndCopyrightCheck \
+          -e BinaryFiles
           -c origin/${BASE_REF}..
 
       - name: upload-results


### PR DESCRIPTION
Exclude BinaryFiles check as this fails on SoftDevice PRs. There is no good way to exclude certain folders or filetypes except what is specified directly in the Zephyr check_compliance.py script.

Alternative would be to merge all SoftDevice PRs with red compliance.