### PR TITLE
ble_common: move, rename and cleanup the common.h file and introduce defines for some common ATT PDU parameter lengths

### DIFF
--- a/doc/nrf-bm/api/api.rst
+++ b/doc/nrf-bm/api/api.rst
@@ -356,6 +356,13 @@ Characteristic UUID definitions
 
 .. doxygengroup:: UUID_CHARACTERISTICS
 
+.. _api_ble_common:
+
+Bluetooth LE Common
+===================
+
+.. doxygengroup:: bm_ble_common
+
 .. _api_ble_date_time_char:
 
 Bluetooth LE Date Time characteristic type

--- a/doc/nrf-bm/api/api.rst
+++ b/doc/nrf-bm/api/api.rst
@@ -356,7 +356,9 @@ Characteristic UUID definitions
 
 .. doxygengroup:: UUID_CHARACTERISTICS
 
+.. _api_ble_date_time_char:
+
 Bluetooth LE Date Time characteristic type
 ==========================================
 
-.. doxygengroup:: ble_sdk_srv_date_time
+.. doxygengroup:: ble_date_time_char

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -247,6 +247,11 @@ Utils
 
    * Moved the :file:`ble_date_time.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
 
+* ``ble_common.h``:
+
+   * Renamed the ``common.h`` header file to :file:`ble_common.h`.
+   * Moved the :file:`ble_common.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
+
 Samples
 =======
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -240,6 +240,13 @@ Libraries for NFC
 
 * Added NFC libraries for NFC Connection Handover and Bluetooth LE Out-of-Band (OOB) pairing.
 
+Utils
+-----
+
+* :ref:`api_ble_date_time_char`:
+
+   * Moved the :file:`ble_date_time.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
+
 Samples
 =======
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -251,6 +251,8 @@ Utils
 
    * Renamed the ``common.h`` header file to :file:`ble_common.h`.
    * Moved the :file:`ble_common.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
+   * Removed the ``gap_conn_sec_mode_from_u8`` function from the :file:`ble_common.h` file.
+     Use the :c:macro:`BLE_GAP_CONN_SEC_MODE_OPEN` and similar macros instead.
 
 Samples
 =======

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -247,7 +247,7 @@ Utils
 
    * Moved the :file:`ble_date_time.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
 
-* ``ble_common.h``:
+* :ref:`api_ble_common`:
 
    * Renamed the ``common.h`` header file to :file:`ble_common.h`.
    * Moved the :file:`ble_common.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -253,6 +253,7 @@ Utils
    * Moved the :file:`ble_common.h` header file from :file:`include/bm/bluetooth/services/` to :file:`include/bm/bluetooth/`.
    * Removed the ``gap_conn_sec_mode_from_u8`` function from the :file:`ble_common.h` file.
      Use the :c:macro:`BLE_GAP_CONN_SEC_MODE_OPEN` and similar macros instead.
+   * Updated the return value of the :c:func:`is_notification_enabled` and :c:func:`is_indication_enabled` functions to ``bool`` to reflect that it returns a boolean value and not an ``uint16_t``.
 
 Samples
 =======

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/** @file
+ *
+ * @defgroup bm_ble_common Bluetooth LE Common
+ * @{
+ * @brief Definitions of common macros and helper functions.
+ */
+
 #ifndef BLE_COMMON_H__
 #define BLE_COMMON_H__
 
@@ -92,3 +99,5 @@ static inline bool ble_gap_conn_sec_mode_equal(const ble_gap_conn_sec_mode_t *a,
 #endif
 
 #endif /* BLE_COMMON_H__ */
+
+/** @} */

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -14,8 +14,8 @@
 #ifndef BLE_COMMON_H__
 #define BLE_COMMON_H__
 
-#include <ble.h>
 #include <ble_gap.h>
+#include <ble_gatt.h>
 #include <zephyr/sys/byteorder.h>
 
 #ifdef __cplusplus

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -36,11 +36,6 @@ static inline uint16_t is_indication_enabled(const uint8_t *gatts_write_data)
 	return (cccd_val & BLE_GATT_HVX_INDICATION);
 }
 
