### PR TITLE
nrf_sdh: Add SoftDevice info logging and refactor app ram minimum addr logging

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -34,8 +34,12 @@ SoftDevice Handler
 * Added:
 
    * The :kconfig:option:`CONFIG_NRF_SDH_LOG_SD_INFO` Kconfig option to log SoftDevice information like version and firmware ID when enabling the SoftDevice.
+   * The :kconfig:option:`CONFIG_NRF_SDH_BLE_LOG_SD_RAM_USAGE` Kconfig option to log SoftDevice RAM usage and the application RAM minimum address when enabling Bluetooth LE in the SoftDevice.
 
-* Updated the :c:macro:`NRF_SDH_STATE_EVT_OBSERVER` and :c:macro:`NRF_SDH_STACK_EVT_OBSERVER` macros to not declare the handler prototype.
+* Updated:
+
+   * The :c:macro:`NRF_SDH_STATE_EVT_OBSERVER` and :c:macro:`NRF_SDH_STACK_EVT_OBSERVER` macros to not declare the handler prototype.
+   * The log error message when there is insufficient RAM for the SoftDevice when enabling Bluetooth LE in the SoftDevice.
 
 Boards
 ======

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -31,6 +31,10 @@ S145 SoftDevice
 SoftDevice Handler
 ==================
 
+* Added:
+
+   * The :kconfig:option:`CONFIG_NRF_SDH_LOG_SD_INFO` Kconfig option to log SoftDevice information like version and firmware ID when enabling the SoftDevice.
+
 * Updated the :c:macro:`NRF_SDH_STATE_EVT_OBSERVER` and :c:macro:`NRF_SDH_STACK_EVT_OBSERVER` macros to not declare the handler prototype.
 
 Boards

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -35,6 +35,7 @@ SoftDevice Handler
 
    * The :kconfig:option:`CONFIG_NRF_SDH_LOG_SD_INFO` Kconfig option to log SoftDevice information like version and firmware ID when enabling the SoftDevice.
    * The :kconfig:option:`CONFIG_NRF_SDH_BLE_LOG_SD_RAM_USAGE` Kconfig option to log SoftDevice RAM usage and the application RAM minimum address when enabling Bluetooth LE in the SoftDevice.
+   * The :c:func:`nrf_sdh_ble_sd_ram_usage_get` function for returning the number of bytes used or required for SoftDevice RAM.
 
 * Updated:
 

