### PR TITLE
lib: ble_db_discovery: improvements part two

### DIFF
--- a/doc/nrf-bm/libraries/bluetooth/ble_db_discovery.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_db_discovery.rst
@@ -7,16 +7,21 @@ Bluetooth: Database Discovery library
    :local:
    :depth: 2
 
-This module contains the APIs and types exposed by the Database Discovery module.
-These APIs and types can be used by the application to perform discovery of a service and its characteristics at the peer server.
-This module can also be used to discover the desired services in multiple remote devices.
+This library handles the discovery of a connected peer's database.
+You can use it to discover one or more services and their characteristics at a peer server.
 
 Overview
 ********
 
-The library allows registration of callbacks that trigger upon discoveering selected services and characteristics in the peer device.
+Before starting a discovery, you need to register the UUID of one or more services you want to discover.
+In addition, a GATT queue instance and a callback for handling discovery events must be set during initialization.
 
-.. _lib_ble_db_discovery_configure:
+On discovery start, the library does automatically the necessary SoftDevice calls and handles the necessary events from the SoftDevice to discover the registered services, their characteristics, and possible descriptors.
+To automatically discover services, characteristics, and descriptors, the library calls the SoftDevice discovery functions in response to and based on the content of discovery response events received from the SoftDevice.
+Discovery results for each service will be queued up.
+Once the discovery has been attempted for all registered services, the queued results are dispatched to the callback one at a time.
+
+An event signaling that the instance is available and a new discovery can be started is dispatched when all discovery result events have been passed to the callback.
 
 Configuration
 *************
@@ -24,9 +29,14 @@ Configuration
 To enable and configure the library, use the following Kconfig options:
 
 * :kconfig:option:`CONFIG_BLE_DB_DISCOVERY` - Enables the database discovery library.
-* :kconfig:option:`CONFIG_BLE_DB_DISCOVERY_MAX_SRV`- Sets the maximum number of services that can be discovered.
-* :kconfig:option:`CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE`- Sets the start value used durning discovery.
+* :kconfig:option:`CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE`- Sets the start value used during discovery.
+* :kconfig:option:`CONFIG_BLE_DB_DISCOVERY_MAX_SRV`- Sets the maximum number of service UUIDs that can be registered and subsequently discovered at a time and with one database discovery instance.
+* :kconfig:option:`CONFIG_BLE_GATT_DB_MAX_CHARS` - Sets the maximum number of characteristics for each service that can be discovered.
 
+.. note::
+
+   * The size of the :c:struct:`ble_db_discovery` structure is affected by the choice of both :kconfig:option:`CONFIG_BLE_DB_DISCOVERY_MAX_SRV` and :kconfig:option:`CONFIG_BLE_GATT_DB_MAX_CHARS`.
+   * The size of the :c:struct:`ble_gatt_db_srv` structure is affected by the choice of :kconfig:option:`CONFIG_BLE_GATT_DB_MAX_CHARS`.
 
 Initialization
 ==============
@@ -37,9 +47,21 @@ See the :c:struct:`ble_db_discovery_config` structure for configuration details.
 Usage
 *****
 
-After initialization, use the :c:func:`ble_db_discovery_service_register` function to register a callback that triggers when a service is discovered with a specific UUID.
-To start discovering from a peer, you must use the :c:func:`ble_db_discovery_start` function with the connection handle of the peer device.
+After initialization, use the :c:func:`ble_db_discovery_service_register` function to register one or more service UUIDs for discovery.
+A registered service UUID will stay registered even after a discovery completes.
+This makes it possible to run discovery of the same services on different peers without having to register the services again.
+You can use the :c:func:`ble_db_discovery_init` function to clear the registered service UUIDs.
+
+To start discovering a peer's database, you must use the :c:func:`ble_db_discovery_start` function with the connection handle of the peer device.
 For example, you can call the :c:func:`ble_db_discovery_start` function when the ble event :c:enum:`BLE_GAP_EVT_CONNECTED` event is triggered and use the connection handle from the event as the second argument in the :c:func:`ble_db_discovery_start` function.
+
+When the discovery procedure completes, an event of either type :c:enumerator:`BLE_DB_DISCOVERY_COMPLETE` or :c:enumerator:`BLE_DB_DISCOVERY_SRV_NOT_FOUND` is raised for each registered service UUID.
+An event of type :c:enumerator:`BLE_DB_DISCOVERY_COMPLETE` indicates that a service was found in the peer's database and the discovery result can be found by dereferencing the :c:member:`ble_db_discovery_evt.discovered_db` parameter.
+The service UUID can be found in the discovery result.
+An event of type :c:enumerator:`BLE_DB_DISCOVERY_SRV_NOT_FOUND` indicates that a service was not found in the peer's database.
+The service UUID can be found from the :c:member:`ble_db_discovery_evt.srv_uuid` parameter.
+
+When all discovery result events have been passed to the event handler, an additional event of type :c:enumerator:`BLE_DB_DISCOVERY_AVAILABLE` is passed to indicate that a new discovery can now be started using the :c:func:`ble_db_discovery_start` function.
 
 Dependencies
 ************
@@ -47,7 +69,8 @@ Dependencies
 This library uses the following |BMshort| libraries:
 
 * SoftDevice - :kconfig:option:`CONFIG_SOFTDEVICE`
-* SoftDevice handler - :kconfig:option:`CONFIG_NRF_SDH`
+* :ref:`lib_nrf_sdh` - :kconfig:option:`CONFIG_NRF_SDH`
+* :ref:`lib_ble_gatt_queue` - :kconfig:option:`CONFIG_BLE_GATT_QUEUE`
 
 API documentation
 *****************

