### PR TITLE
workflows: build_samples: split sample build in two subsets

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -45,22 +45,14 @@ jobs:
       - name: Build samples
         working-directory: nrf-bm
         run: |
-          west twister -T samples --build-only -v --inline-logs --integration
+          west twister -T samples --build-only -vc --inline-logs --integration --subset 1/2
+          west twister -T samples --build-only -vc --inline-logs --integration --subset 2/2
 
       - name: upload-logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ failure() && !contains(github.event.pull_request.user.login, 'dependabot[bot]') }}
         with:
           name: build-logs
-          path: nrf-bm/twister-out/**/*.log
-          retention-days: 5
-
-      - name: upload-artifacts-dispatch
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true &&
-            github.event_name == 'workflow_dispatch'
-        with:
-          name: build-artifacts
           path: nrf-bm/twister-out/**
           retention-days: 5
 


### PR DESCRIPTION
Together with enabling clobber which will overwrite the output of the first subset when building the second, this require less space on the runner. Only upload artifacts for the failing subset.