-#define gap_conn_sec_mode_from_u8(x)                                                               \
-	{                                                                                          \
-		.sm = ((x) >> 4) & 0xf, .lv = (x) & 0xf,                                           \
-	}
-
 static inline bool ble_gap_conn_sec_mode_equal(const ble_gap_conn_sec_mode_t *a,
 					       const ble_gap_conn_sec_mode_t *b)
 {

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -23,27 +23,56 @@
 extern "C" {
 #endif
 
-static inline bool is_notification_enabled(const uint8_t *gatts_write_data)
+/**
+ * @brief Calculate how many 32-bit words are needed to hold n_bytes.
+ *
+ * @param[in] n_bytes Number of bytes.
+ *
+ * @return Number of 32-bit words.
+ */
+#define BYTES_TO_WORDS(n_bytes) (((n_bytes) + 3) >> 2)
+
+/**
+ * @brief Read CCCD value from data and check if notifications are enabled.
+ *
+ * @param[in] gatts_value Pointer to CCCD value.
+ *
+ * @return true if notifications are enabled, false if not.
+ */
+static inline bool is_notification_enabled(const uint8_t *gatts_value)
 {
-	const uint16_t cccd_val = sys_get_le16(gatts_write_data);
+	const uint16_t cccd_val = sys_get_le16(gatts_value);
 
 	return (cccd_val & BLE_GATT_HVX_NOTIFICATION);
 }
 
-static inline bool is_indication_enabled(const uint8_t *gatts_write_data)
+/**
+ * @brief Read CCCD value from data and check if indications are enabled.
+ *
+ * @param[in] gatts_value Pointer to CCCD value.
+ *
+ * @return true if indications are enabled, false if not.
+ */
+static inline bool is_indication_enabled(const uint8_t *gatts_value)
 {
-	const uint16_t cccd_val = sys_get_le16(gatts_write_data);
+	const uint16_t cccd_val = sys_get_le16(gatts_value);
 
 	return (cccd_val & BLE_GATT_HVX_INDICATION);
 }
 
+/**
+ * @brief Compare GAP connection security mode.
+ *
+ * @param[in] a First conn_sec_mode value.
+ * @param[in] b Second conn_sec_mode value.
+ *
+ * @return true if the GAP connection security modes are equal, false if not.
+ */
 static inline bool ble_gap_conn_sec_mode_equal(const ble_gap_conn_sec_mode_t *a,
 					       const ble_gap_conn_sec_mode_t *b)
 {
 	return (a->sm == b->sm) && (a->lv == b->lv);
 }
-
-#define BYTES_TO_WORDS(n_bytes) (((n_bytes) + 3) >> 2)
 
 /**
  * @brief Set sec_mode to have no access rights.

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -15,6 +15,7 @@
 #define BLE_COMMON_H__
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <ble_gap.h>
 #include <ble_gatt.h>
 #include <zephyr/sys/byteorder.h>
@@ -22,6 +23,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Length of the Attribute Opcode parameter in an Attribute PDU.
+ */
+#define ATT_OPCODE_LEN sizeof(uint8_t)
+
+/**
+ * @brief Length of the Attribute Handle parameter in an Attribute PDU.
+ */
+#define ATT_HANDLE_LEN sizeof(uint16_t)
 
 /**
  * @brief Calculate how many 32-bit words are needed to hold n_bytes.

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -14,6 +14,7 @@
 #ifndef BLE_COMMON_H__
 #define BLE_COMMON_H__
 
+#include <stdbool.h>
 #include <ble_gap.h>
 #include <ble_gatt.h>
 #include <zephyr/sys/byteorder.h>
@@ -22,14 +23,14 @@
 extern "C" {
 #endif
 
-static inline uint16_t is_notification_enabled(const uint8_t *gatts_write_data)
+static inline bool is_notification_enabled(const uint8_t *gatts_write_data)
 {
 	const uint16_t cccd_val = sys_get_le16(gatts_write_data);
 
 	return (cccd_val & BLE_GATT_HVX_NOTIFICATION);
 }
 
-static inline uint16_t is_indication_enabled(const uint8_t *gatts_write_data)
+static inline bool is_indication_enabled(const uint8_t *gatts_write_data)
 {
 	const uint16_t cccd_val = sys_get_le16(gatts_write_data);
 

--- a/include/bm/bluetooth/ble_common.h
+++ b/include/bm/bluetooth/ble_common.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef BLE_SERVICES_COMMON_H__
-#define BLE_SERVICES_COMMON_H__
+#ifndef BLE_COMMON_H__
+#define BLE_COMMON_H__
 
 #include <ble.h>
 #include <ble_gap.h>
@@ -91,4 +91,4 @@ static inline bool ble_gap_conn_sec_mode_equal(const ble_gap_conn_sec_mode_t *a,
 }
 #endif
 
-#endif /* BLE_SERVICES_COMMON_H__ */
+#endif /* BLE_COMMON_H__ */

--- a/include/bm/bluetooth/ble_date_time.h
+++ b/include/bm/bluetooth/ble_date_time.h
@@ -5,14 +5,9 @@
  */
 
 /** @file
- * @brief Contains definition of ble_date_time structure.
- */
-
-/** @file
  *
- * @defgroup ble_sdk_srv_date_time BLE Date Time characteristic type
+ * @defgroup ble_date_time_char BLE Date Time characteristic type
  * @{
- * @ingroup ble_sdk_lib
  * @brief Definition of struct ble_date_time type.
  */
 

--- a/include/bm/bluetooth/services/ble_bas.h
+++ b/include/bm/bluetooth/services/ble_bas.h
@@ -15,8 +15,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <ble.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
-#include <bm/bluetooth/services/common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/bm/bluetooth/services/ble_cgms.h
+++ b/include/bm/bluetooth/services/ble_cgms.h
@@ -24,9 +24,9 @@
 
 #include <stdint.h>
 
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/ble_racp.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 #include <zephyr/sys/util.h>
 

--- a/include/bm/bluetooth/services/ble_cgms.h
+++ b/include/bm/bluetooth/services/ble_cgms.h
@@ -67,14 +67,11 @@ extern "C" {
 		},                                                                                 \
 	}
 
-#define OPCODE_LENGTH 1
-#define HANDLE_LENGTH 2
-
 /**
  * @brief Macro for calculating maximum length of data (in bytes) that can be transmitted to
- *        the peer in one ATT packet, given the ATT MTU size.
+ *        the peer in one ATT write or notification packet, given the ATT MTU size.
  */
-#define BLE_CGMS_DATA_MAX_LEN_CALC(mtu_size) ((mtu_size) - OPCODE_LENGTH - HANDLE_LENGTH)
+#define BLE_CGMS_DATA_MAX_LEN_CALC(mtu_size) ((mtu_size) - ATT_OPCODE_LEN - ATT_HANDLE_LEN)
 
 /**
  * @name CGM Feature characteristic defines

--- a/include/bm/bluetooth/services/ble_dis.h
+++ b/include/bm/bluetooth/services/ble_dis.h
@@ -18,7 +18,7 @@
 #define BLE_DIS_H__
 
 #include <stdint.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/bm/bluetooth/services/ble_hids.h
+++ b/include/bm/bluetooth/services/ble_hids.h
@@ -18,7 +18,7 @@
 #include <ble.h>
 #include <ble_gap.h>
 #include <ble_gatts.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 
 #ifdef __cplusplus

--- a/include/bm/bluetooth/services/ble_lbs.h
+++ b/include/bm/bluetooth/services/ble_lbs.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 #include <ble.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 
 #ifdef __cplusplus

--- a/include/bm/bluetooth/services/ble_mcumgr.h
+++ b/include/bm/bluetooth/services/ble_mcumgr.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <ble.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <ble.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 
 #ifdef __cplusplus

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -61,14 +61,11 @@ void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *context);
 		},                                                                                 \
 	}
 
-#define OPCODE_LENGTH 1
-#define HANDLE_LENGTH 2
-
 /**
  * @brief Macro for calculating maximum length of data (in bytes) that can be transmitted to
  *        the peer by the Nordic UART service module, given the ATT MTU size.
  */
-#define BLE_NUS_MAX_DATA_LEN_CALC(mtu_size) ((mtu_size) - OPCODE_LENGTH - HANDLE_LENGTH)
+#define BLE_NUS_MAX_DATA_LEN_CALC(mtu_size) ((mtu_size) - ATT_OPCODE_LEN - ATT_HANDLE_LEN)
 
 /**
  * @brief Maximum length of data (in bytes) that can be transmitted to the peer by the Nordic UART

--- a/samples/bluetooth/ble_bms/src/main.c
+++ b/samples/bluetooth/ble_bms/src/main.c
@@ -13,8 +13,8 @@
 #include <ble_types.h>
 #include <bm/bm_buttons.h>
 #include <bm/bluetooth/ble_adv.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_qwr.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/ble_bms.h>
 #include <bm/bluetooth/services/ble_dis.h>

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -21,11 +21,11 @@
 #include <ble_gap.h>
 #include <hal/nrf_gpio.h>
 #include <bm/bluetooth/ble_adv.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_conn_params.h>
 #include <bm/bluetooth/peer_manager/nrf_ble_lesc.h>
 #include <bm/bluetooth/peer_manager/peer_manager.h>
 #include <bm/bluetooth/peer_manager/peer_manager_handler.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/ble_bas.h>
 #include <bm/bluetooth/services/ble_cgms.h>

--- a/samples/bluetooth/ble_hids_keyboard/src/main.c
+++ b/samples/bluetooth/ble_hids_keyboard/src/main.c
@@ -16,8 +16,8 @@
 #include <bm/bm_timer.h>
 #include <bm/bm_buttons.h>
 #include <bm/bluetooth/ble_adv.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_qwr.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/ble_bas.h>
 #include <bm/bluetooth/services/ble_dis.h>

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -11,8 +11,8 @@
 #include <ble_types.h>
 #include <hal/nrf_gpio.h>
 #include <bm/bluetooth/ble_adv.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_qwr.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/ble_bas.h>
 #include <bm/bluetooth/services/ble_dis.h>

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <ble_gap.h>
 #include <nrf_soc.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bm_timer.h>
 #include <bm/bm_buttons.h>
 #include <bm/bluetooth/ble_adv_data.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_conn_params.h>
 #include <bm/bluetooth/ble_qwr.h>
 #include <bm/softdevice_handler/nrf_sdh.h>

--- a/subsys/bluetooth/services/ble_bas/bas.c
+++ b/subsys/bluetooth/services/ble_bas/bas.c
@@ -6,8 +6,8 @@
 
 #include <nrf_error.h>
 #include <string.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/services/ble_bas.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <zephyr/logging/log.h>
 

--- a/subsys/bluetooth/services/ble_bms/bms.c
+++ b/subsys/bluetooth/services/ble_bms/bms.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <bm/bluetooth/services/ble_bms.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/ble_qwr.h>
 

--- a/subsys/bluetooth/services/ble_cgms/cgms.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms.c
@@ -7,9 +7,9 @@
 #include <nrf_error.h>
 #include <stdint.h>
 
+#include <bm/bluetooth/ble_date_time.h>
 #include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/ble_racp.h>
-#include <bm/bluetooth/services/ble_date_time.h>
 #include <bm/bluetooth/services/ble_cgms.h>
 #include <bm/bluetooth/services/uuid.h>
 #include "cgms_db.h"

--- a/subsys/bluetooth/services/ble_cgms/cgms_meas.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_meas.c
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 #include <ble.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/services/ble_cgms.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include "cgms_meas.h"
 #include "cgms_db.h"

--- a/subsys/bluetooth/services/ble_cgms/cgms_racp.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_racp.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <ble.h>
 #include <ble_gatts.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/services/ble_cgms.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 
 #include "cgms_racp.h"

--- a/subsys/bluetooth/services/ble_cgms/cgms_socp.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms_socp.c
@@ -6,8 +6,8 @@
 #include <stdint.h>
 #include <string.h>
 #include <ble.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_gq.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 
 #include "cgms_db.h"

--- a/subsys/bluetooth/services/ble_cgms/cgms_sst.h
+++ b/subsys/bluetooth/services/ble_cgms/cgms_sst.h
@@ -21,7 +21,7 @@
 #define BLE_CGMS_SST_H__
 
 #include <ble.h>
-#include <bm/bluetooth/services/ble_date_time.h>
+#include <bm/bluetooth/ble_date_time.h>
 #include <bm/bluetooth/services/ble_cgms.h>
 
 #ifdef __cplusplus

--- a/subsys/bluetooth/services/ble_dis/dis.c
+++ b/subsys/bluetooth/services/ble_dis/dis.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <ble_gatts.h>
 #include <bm/bluetooth/services/uuid.h>
-#include <bm/bluetooth/services/common.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>

--- a/subsys/bluetooth/services/ble_hids/hids.c
+++ b/subsys/bluetooth/services/ble_hids/hids.c
@@ -11,9 +11,9 @@
 #include <ble_gap.h>
 #include <ble_types.h>
 #include <ble_gatts.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/services/ble_hids.h>
 #include <bm/bluetooth/services/uuid.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -18,10 +18,8 @@
 
 LOG_MODULE_REGISTER(ble_hrs, CONFIG_BLE_HRS_LOG_LEVEL);
 
-/* Length of ATT header. Opcode (1 byte) and attribute handle (2 bytes). */
-#define ATT_HEADER_LENGTH 3
 /* Macro for calculating max ATT data/payload size from max ATT GATT MTU size. */
-#define MAX_HRM_LEN_CALC(max_mtu_size) ((max_mtu_size) - ATT_HEADER_LENGTH)
+#define MAX_HRM_LEN_CALC(max_mtu_size) ((max_mtu_size) - ATT_OPCODE_LEN - ATT_HANDLE_LEN)
 
 /* Initial Heart Rate Measurement value. */
 #define INITIAL_VALUE_HRM 0

--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -8,9 +8,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_conn_params.h>
 #include <bm/bluetooth/services/ble_hrs.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>

--- a/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
+++ b/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
@@ -13,8 +13,8 @@
 #include <nrf_soc.h>
 #include <bm/softdevice_handler/nrf_sdh.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/ble_conn_params.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <bm/bluetooth/services/ble_mcumgr.h>
 

--- a/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
+++ b/subsys/bluetooth/services/ble_mcumgr/mcumgr.c
@@ -28,14 +28,11 @@
 
 LOG_MODULE_REGISTER(mcumgr, CONFIG_BLE_MCUMGR_LOG_LEVEL);
 
-#define OPCODE_LENGTH 1
-#define HANDLE_LENGTH 2
-
 /**
  * @brief Macro for calculating maximum length of data (in bytes) that can be transmitted to
- *        the peer over GATT, given the ATT MTU size.
+ *        the peer in one ATT write or notification packet, given the ATT MTU size.
  */
-#define BLE_GATT_MAX_DATA_LEN_CALC(mtu_size) ((mtu_size) - OPCODE_LENGTH - HANDLE_LENGTH)
+#define BLE_GATT_MAX_DATA_LEN_CALC(mtu_size) ((mtu_size) - ATT_OPCODE_LEN - ATT_HANDLE_LEN)
 
 /**
  * @brief Maximum length of data (in bytes) that can be transmitted to the peer over GATT

--- a/subsys/bluetooth/services/ble_nus/nus.c
+++ b/subsys/bluetooth/services/ble_nus/nus.c
@@ -7,8 +7,8 @@
 #include <nrf_error.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <bm/bluetooth/ble_common.h>
 #include <bm/bluetooth/services/ble_nus.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/uuid.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/unit/lib/bluetooth/ble_adv/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_adv/src/unity_test.c
@@ -12,7 +12,7 @@
 
 #include <bm/bluetooth/ble_adv.h>
 #include <bm/bluetooth/ble_adv_data.h>
-#include <bm/bluetooth/services/common.h>
+#include <bm/bluetooth/ble_common.h>
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>

--- a/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
@@ -12,7 +12,6 @@
 #include <ble_err.h>
 #include <ble_gatt.h>
 #include <nrf_error.h>
-#include <bm/bluetooth/services/common.h>
 #include <bm/bluetooth/services/ble_bms.h>
 #include <bm/bluetooth/services/uuid.h>
 


### PR DESCRIPTION
A bit of cleanup.

* Move, rename and cleanup the `bm/bluetooth/services/common.h` file. Now `bm/bluetooth/ble_common.h`.
* Add `ble_common.h` to API documentation.
* Add common defines for ATT opcode and ATT handle parameter lengths and make use of them in the relevant service files.
* Additionally, move the `bm/bluetooth/services/ble_data_time.h` file to `bm/bluetooth/ble_data_time.h`. The file is similar to the `ble_racp.h` which already lies in the `bm/bluetooth` directory.