--- a/doc/nrf-bm/migration/nrf5_bm_migration.rst
+++ b/doc/nrf-bm/migration/nrf5_bm_migration.rst
@@ -160,7 +160,7 @@ See table below for a summary of supported libraries.
      - Yes
      -
      -
-     - Experimental
+     -
    * - ``ble_conn_params``
      - Yes
      - Name unchanged

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -151,6 +151,8 @@ Libraries
    * Updated:
 
       * The ``params`` union field of the :c:struct:`ble_db_discovery_evt` structure to an anonymous union.
+      * The :c:enumerator:`BLE_DB_DISCOVERY_COMPLETE` event to pass the service discovery result by-reference instead of by-value.
+        This removes one copy operation for each :c:enumerator:`BLE_DB_DISCOVERY_COMPLETE` event and significantly reduces the size of both :c:struct:`ble_db_discovery_evt` and :c:struct:`ble_db_discovery` structures.
 
    * Fixed:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -148,7 +148,13 @@ Libraries
 
 * :ref:`lib_ble_db_discovery`:
 
-   * Removed the :c:struct:`ble_db_discovery_user_evt` structure after a rework.
+   * Updated:
+
+      * The ``params`` union field of the :c:struct:`ble_db_discovery_evt` structure to an anonymous union.
+
+   * Removed:
+
+      * The ``ble_db_discovery_user_evt`` structure after a rework.
 
 * :ref:`lib_ble_scan`:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -146,7 +146,9 @@ Libraries
       * An issue causing slow advertising with allow list to incorrectly send event :c:enumerator:`BLE_ADV_EVT_SLOW` when it should have sent event :c:enumerator:`BLE_ADV_EVT_SLOW_ALLOW_LIST`.
       * An issue in the data module where the short name would not be matched in certain cases.
 
-* :ref:`lib_ble_db_discovery`:
+* :ref:`lib_ble_db_discovery` library:
+
+   The library is now supported.
 
    * Updated:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -152,6 +152,11 @@ Libraries
 
       * The ``params`` union field of the :c:struct:`ble_db_discovery_evt` structure to an anonymous union.
 
+   * Fixed:
+
+      * An issue where starting a second round of discovery, after either a disconnect or a completed discovery, could result in incorrect internal state.
+        This could eventually lead to insufficient memory for discovering new services.
+
    * Removed:
 
       * The ``ble_db_discovery_user_evt`` structure after a rework.

--- a/include/bm/bluetooth/ble_db_discovery.h
+++ b/include/bm/bluetooth/ble_db_discovery.h
@@ -69,16 +69,18 @@ struct ble_db_discovery_evt {
 	uint16_t conn_handle;
 	union {
 		/**
-		 * @brief Parameters for
-		 * - @ref BLE_DB_DISCOVERY_COMPLETE
-		 * - @ref BLE_DB_DISCOVERY_SRV_NOT_FOUND
+		 * @brief Parameters for @ref BLE_DB_DISCOVERY_COMPLETE.
 		 *
-		 * Contains information about the GATT Database at the server.
+		 * Result of one service discovery at the server's GATT Database.
 		 *
-		 * Only the UUID field will be filled when the event type is
-		 * @ref BLE_DB_DISCOVERY_SRV_NOT_FOUND.
+		 * This points to data stored in the ble_db_discovery instance.
+		 * The pointer should be considered invalid after returning from the event handler.
 		 */
-		struct ble_gatt_db_srv discovered_db;
+		const struct ble_gatt_db_srv *discovered_db;
+		/**
+		 * @brief Parameters for @ref BLE_DB_DISCOVERY_SRV_NOT_FOUND.
+		 */
+		ble_uuid_t srv_uuid;
 		/**
 		 * @brief Parameters for @ref BLE_DB_DISCOVERY_ERROR.
 		 */

--- a/include/bm/bluetooth/ble_db_discovery.h
+++ b/include/bm/bluetooth/ble_db_discovery.h
@@ -88,7 +88,7 @@ struct ble_db_discovery_evt {
 			 */
 			uint32_t reason;
 		} error;
-	} params;
+	};
 };
 
 /* Forward declaration. */

--- a/lib/bluetooth/ble_db_discovery/Kconfig
+++ b/lib/bluetooth/ble_db_discovery/Kconfig
@@ -5,11 +5,10 @@
 #
 
 menuconfig BLE_DB_DISCOVERY
-	bool "BLE database discovery [EXPERIMENTAL]"
+	bool "BLE database discovery"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_GATT_QUEUE
-	select EXPERIMENTAL
 
 if BLE_DB_DISCOVERY
 

--- a/lib/bluetooth/ble_db_discovery/Kconfig
+++ b/lib/bluetooth/ble_db_discovery/Kconfig
@@ -5,7 +5,7 @@
 #
 
 menuconfig BLE_DB_DISCOVERY
-	bool "BLE DB discovery [EXPERIMENTAL]"
+	bool "BLE database discovery [EXPERIMENTAL]"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_GATT_QUEUE