--- a/include/bm/softdevice_handler/nrf_sdh_ble.h
+++ b/include/bm/softdevice_handler/nrf_sdh_ble.h
@@ -86,6 +86,15 @@ int nrf_sdh_ble_enable(uint8_t conn_cfg_tag);
 const char *nrf_sdh_ble_evt_to_str(uint32_t evt);
 
 /**
+ * @brief Get the SoftDevice RAM usage.
+ *
+ * The value is only valid after enabling Bluetooth LE with @ref nrf_sdh_ble_enable.
+ *
+ * @return SoftDevice RAM usage in bytes.
+ */
+uint32_t nrf_sdh_ble_sd_ram_usage_get(void);
+
+/**
  * @brief Get the assigned index for a connection handle.
  *
  * The returned value can be used for indexing into arrays where each element is associated

--- a/include/bm/softdevice_handler/nrf_sdh_info.h
+++ b/include/bm/softdevice_handler/nrf_sdh_info.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *
+ * @defgroup nrf_sdh_info SoftDevice Information utility in SoftDevice Handler
+ * @{
+ * @ingroup  nrf_sdh
+ * @brief    Declarations of types and function for getting SoftDevice information structure values.
+ */
+
+#ifndef NRF_SDH_INFO_H__
+#define NRF_SDH_INFO_H__
+
+#include <stdint.h>
+#include <nrf_sdm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief SoftDevice version info.
+ */
+struct nrf_sdh_info_version {
+	/**
+	 * @brief SoftDevice major version (sd_version).
+	 */
+	uint16_t major;
+	/**
+	 * @brief SoftDevice minor version (sd_version).
+	 */
+	uint16_t minor;
+	/**
+	 * @brief SoftDevice bugfix version (sd_version).
+	 */
+	uint16_t bugfix;
+	/**
+	 * @brief SoftDevice ID (sd_id).
+	 */
+	uint16_t id;
+	/**
+	 * @brief SoftDevice firmware ID (firmware_id).
+	 */
+	uint16_t fwid;
+};
+
+/**
+ * @brief SoftDevice unique string.
+ */
+struct nrf_sdh_info_unique_str {
+	/**
+	 * @brief SoftDevice unique string (sd_unique_str) in string format.
+	 */
+	char str[2 * SD_UNIQUE_STR_SIZE + 1];
+};
+
+/**
+ * @brief Get version information stored in the SoftDevice information structure.
+ *
+ * @param[in] sd_base_addr SoftDevice base address
+ *
+ * @return The SoftDevice version information.
+ */
+struct nrf_sdh_info_version nrf_sdh_info_version_get(uint32_t sd_base_addr);
+
+/**
+ * @brief Get the unique string stored in the SoftDevice information structure.
+ *
+ * @param[in] sd_base_addr SoftDevice base address.
+ *
+ * @return The SoftDevice unique string.
+ */
+struct nrf_sdh_info_unique_str nrf_sdh_info_unique_str_get(uint32_t sd_base_addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_SDH_INFO_H__ */
+
+/** @} */

--- a/subsys/softdevice_handler/CMakeLists.txt
+++ b/subsys/softdevice_handler/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_linker_sources(SECTIONS sdh.ld)
 zephyr_linker_sources(DATA_SECTIONS sdh_ram.ld)
 zephyr_library_sources(
   nrf_sdh.c
+  nrf_sdh_info.c
   nrf_sdh_soc.c
   irq_connect.c
 )

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -233,6 +233,12 @@ config NRF_SDH_STR_TABLES
 	  Compile a table of stringified SoftDevice events for nrf_sdh_ble_evt_to_str() and
 	  nrf_sdh_soc_evt_to_str(). Disable to save non-volatile memory.
 
+config NRF_SDH_LOG_SD_INFO
+	bool "Log SoftDevice information on enable"
+	help
+	  Log SoftDevice ID, version, firmware ID and unique string when enabling the SoftDevice.
+	  Log Link Layer version when enabling Bluetooth LE.
+
 module=NRF_SDH
 module-str= SoftDevice handler
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -208,9 +208,13 @@ config NRF_SDH_BLE_GATT_MAX_MTU_SIZE
 
 config NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
 	int "Attribute Table size in bytes"
+	range 248 $(UINT32_MAX)
 	default 1408
 	help
-	  The size must be a multiple of 4.
+	  Size of the Attribute Table in the SoftDevice. Increasing this number allows for more
+	  services and characteristics to be added to the Attribute Table in the SoftDevice.
+	  Increasing this number will increase the amount of dynamic RAM required by the SoftDevice.
+	  The minimum size is BLE_GATTS_ATTR_TAB_SIZE_MIN. The size must be a multiple of 4.
 
 config NRF_SDH_BLE_VS_UUID_COUNT
 	int "Number of vendor-specific UUIDs"

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -198,8 +198,13 @@ config NRF_SDH_BLE_GAP_EVENT_LENGTH
 
 config NRF_SDH_BLE_GATT_MAX_MTU_SIZE
 	int "Maximum MTU size"
-	range 23 65535
+	range 23 $(UINT16_MAX)
 	default 23
+	help
+	  Maximum size of an ATT packet the SoftDevice can send or receive.
+	  Increasing this number will increase the size of internal buffers in the SoftDevice
+	  and hence, the amount of dynamic RAM required by the SoftDevice.
+	  The minimum size is BLE_GATT_ATT_MTU_DEFAULT.
 
 config NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
 	int "Attribute Table size in bytes"

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -214,6 +214,14 @@ config NRF_SDH_BLE_VS_UUID_COUNT
 config NRF_SDH_BLE_SERVICE_CHANGED
 	bool "Include the Service Changed characteristic in the Attribute Table"
 
+config NRF_SDH_BLE_LOG_SD_RAM_USAGE
+	bool "Log RAM usage on BLE enable"
+	help
+	  The amount of RAM needed by the SoftDevice changes based on the configuration.
+	  This enables logging of SoftDevice RAM usage and also the SoftDevice RAM end address.
+	  The reported SoftDevice RAM end address can be used to tweak the application RAM start
+	  address. For instance to maximize RAM for the application.
+
 endmenu
 
 endif # NRF_SDH_BLE

--- a/subsys/softdevice_handler/nrf_sdh.c
+++ b/subsys/softdevice_handler/nrf_sdh.c
@@ -7,10 +7,12 @@
 #include <nrf_sdm.h>
 #include <nrf_soc.h>
 #include <bm/softdevice_handler/nrf_sdh.h>
+#include <bm/softdevice_handler/nrf_sdh_info.h>
 #include <bm/bm_irq.h>
 #include <bm/bm_scheduler.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/iterable_sections.h>
 
@@ -128,6 +130,16 @@ static int nrf_sdh_enable(void)
 		.hfclk_latency = CONFIG_NRF_SDH_CLOCK_HFCLK_LATENCY,
 		.hfint_ctiv = CONFIG_NRF_SDH_CLOCK_HFINT_CALIBRATION_INTERVAL,
 	};