--- a/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
+++ b/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
@@ -127,9 +127,14 @@ static void discovery_complete_evt_trigger(struct ble_db_discovery *db_discovery
 
 	/* Insert an event into the pending event list. */
 	usr_evt->conn_handle = conn_handle;
-	usr_evt->discovered_db = *srv_being_discovered;
-	usr_evt->evt_type = (is_srv_found == true) ? BLE_DB_DISCOVERY_COMPLETE :
-						     BLE_DB_DISCOVERY_SRV_NOT_FOUND;
+	if (is_srv_found) {
+		usr_evt->evt_type = BLE_DB_DISCOVERY_COMPLETE;
+		usr_evt->discovered_db = srv_being_discovered;
+	} else {
+		usr_evt->evt_type = BLE_DB_DISCOVERY_SRV_NOT_FOUND;
+		usr_evt->srv_uuid = srv_being_discovered->srv_uuid;
+	}
+
 	db_discovery->pending_usr_evt_idx++;
 
 	if (db_discovery->pending_usr_evt_idx == db_discovery->num_registered_uuids) {

--- a/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
+++ b/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
@@ -79,7 +79,7 @@ static void discovery_error_evt_trigger(struct ble_db_discovery *db_discovery, u
 		struct ble_db_discovery_evt evt = {
 			.evt_type = BLE_DB_DISCOVERY_ERROR,
 			.conn_handle = conn_handle,
-			.params.error.reason = nrf_err,
+			.error.reason = nrf_err,
 		};
 
 		db_discovery->evt_handler(db_discovery, &evt);
@@ -123,7 +123,7 @@ static void discovery_complete_evt_trigger(struct ble_db_discovery *db_discovery
 
 	/* Insert an event into the pending event list. */
 	usr_evt->conn_handle = conn_handle;
-	usr_evt->params.discovered_db = *srv_being_discovered;
+	usr_evt->discovered_db = *srv_being_discovered;
 	usr_evt->evt_type = (is_srv_found == true) ? BLE_DB_DISCOVERY_COMPLETE :
 						     BLE_DB_DISCOVERY_SRV_NOT_FOUND;
 	db_discovery->pending_usr_evt_idx++;

--- a/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
+++ b/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
@@ -13,11 +13,15 @@
 #include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(ble_db_disc, CONFIG_BLE_DB_DISCOVERY_LOG_LEVEL);
 
 static inline struct ble_gatt_db_srv *curr_discovered_srv_get(struct ble_db_discovery *db_discovery)
 {
+	__ASSERT(db_discovery->curr_srv_idx < CONFIG_BLE_DB_DISCOVERY_MAX_SRV,
+		 "Service index out of range");
+
 	return &(db_discovery->services[db_discovery->curr_srv_idx]);
 }
 
@@ -548,16 +552,23 @@ static void on_descriptor_discovery_rsp(struct ble_db_discovery *const db_discov
 static uint32_t discovery_start(struct ble_db_discovery *const db_discovery, uint16_t conn_handle)
 {
 	int nrf_err;
-	struct ble_gatt_db_srv *const srv_being_discovered = curr_discovered_srv_get(db_discovery);
+	struct ble_gatt_db_srv *srv_being_discovered;
 
 	nrf_err = ble_gq_conn_handle_register(db_discovery->gatt_queue, conn_handle);
 	if (nrf_err) {
 		return nrf_err;
 	}
 
+	db_discovery->srv_count = 0;
+	db_discovery->curr_char_idx = 0;
+	db_discovery->curr_srv_idx = 0;
+	db_discovery->discoveries_count = 0;
 	db_discovery->conn_handle = conn_handle;
+	db_discovery->pending_usr_evt_idx = 0;
 
+	srv_being_discovered = curr_discovered_srv_get(db_discovery);
 	srv_being_discovered->srv_uuid = db_discovery->registered_uuids[db_discovery->curr_srv_idx];
+	srv_being_discovered->char_count = 0;
 
 	LOG_DBG("Starting discovery of service with UUID %#x on connection handle %#x",
 		srv_being_discovered->srv_uuid.uuid, conn_handle);

--- a/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
+++ b/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
@@ -137,14 +137,14 @@ void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
 
 	/* Check if the Heart Rate Service was discovered. */
 	if (evt->evt_type != BLE_DB_DISCOVERY_COMPLETE ||
-	    evt->discovered_db.srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
-	    evt->discovered_db.srv_uuid.type != BLE_UUID_TYPE_BLE) {
+	    evt->discovered_db->srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
+	    evt->discovered_db->srv_uuid.type != BLE_UUID_TYPE_BLE) {
 		return;
 	}
 
 	/* Find the CCCD Handle of the Heart Rate Measurement characteristic. */
-	for (uint32_t i = 0; i < evt->discovered_db.char_count; i++) {
-		db_char = &evt->discovered_db.characteristics[i];
+	for (uint32_t i = 0; i < evt->discovered_db->char_count; i++) {
+		db_char = &evt->discovered_db->characteristics[i];
 
 		if (db_char->characteristic.uuid.uuid == BLE_UUID_HEART_RATE_MEASUREMENT_CHAR) {
 			/* Found Heart Rate characteristic. Store CCCD handle and break. */

--- a/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
+++ b/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
@@ -137,14 +137,14 @@ void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
 
 	/* Check if the Heart Rate Service was discovered. */
 	if (evt->evt_type != BLE_DB_DISCOVERY_COMPLETE ||
-	    evt->params.discovered_db.srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
-	    evt->params.discovered_db.srv_uuid.type != BLE_UUID_TYPE_BLE) {
+	    evt->discovered_db.srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
+	    evt->discovered_db.srv_uuid.type != BLE_UUID_TYPE_BLE) {
 		return;
 	}
 
 	/* Find the CCCD Handle of the Heart Rate Measurement characteristic. */
-	for (uint32_t i = 0; i < evt->params.discovered_db.char_count; i++) {
-		db_char = &evt->params.discovered_db.characteristics[i];
+	for (uint32_t i = 0; i < evt->discovered_db.char_count; i++) {
+		db_char = &evt->discovered_db.characteristics[i];
 
 		if (db_char->characteristic.uuid.uuid == BLE_UUID_HEART_RATE_MEASUREMENT_CHAR) {
 			/* Found Heart Rate characteristic. Store CCCD handle and break. */

--- a/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
@@ -15,7 +15,7 @@
 BLE_DB_DISCOVERY_DEF(db_discovery);
 static struct ble_gq ble_gatt_queue;
 
-static struct ble_db_discovery_evt db_disc_evt[4];
+static struct ble_db_discovery_evt db_disc_evt[8];
 static uint32_t db_disc_evt_count;
 
 static uint16_t test_conn_handle;
@@ -574,6 +574,510 @@ void test_scenario_discover_two_services(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 	db_char = &db_srv->characteristics[1];
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_char2_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+}
+
+static uint32_t stub_ble_gq_item_scenario_two_back_to_back_discoveries(
+	const struct ble_gq *gatt_queue, struct ble_gq_req *req, uint16_t conn_handle,
+	int cmock_num_calls)
+{
+	stub_ble_gq_item_add_success_num_calls = cmock_num_calls + 1;
+
+	TEST_ASSERT_EQUAL_PTR(&ble_gatt_queue, gatt_queue);
+	TEST_ASSERT_EQUAL(test_conn_handle, conn_handle);
+
+	TEST_ASSERT_NOT_NULL(req->evt_handler);
+	TEST_ASSERT_EQUAL_PTR(&db_discovery, req->ctx);
+
+	switch (stub_ble_gq_item_add_success_num_calls) {
+	/* Discovery 1 of 2. */
+	case 1:
+		/* Check service 1 discovery request. */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_SRV_DISCOVERY, req->type);
+		TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &req->gattc_srv_disc.srvc_uuid));
+		TEST_ASSERT_EQUAL(CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE,
+				  req->gattc_srv_disc.start_handle);
+		break;
+	case 2:
+		/* Check characteristic 1 discovery request (service 1). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x0001, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0x0005, req->gattc_char_disc.end_handle);
+		break;
+	case 3:
+		/* Check characteristic 2 discovery request (service 1). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x0004, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0x0005, req->gattc_char_disc.end_handle);
+		break;
+	case 4:
+		/* Check service 2 discovery request. */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_SRV_DISCOVERY, req->type);
+		TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &req->gattc_srv_disc.srvc_uuid));
+		TEST_ASSERT_EQUAL(CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE,
+				  req->gattc_srv_disc.start_handle);
+		break;
+	case 5:
+		/* Check characteristic 1 discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x0007, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_char_disc.end_handle);
+		break;
+	case 6:
+		/* Check characteristic 2 discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x000A, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_char_disc.end_handle);
+		break;
+	case 7:
+		/* Check characteristic 3 discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x000C, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_char_disc.end_handle);
+		break;
+	case 8:
+		/* Check descriptor discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_DESC_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x000C, req->gattc_desc_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_desc_disc.end_handle);
+		break;
+
+	/* Discovery 2 of 2. */
+	case 9:
+		/* Check service 1 discovery request. */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_SRV_DISCOVERY, req->type);
+		TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &req->gattc_srv_disc.srvc_uuid));
+		TEST_ASSERT_EQUAL(CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE,
+				  req->gattc_srv_disc.start_handle);
+		break;
+	case 10:
+		/* Check characteristic 1 discovery request (service 1). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x0011, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0x0013, req->gattc_char_disc.end_handle);
+		break;
+	case 11:
+		/* Check service 2 discovery request. */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_SRV_DISCOVERY, req->type);
+		TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &req->gattc_srv_disc.srvc_uuid));
+		TEST_ASSERT_EQUAL(CONFIG_BLE_DB_DISCOVERY_SRV_DISC_START_HANDLE,
+				  req->gattc_srv_disc.start_handle);
+		break;
+	case 12:
+		/* Check characteristic 1 discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x0017, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_char_disc.end_handle);
+		break;
+	case 13:
+		/* Check characteristic 2 discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_CHAR_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x001A, req->gattc_char_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_char_disc.end_handle);
+		break;
+	case 14:
+		/* Check descriptor discovery request (service 2). */
+		TEST_ASSERT_EQUAL(BLE_GQ_REQ_DESC_DISCOVERY, req->type);
+		TEST_ASSERT_EQUAL(0x001A, req->gattc_desc_disc.start_handle);
+		TEST_ASSERT_EQUAL(0xFFFF, req->gattc_desc_disc.end_handle);
+		break;
+	default:
+		TEST_FAIL();
+	}
+	return NRF_SUCCESS;
+}
+
+void test_scenario_two_back_to_back_discoveries(void)
+{
+	uint32_t nrf_err;
+	ble_evt_t evt;
+	ble_gattc_handle_range_t range;
+
+	__cmock_ble_gq_item_add_Stub(stub_ble_gq_item_scenario_two_back_to_back_discoveries);
+	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&ble_gatt_queue, test_conn_handle,
+							    NRF_SUCCESS);
+
+	nrf_err = ble_db_discovery_init(&db_discovery, &db_disc_config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Register UUID of service 1. */
+	nrf_err = ble_db_discovery_service_register(&db_discovery, &srv1_uuid);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Register UUID of service 2. */
+	nrf_err = ble_db_discovery_service_register(&db_discovery, &srv2_uuid);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Discovery 1 of 2. */
+
+	/* Start Discovery. Sends a Primary Service Discovery Request. */
+	nrf_err = ble_db_discovery_start(&db_discovery, test_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_EQUAL(1, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Primary Service Discovery Response from SoftDevice (service 1).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	range = (ble_gattc_handle_range_t) {.start_handle = 0x0001, .end_handle = 0x0005};
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.prim_srvc_disc_rsp = {
+				.count = 1,
+				.services[0] = {.uuid = srv1_uuid, .handle_range = range},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(2, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 1 of service 1).
+	 * Another Characteristic Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv1_char1_uuid,
+					.handle_decl = 0x0002,
+					.handle_value = 0x0003,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(3, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 2 of service 1).
+	 * A Service Discovery Request (next service) is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv1_char2_uuid,
+					.handle_decl = 0x0004,
+					.handle_value = 0x0005,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(4, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Primary Service Discovery Response from SoftDevice (service 2).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	range = (ble_gattc_handle_range_t) {.start_handle = 0x0007, .end_handle = 0xFFFF};
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.prim_srvc_disc_rsp = {
+				.count = 1,
+				.services[0] = {.uuid = srv2_uuid, .handle_range = range},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(5, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 1 of service 2).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv2_char1_uuid,
+					.handle_decl = 0x0008,
+					.handle_value = 0x0009,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(6, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 2 of service 2).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv2_char2_uuid,
+					.handle_decl = 0x000A,
+					.handle_value = 0x000B,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(7, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (No more chars found).
+	 * A Descriptor Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_FOUND,
+			.conn_handle = test_conn_handle,
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(8, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(0, db_disc_evt_count);
+
+	/* Simulate Descriptor Discovery Response from SoftDevice (No descriptors found).
+	 *
+	 * Discovery completed!
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_DESC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_FOUND,
+			.conn_handle = test_conn_handle,
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(8, stub_ble_gq_item_add_success_num_calls);
+
+	/* Expect a BLE_DB_DISCOVERY_COMPLETE event for each registered service (two services).
+	 * Then, expect a BLE_DB_DISCOVERY_AVAILABLE event.
+	 */
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_COMPLETE, db_disc_evt[0].evt_type);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_COMPLETE, db_disc_evt[1].evt_type);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_AVAILABLE, db_disc_evt[2].evt_type);
+
+	const struct ble_gatt_db_srv *db_srv;
+	const struct ble_gatt_db_char *db_char;
+
+	/* Check service 1 discovery result. */
+	db_srv = &db_disc_evt[0].discovered_db;
+	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
+	TEST_ASSERT_EQUAL(2, db_srv->char_count);
+	TEST_ASSERT_EQUAL(0x0001, db_srv->handle_range.start_handle);
+	TEST_ASSERT_EQUAL(0x0005, db_srv->handle_range.end_handle);
+	db_char = &db_srv->characteristics[0];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_char1_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+	db_char = &db_srv->characteristics[1];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_char2_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+
+	/* Check service 2 discovery result. */
+	db_srv = &db_disc_evt[1].discovered_db;
+	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
+	TEST_ASSERT_EQUAL(2, db_srv->char_count);
+	TEST_ASSERT_EQUAL(0x0007, db_srv->handle_range.start_handle);
+	TEST_ASSERT_EQUAL(0xFFFF, db_srv->handle_range.end_handle);
+	db_char = &db_srv->characteristics[0];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_char1_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+	db_char = &db_srv->characteristics[1];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_char2_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+
+	/* Discovery 2 of 2. */
+
+	test_conn_handle++;
+
+	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&ble_gatt_queue, test_conn_handle,
+							    NRF_SUCCESS);
+
+	/* Start Discovery. Sends a Primary Service Discovery Request. */
+	nrf_err = ble_db_discovery_start(&db_discovery, test_conn_handle);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_EQUAL(9, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate a Primary Service Discovery Response from SoftDevice (service 1).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	range = (ble_gattc_handle_range_t) {.start_handle = 0x0011, .end_handle = 0x0013};
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.prim_srvc_disc_rsp = {
+				.count = 1,
+				.services[0] = {.uuid = srv1_uuid, .handle_range = range},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(10, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 1 of service 1).
+	 * Another Characteristic Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv1_char1_uuid,
+					.handle_decl = 0x0012,
+					.handle_value = 0x0013,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(11, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate a Primary Service Discovery Response from SoftDevice (service 2).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	range = (ble_gattc_handle_range_t) {.start_handle = 0x0017, .end_handle = 0xFFFF};
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.prim_srvc_disc_rsp = {
+				.count = 1,
+				.services[0] = {.uuid = srv2_uuid, .handle_range = range},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(12, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (char 1 of service 2).
+	 * A Characteristic Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_SUCCESS,
+			.conn_handle = test_conn_handle,
+			.params.char_disc_rsp = {
+				.count = 1,
+				.chars[0] = {
+					.uuid = srv2_char1_uuid,
+					.handle_decl = 0x0018,
+					.handle_value = 0x0019,
+				},
+			},
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(13, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate a Characteristic Discovery Response from SoftDevice. (No more chars found).
+	 * A Descriptor Discovery Request is expected sent in response to this.
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_CHAR_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_FOUND,
+			.conn_handle = test_conn_handle,
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(14, stub_ble_gq_item_add_success_num_calls);
+	TEST_ASSERT_EQUAL(3, db_disc_evt_count);
+
+	/* Simulate Descriptor Discovery Response from SoftDevice (No descriptors found).
+	 *
+	 * Discovery completed!
+	 */
+	evt = (ble_evt_t) {
+		.header.evt_id = BLE_GATTC_EVT_DESC_DISC_RSP,
+		.evt.gattc_evt = {
+			.gatt_status = BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_FOUND,
+			.conn_handle = test_conn_handle,
+		},
+	};
+	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
+	TEST_ASSERT_EQUAL(14, stub_ble_gq_item_add_success_num_calls);
+
+	/* Expect a BLE_DB_DISCOVERY_COMPLETE event for each registered service (two services).
+	 * Then, expect a BLE_DB_DISCOVERY_AVAILABLE event.
+	 */
+	TEST_ASSERT_EQUAL(6, db_disc_evt_count);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_COMPLETE, db_disc_evt[3].evt_type);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_COMPLETE, db_disc_evt[4].evt_type);
+	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_AVAILABLE, db_disc_evt[5].evt_type);
+
+	/* Check service 1 discovery result. */
+	db_srv = &db_disc_evt[3].discovered_db;
+	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[3].conn_handle);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
+	TEST_ASSERT_EQUAL(1, db_srv->char_count);
+	TEST_ASSERT_EQUAL(0x0011, db_srv->handle_range.start_handle);
+	TEST_ASSERT_EQUAL(0x0013, db_srv->handle_range.end_handle);
+	db_char = &db_srv->characteristics[0];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_char1_uuid, &db_char->characteristic.uuid));
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
+
+	/* Check service 2 discovery result. */
+	db_srv = &db_disc_evt[4].discovered_db;
+	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[4].conn_handle);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
+	TEST_ASSERT_EQUAL(1, db_srv->char_count);
+	TEST_ASSERT_EQUAL(0x0017, db_srv->handle_range.start_handle);
+	TEST_ASSERT_EQUAL(0xFFFF, db_srv->handle_range.end_handle);
+	db_char = &db_srv->characteristics[0];
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_char1_uuid, &db_char->characteristic.uuid));
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->cccd_handle);
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->ext_prop_handle);
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->user_desc_handle);

--- a/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
@@ -540,7 +540,7 @@ void test_scenario_discover_two_services(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].params.discovered_db;
+	db_srv = &db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -560,7 +560,7 @@ void test_scenario_discover_two_services(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[1].params.discovered_db;
+	db_srv = &db_disc_evt[1].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -855,7 +855,7 @@ void test_scenario_discover_one_srvc_with_descriptors(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].params.discovered_db;
+	db_srv = &db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(4, db_srv->char_count);
@@ -1046,13 +1046,13 @@ void test_scenario_discover_one_of_three_services_found(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].params.discovered_db;
+	db_srv = &db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(0, db_srv->char_count);
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[1].params.discovered_db;
+	db_srv = &db_disc_evt[1].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -1066,7 +1066,7 @@ void test_scenario_discover_one_of_three_services_found(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 3 discovery result. */
-	db_srv = &db_disc_evt[2].params.discovered_db;
+	db_srv = &db_disc_evt[2].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[2].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv3_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(0, db_srv->char_count);
@@ -1238,7 +1238,7 @@ void test_scenario_ignore_discovery_responses_for_other_conn_handles(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].params.discovered_db;
+	db_srv = &db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -1455,7 +1455,7 @@ void test_scenario_ble_gq_item_add_no_mem(void)
 	TEST_ASSERT_EQUAL(2, stub_ble_gq_item_add_success_num_calls);
 	TEST_ASSERT_EQUAL(2, db_disc_evt_count);
 	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_ERROR, db_disc_evt[0].evt_type);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, db_disc_evt[0].params.error.reason);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, db_disc_evt[0].error.reason);
 	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_AVAILABLE, db_disc_evt[1].evt_type);
 
 	/* Restart Discovery. Sends a Primary Service Discovery Request. */