+
+	if (IS_ENABLED(CONFIG_NRF_SDH_LOG_SD_INFO)) {
+		const uint32_t base = FIXED_PARTITION_OFFSET(softdevice_partition);
+		const struct nrf_sdh_info_version sd_ver = nrf_sdh_info_version_get(base);
+		const struct nrf_sdh_info_unique_str sd_unique = nrf_sdh_info_unique_str_get(base);
+
+		LOG_INF("Found S%u v%u.%u.%u, firmware_id: %#x", sd_ver.id, sd_ver.major,
+			sd_ver.minor, sd_ver.bugfix, sd_ver.fwid);
+		LOG_INF("sd_unique_str: %s", sd_unique.str);
+	}
 
 	err = sd_softdevice_enable(&clock_lf_cfg, softdevice_fault_handler);
 	if (err) {

--- a/subsys/softdevice_handler/nrf_sdh.c
+++ b/subsys/softdevice_handler/nrf_sdh.c
@@ -139,6 +139,15 @@ static int nrf_sdh_enable(void)
 		LOG_INF("Found S%u v%u.%u.%u, firmware_id: %#x", sd_ver.id, sd_ver.major,
 			sd_ver.minor, sd_ver.bugfix, sd_ver.fwid);
 		LOG_INF("sd_unique_str: %s", sd_unique.str);
+
+		if ((sd_ver.id != SD_VARIANT_ID) || (sd_ver.major != SD_MAJOR_VERSION) ||
+		    (sd_ver.minor != SD_MINOR_VERSION) || (sd_ver.bugfix != SD_BUGFIX_VERSION)) {
+			LOG_WRN("Application was compiled with S%u v%u.%u.%u, which is different "
+				"from the SoftDevice found on the device (S%u v%u.%u.%u).",
+				SD_VARIANT_ID, SD_MAJOR_VERSION, SD_MINOR_VERSION,
+				SD_BUGFIX_VERSION, sd_ver.id, sd_ver.major, sd_ver.minor,
+				sd_ver.bugfix);
+		}
 	}
 
 	err = sd_softdevice_enable(&clock_lf_cfg, softdevice_fault_handler);

--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -259,6 +259,14 @@ int nrf_sdh_ble_enable(uint8_t conn_cfg_tag)
 		return err;
 	}
 
+	if (IS_ENABLED(CONFIG_NRF_SDH_LOG_SD_INFO)) {
+		ble_version_t ll_ver = {0};
+
+		(void)sd_ble_version_get(&ll_ver);
+		LOG_INF("SoftDevice Link Layer version %u.%u", ll_ver.version_number,
+			ll_ver.subversion_number);
+	}
+
 	LOG_DBG("SoftDevice BLE enabled");
 
 	(void)sdh_state_evt_observer_notify(NRF_SDH_STATE_EVT_BLE_ENABLED);

--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -30,6 +30,8 @@ BUILD_ASSERT(PERIPHERAL_LINKS + CENTRAL_LINKS <= CONFIG_NRF_SDH_BLE_TOTAL_LINK_C
 
 extern bool sdh_state_evt_observer_notify(enum nrf_sdh_state_evt state);
 
+static uint32_t sd_ram_size;
+
 const char *nrf_sdh_ble_evt_to_str(uint32_t evt)
 {
 	int err;
@@ -144,6 +146,11 @@ const char *nrf_sdh_ble_evt_to_str(uint32_t evt)
 		(void)err;
 		return buf;
 	}
+}
+
+uint32_t nrf_sdh_ble_sd_ram_usage_get(void)
+{
+	return sd_ram_size;
 }
 
 static int default_cfg_set(void)
@@ -273,6 +280,8 @@ int nrf_sdh_ble_enable(uint8_t conn_cfg_tag)
 	}
 
 	LOG_DBG("SoftDevice BLE enabled");
+
+	sd_ram_size = app_ram_minimum - SD_RAM_START;
 
 	(void)sdh_state_evt_observer_notify(NRF_SDH_STATE_EVT_BLE_ENABLED);
 