@@ -1489,7 +1489,7 @@ void test_scenario_ble_gq_item_add_no_mem(void)
 	TEST_ASSERT_EQUAL(4, stub_ble_gq_item_add_success_num_calls);
 	TEST_ASSERT_EQUAL(4, db_disc_evt_count);
 	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_ERROR, db_disc_evt[2].evt_type);
-	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, db_disc_evt[2].params.error.reason);
+	TEST_ASSERT_EQUAL(NRF_ERROR_NO_MEM, db_disc_evt[2].error.reason);
 	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_AVAILABLE, db_disc_evt[3].evt_type);
 }
 

--- a/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
@@ -15,6 +15,7 @@
 BLE_DB_DISCOVERY_DEF(db_discovery);
 static struct ble_gq ble_gatt_queue;
 
+static struct ble_gatt_db_srv db_disc_srv[8];
 static struct ble_db_discovery_evt db_disc_evt[8];
 static uint32_t db_disc_evt_count;
 
@@ -52,11 +53,23 @@ static const ble_uuid_t rrd_uuid = {
 static void db_discovery_evt_handler(struct ble_db_discovery *db_discovery,
 				     struct ble_db_discovery_evt *evt)
 {
-	if (db_disc_evt_count >= ARRAY_SIZE(db_disc_evt)) {
+	if (db_disc_evt_count >= ARRAY_SIZE(db_disc_evt) &&
+	    db_disc_evt_count >= ARRAY_SIZE(db_disc_srv)) {
 		TEST_FAIL_MESSAGE("Not enough space to store all generated db_discovery events.");
 	}
 
-	db_disc_evt[db_disc_evt_count++] = *evt;
+	db_disc_evt[db_disc_evt_count] = *evt;
+
+	switch (evt->evt_type) {
+	case BLE_DB_DISCOVERY_COMPLETE:
+		/* Copy out the full result of the discovery from the pointer in the event. */
+		db_disc_srv[db_disc_evt_count] = *(db_disc_evt[db_disc_evt_count].discovered_db);
+		break;
+	default:
+		break;
+	}
+
+	db_disc_evt_count++;
 }
 
 static const struct ble_db_discovery_config db_disc_config = {
@@ -540,7 +553,7 @@ void test_scenario_discover_two_services(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].discovered_db;
+	db_srv = db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -560,7 +573,7 @@ void test_scenario_discover_two_services(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[1].discovered_db;
+	db_srv = db_disc_evt[1].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -885,7 +898,7 @@ void test_scenario_two_back_to_back_discoveries(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].discovered_db;
+	db_srv = db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -905,7 +918,7 @@ void test_scenario_two_back_to_back_discoveries(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[1].discovered_db;
+	db_srv = db_disc_evt[1].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(2, db_srv->char_count);
@@ -1056,7 +1069,7 @@ void test_scenario_two_back_to_back_discoveries(void)
 	TEST_ASSERT_EQUAL(BLE_DB_DISCOVERY_AVAILABLE, db_disc_evt[5].evt_type);
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[3].discovered_db;
+	db_srv = db_disc_evt[3].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[3].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -1070,7 +1083,7 @@ void test_scenario_two_back_to_back_discoveries(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[4].discovered_db;
+	db_srv = db_disc_evt[4].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[4].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -1359,7 +1372,7 @@ void test_scenario_discover_one_srvc_with_descriptors(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].discovered_db;
+	db_srv = db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(4, db_srv->char_count);
@@ -1534,6 +1547,7 @@ void test_scenario_discover_one_of_three_services_found(void)
 			.conn_handle = test_conn_handle,
 		},
 	};
+
 	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
 	TEST_ASSERT_EQUAL(4, stub_ble_gq_item_add_success_num_calls);
 
@@ -1550,13 +1564,11 @@ void test_scenario_discover_one_of_three_services_found(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
-	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
-	TEST_ASSERT_EQUAL(0, db_srv->char_count);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_disc_evt[0].srv_uuid));
 
 	/* Check service 2 discovery result. */
-	db_srv = &db_disc_evt[1].discovered_db;
+	db_srv = db_disc_evt[1].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[1].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv2_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -1570,10 +1582,8 @@ void test_scenario_discover_one_of_three_services_found(void)
 	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, db_char->report_ref_handle);
 
 	/* Check service 3 discovery result. */
-	db_srv = &db_disc_evt[2].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[2].conn_handle);
-	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv3_uuid, &db_srv->srv_uuid));
-	TEST_ASSERT_EQUAL(0, db_srv->char_count);
+	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv3_uuid, &db_disc_evt[2].srv_uuid));
 }
 
 static uint32_t stub_ble_gq_item_add_scenario_ignore_other_conn_handles(
@@ -1742,7 +1752,7 @@ void test_scenario_ignore_discovery_responses_for_other_conn_handles(void)
 	const struct ble_gatt_db_char *db_char;
 
 	/* Check service 1 discovery result. */
-	db_srv = &db_disc_evt[0].discovered_db;
+	db_srv = db_disc_evt[0].discovered_db;
 	TEST_ASSERT_EQUAL(test_conn_handle, db_disc_evt[0].conn_handle);
 	TEST_ASSERT_TRUE(BLE_UUID_EQ(&srv1_uuid, &db_srv->srv_uuid));
 	TEST_ASSERT_EQUAL(1, db_srv->char_count);
@@ -2003,6 +2013,7 @@ void setUp(void)
 	memset(&db_discovery, 0, sizeof(db_discovery));
 
 	/* Clear the database event global variables before each test. */
+	memset(db_disc_srv, 0xFF, sizeof(db_disc_srv));
 	memset(db_disc_evt, 0xFF, sizeof(db_disc_evt));
 	db_disc_evt_count = 0;
 

--- a/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
@@ -380,14 +380,17 @@ void test_ble_hrs_on_db_disc_evt_wrong_service_ignored(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
+			.uuid = BLE_UUID_BATTERY_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
+		},
+		.char_count = 0,
+	};
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
-			.uuid = BLE_UUID_BATTERY_SERVICE,
-		},
-		.discovered_db.char_count = 0,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -411,13 +414,16 @@ void test_ble_hrs_on_db_disc_evt_srv_not_found_ignored(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
+			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
+		},
+	};
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_SRV_NOT_FOUND,
 		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
-			.uuid = BLE_UUID_HEART_RATE_SERVICE,
-		},
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -441,21 +447,24 @@ void test_ble_hrs_on_db_disc_evt_complete_with_hrm_char(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct ble_db_discovery_evt evt = {
-		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
-		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
 		},
-		.discovered_db.char_count = 1,
-		.discovered_db.characteristics = {
+		.char_count = 1,
+		.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				.characteristic.handle_value = HRM_HANDLE,
 				.cccd_handle = HRM_CCCD_HANDLE,
 			},
 		},
+	};
+	struct ble_db_discovery_evt evt = {
+		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
+		.conn_handle = CONN_HANDLE,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -483,15 +492,13 @@ void test_ble_hrs_on_db_disc_evt_hrm_char_at_index_one(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct ble_db_discovery_evt evt = {
-		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
-		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
 		},
-		.discovered_db.char_count = 2,
-		.discovered_db.characteristics = {
+		.char_count = 2,
+		.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_BODY_SENSOR_LOCATION_CHAR,
 				.characteristic.handle_value = 0x000E,
@@ -503,6 +510,11 @@ void test_ble_hrs_on_db_disc_evt_hrm_char_at_index_one(void)
 				.cccd_handle = HRM_CCCD_HANDLE,
 			},
 		},
+	};
+	struct ble_db_discovery_evt evt = {
+		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
+		.conn_handle = CONN_HANDLE,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -532,14 +544,17 @@ void test_ble_hrs_on_db_disc_evt_complete_hrs_no_hrm_char(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
+			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
+		},
+		.char_count = 0,
+	};
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
-			.uuid = BLE_UUID_HEART_RATE_SERVICE,
-		},
-		.discovered_db.char_count = 0,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -578,15 +593,13 @@ void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigne
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
-	struct ble_db_discovery_evt disc_evt = {
-		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
-		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
 		},