--- a/subsys/softdevice_handler/nrf_sdh_ble.c
+++ b/subsys/softdevice_handler/nrf_sdh_ble.c
@@ -13,6 +13,7 @@
 #include <zephyr/logging/log.h>
 
 #define APP_RAM_START DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
+#define SD_RAM_START DT_REG_ADDR(DT_NODELABEL(cpuapp_sram))
 
 LOG_MODULE_DECLARE(nrf_sdh, CONFIG_NRF_SDH_LOG_LEVEL);
 
@@ -240,18 +241,22 @@ int nrf_sdh_ble_enable(uint8_t conn_cfg_tag)
 {
 	int err;
 	uint32_t app_ram_minimum = APP_RAM_START;
-	const uint32_t app_ram_start_link = APP_RAM_START;
 
 	default_cfg_set();
 
-	LOG_DBG("Application RAM starts at 0x%x", app_ram_start_link);
-
 	err = sd_ble_enable(&app_ram_minimum);
-	if (app_ram_minimum > app_ram_start_link) {
-		LOG_ERR("Insufficient RAM allocated for the SoftDevice (have %#x, need %#x)",
-			app_ram_start_link, app_ram_minimum);
-	} else if (app_ram_minimum != app_ram_start_link) {
-		LOG_DBG("Application RAM start location can be adjusted to %#x", app_ram_minimum);
+	if (app_ram_minimum > APP_RAM_START) {
+		LOG_ERR("Insufficient RAM allocated for the SoftDevice! Change application RAM "
+			"start address from %#x to >= %#x", APP_RAM_START, app_ram_minimum);
+	} else if ((app_ram_minimum < APP_RAM_START) &&
+		   IS_ENABLED(CONFIG_NRF_SDH_BLE_LOG_SD_RAM_USAGE)) {
+		LOG_INF("Application RAM start address can be lowered from %#x to %#x",
+			APP_RAM_START, app_ram_minimum);
+	}
+
+	if (IS_ENABLED(CONFIG_NRF_SDH_BLE_LOG_SD_RAM_USAGE)) {
+		LOG_INF("SoftDevice RAM location: %#x - %#x, size: %u bytes",
+			SD_RAM_START, app_ram_minimum, (app_ram_minimum - SD_RAM_START));
 	}
 
 	if (err) {

--- a/subsys/softdevice_handler/nrf_sdh_info.c
+++ b/subsys/softdevice_handler/nrf_sdh_info.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <nrf_sdm.h>
+#include <bm/softdevice_handler/nrf_sdh_info.h>
+
+struct nrf_sdh_info_version nrf_sdh_info_version_get(uint32_t sd_base_addr)
+{
+	const uint32_t sd_ver = SD_VERSION_GET(sd_base_addr);
+	struct nrf_sdh_info_version version;
+
+	/* See the definition of SD_VERSION. */
+	version.major = sd_ver / 1000000UL;
+	version.minor = (sd_ver - (version.major * 1000000UL)) / 1000UL;
+	version.bugfix = (sd_ver - (version.major * 1000000UL) - (version.minor * 1000UL));
+
+	version.id = SD_ID_GET(sd_base_addr);
+	version.fwid = SD_FWID_GET(sd_base_addr);
+
+	return version;
+}
+
+struct nrf_sdh_info_unique_str nrf_sdh_info_unique_str_get(uint32_t sd_base_addr)
+{
+	int ret;
+	unsigned int offset = 0;
+	const uint8_t *addr = SD_UNIQUE_STR_ADDR_GET(sd_base_addr);
+	struct nrf_sdh_info_unique_str buf;
+
+	for (unsigned int i = 0; i < SD_UNIQUE_STR_SIZE; ++i) {
+		ret = sprintf(&buf.str[offset], "%02x", addr[i]);
+		if (ret < 0) {
+			break;
+		}
+
+		offset += ret;
+	}
+
+	buf.str[offset++] = '\0';
+
+	return buf;
+}


### PR DESCRIPTION
* Log SoftDevice information like version and firmware ID on SoftDevice enable if the `CONFIG_NRF_SDH_LOG_SD_INFO` option is set.
* Rework the reporting of minimum app ram start address on SoftDevice BLE enable.
* Added the `CONFIG_NRF_SDH_BLE_LOG_SD_RAM_USAGE` option for logging SoftDevice ram usage.
* Added the `nrf_sdh_ble_sd_ram_usage_get` function to return SoftDevice RAM usage.