-		.discovered_db.char_count = 1,
-		.discovered_db.characteristics = {
+		.char_count = 1,
+		.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				/* different from HRM_HANDLE */
@@ -594,6 +607,11 @@ void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigne
 				.cccd_handle = 0x999a,
 			},
 		},
+	};
+	struct ble_db_discovery_evt disc_evt = {
+		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
+		.conn_handle = CONN_HANDLE,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -643,21 +661,24 @@ void test_ble_hrs_on_db_disc_evt_assigns_peer_db_when_conn_handle_set(void)
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct ble_db_discovery_evt disc_evt = {
-		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
-		.conn_handle = CONN_HANDLE,
-		.discovered_db.srv_uuid = {
-			.type = BLE_UUID_TYPE_BLE,
+	struct ble_gatt_db_srv discovered_service = {
+		.srv_uuid = {
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
 		},
-		.discovered_db.char_count = 1,
-		.discovered_db.characteristics = {
+		.char_count = 1,
+		.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				.characteristic.handle_value = HRM_HANDLE,
 				.cccd_handle = HRM_CCCD_HANDLE,
 			},
 		},
+	};
+	struct ble_db_discovery_evt disc_evt = {
+		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
+		.conn_handle = CONN_HANDLE,
+		.discovered_db = &discovered_service,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);

--- a/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
@@ -383,11 +383,11 @@ void test_ble_hrs_on_db_disc_evt_wrong_service_ignored(void)
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_BATTERY_SERVICE,
 		},
-		.params.discovered_db.char_count = 0,
+		.discovered_db.char_count = 0,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -414,7 +414,7 @@ void test_ble_hrs_on_db_disc_evt_srv_not_found_ignored(void)
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_SRV_NOT_FOUND,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
@@ -444,12 +444,12 @@ void test_ble_hrs_on_db_disc_evt_complete_with_hrm_char(void)
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
-		.params.discovered_db.char_count = 1,
-		.params.discovered_db.characteristics = {
+		.discovered_db.char_count = 1,
+		.discovered_db.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				.characteristic.handle_value = HRM_HANDLE,
@@ -486,12 +486,12 @@ void test_ble_hrs_on_db_disc_evt_hrm_char_at_index_one(void)
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
-		.params.discovered_db.char_count = 2,
-		.params.discovered_db.characteristics = {
+		.discovered_db.char_count = 2,
+		.discovered_db.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_BODY_SENSOR_LOCATION_CHAR,
 				.characteristic.handle_value = 0x000E,
@@ -535,11 +535,11 @@ void test_ble_hrs_on_db_disc_evt_complete_hrs_no_hrm_char(void)
 	struct ble_db_discovery_evt evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
-		.params.discovered_db.char_count = 0,
+		.discovered_db.char_count = 0,
 	};
 
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
@@ -581,12 +581,12 @@ void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigne
 	struct ble_db_discovery_evt disc_evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
-		.params.discovered_db.char_count = 1,
-		.params.discovered_db.characteristics = {
+		.discovered_db.char_count = 1,
+		.discovered_db.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				/* different from HRM_HANDLE */
@@ -646,12 +646,12 @@ void test_ble_hrs_on_db_disc_evt_assigns_peer_db_when_conn_handle_set(void)
 	struct ble_db_discovery_evt disc_evt = {
 		.evt_type = BLE_DB_DISCOVERY_COMPLETE,
 		.conn_handle = CONN_HANDLE,
-		.params.discovered_db.srv_uuid = {
+		.discovered_db.srv_uuid = {
 			.type = BLE_UUID_TYPE_BLE,
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 		},
-		.params.discovered_db.char_count = 1,
-		.params.discovered_db.characteristics = {
+		.discovered_db.char_count = 1,
+		.discovered_db.characteristics = {
 			[0] = {
 				.characteristic.uuid.uuid = BLE_UUID_HEART_RATE_MEASUREMENT_CHAR,
 				.characteristic.handle_value = HRM_HANDLE,


### PR DESCRIPTION
* fixed an issue where internal state indices were not properly reset to zero on subsequent discovery starts.
* Significantly reduce db_discovery instance memory usage by changing the discovery complete result to use pass by reference instead of pass by value.
* Improvements to db_discovery documentation.
* Update library maturity to support (from experimental).

test_bm_samples: PR-90