### PR TITLE
bluetooth: services: hrs_client: cleanup and remove experimental

### DIFF
--- a/doc/nrf-bm/migration/nrf5_bm_migration.rst
+++ b/doc/nrf-bm/migration/nrf5_bm_migration.rst
@@ -205,7 +205,7 @@ See table below for a summary of supported libraries.
      - Yes
      - ``ble_scan``
      -
-     - Experimental
+     -
    * - ``ble_link_ctx_manager``
      - No
      -

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -219,6 +219,12 @@ Bluetooth LE Services
       * Validation of the :c:member:`ble_hrs_client_config.evt_handler` and :c:member:`ble_hrs_client_config.gatt_queue` configuration fields in :c:func:`ble_hrs_client_init`.
       * State validation in :c:func:`ble_hrs_client_hrm_notif_enable` and :c:func:`ble_hrs_client_hrm_notif_disable`, returning :c:macro:`NRF_ERROR_INVALID_STATE` when the connection or CCCD handle has not been assigned.
 
+   * Updated:
+
+      * The :c:struct:`ble_hrs_client_evt` structure was aligned with other client services.
+      * The ``hrs_db`` structure was renamed to :c:struct:`ble_hrs_handles`.
+      * The ``ble_hrm`` structure was renamed to :c:struct:`ble_hrs_measurement`.
+
    * Fixed a potential buffer over-read when parsing malformed Heart Rate Measurement notifications.
 
 * :ref:`lib_ble_service_hids` service:

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -185,6 +185,7 @@ Libraries
 
 * :ref:`lib_ble_scan` library:
 
+   * The library is now supported.
    * Added the :c:struct:`ble_scan_filter_data` structure as input to the :c:func:`ble_scan_filter_add` function.
    * Updated:
 

--- a/include/bm/bluetooth/services/ble_hrs_client.h
+++ b/include/bm/bluetooth/services/ble_hrs_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -8,19 +8,19 @@
  *
  * @defgroup ble_hrs_client Heart Rate Service Client
  * @{
- * @brief    Heart Rate Service Client.
+ * @brief Heart Rate Service Client.
  *
- * @details  This library contains the APIs and types exposed by the Heart Rate Service Client
- *           library. The application can use these APIs and types to perform the discovery of
- *           Heart Rate Service at the peer and to interact with it.
+ * @details This library contains the APIs and types exposed by the Heart Rate Service Client
+ *          library. The application can use these APIs and types to perform the discovery of
+ *          Heart Rate Service at the peer and to interact with it.
  *
- * @warning  Currently, this library only supports the Heart Rate Measurement characteristic. This
- *           means that it is able to enable notification of the characteristic at the peer and
- *           is able to receive Heart Rate Measurement notifications from the peer. It does not
- *           support the Body Sensor Location and the Heart Rate Control Point characteristics.
- *           When a Heart Rate Measurement is received, this library decodes only the
- *           Heart Rate Measurement value field (both 8-bit and 16-bit) and provides it to
- *           the application.
+ * @warning Currently, this library only supports the Heart Rate Measurement characteristic. This
+ *          means that it is able to enable notification of the characteristic at the peer and
+ *          is able to receive Heart Rate Measurement notifications from the peer. It does not
+ *          support the Body Sensor Location and the Heart Rate Control Point characteristics.
+ *          When a Heart Rate Measurement is received, this library decodes only the
+ *          Heart Rate Measurement value field (both 8-bit and 16-bit) and RR intervals and
+ *          provides it to the application.
  */
 
 #ifndef BLE_HRS_CLIENT_H__
@@ -42,9 +42,9 @@ extern "C" {
  * @param _name Name of the instance.
  * @hideinitializer
  */
-#define BLE_HRS_CLIENT_DEF(_name)                                                                 \
-	static struct ble_hrs_client _name;                                                       \
-	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_hrs_client_on_ble_evt, &_name, USER_LOW)
+#define BLE_HRS_CLIENT_DEF(_name)                                                                  \
+	static struct ble_hrs_client _name;                                                        \
+	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_hrs_client_on_ble_evt, &_name, HIGH)
 
 /**
  * @brief HRS Client event type.
@@ -63,7 +63,7 @@ enum ble_hrs_client_evt_type {
 /**
  * @brief Heart Rate Measurement received from the peer.
  */
-struct ble_hrm {
+struct ble_hrs_measurement {
 	/** Heart Rate Value. */
 	uint16_t hr_value;
 	/** Number of RR intervals. */
@@ -75,7 +75,7 @@ struct ble_hrm {
 /**
  * @brief Database for handles related to the Heart Rate Service found on the peer.
  */
-struct hrs_db {
+struct ble_hrs_handles {
 	/** Handle of the CCCD of the Heart Rate Measurement characteristic. */
 	uint16_t hrm_cccd_handle;
 	/** Handle of the Heart Rate Measurement characteristic, as provided by the SoftDevice. */
@@ -91,17 +91,14 @@ struct ble_hrs_client_evt {
 	/** Connection handle on which the Heart Rate service was discovered on the peer device. */
 	uint16_t conn_handle;
 	union {
-		/** Handles related to the Heart Rate, found on the peer device.
-		 *  This is filled if the evt_type is @ref BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE.
-		 */
-		struct hrs_db peer_db;
-		/** Heart Rate Measurement received. This is filled if the evt_type
-		 *  is @ref BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION.
-		 */
-		struct ble_hrm hrm;
-		/** Error event. This is filled if the evt_type
-		 *  is @ref BLE_HRS_CLIENT_EVT_ERROR.
-		 */
+		/** @ref BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE event data. */
+		struct {
+			/** Handles related to the Heart Rate, found on the peer device. */
+			struct ble_hrs_handles handles;
+		} discovery_complete;
+		/** @ref BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION event data. */
+		struct ble_hrs_measurement hrm_notification;
+		/** @ref BLE_HRS_CLIENT_EVT_ERROR event data. */
 		struct {
 			/** Error reason */
 			uint32_t reason;
@@ -118,8 +115,8 @@ struct ble_hrs_client;
  * @details This is the type of the event handler that is to be provided by the application
  *          of this module to receive events.
  */
-typedef void (*ble_hrs_client_evt_handler_t)(struct ble_hrs_client *ble_hrs_client,
-					      struct ble_hrs_client_evt *evt);
+typedef void (*ble_hrs_client_evt_handler_t)(struct ble_hrs_client *hrs_client,
+					     const struct ble_hrs_client_evt *evt);
 
 /**
  * @brief Heart Rate Client.
@@ -128,7 +125,7 @@ struct ble_hrs_client {
 	/** Connection handle, as provided by the SoftDevice. */
 	uint16_t conn_handle;
 	/** Handles related to HRS on the peer. */
-	struct hrs_db peer_hrs_db;
+	struct ble_hrs_handles handles;
 	/** Application event handler to be called when there
 	 *  is an event related to the Heart Rate Service.
 	 */
@@ -158,18 +155,18 @@ struct ble_hrs_client_config {
  *          The module looks for the presence of a Heart Rate Service instance at the peer
  *          when a discovery is started.
  *
- * @param[in] ble_hrs_client Heart Rate Client structure.
- * @param[in] ble_hrs_client_config Heart rate service client configuration.
+ * @param[in, out] hrs_client Heart Rate Client structure.
+ * @param[in] hrs_client_config Heart rate service client configuration.
  *
- * @retval NRF_SUCCESS On successful initialization.
- * @retval NRF_ERROR_NULL If any of @p ble_hrs_client, @p ble_hrs_client_config, or
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If any of @p hrs_client, @p hrs_client_config, or
  *         the configuration's @ref ble_hrs_client_config.evt_handler or
  *         @ref ble_hrs_client_config.gatt_queue fields are NULL.
- * @return Otherwise, this function propagates the error code returned by the
- *         Database Discovery module API @ref ble_db_discovery_service_register.
+ * @return In addition, this function may return any error returned by the following functions:
+ *         - @ref ble_db_discovery_service_register()
  */
-uint32_t ble_hrs_client_init(struct ble_hrs_client *ble_hrs_client,
-			      struct ble_hrs_client_config *ble_hrs_client_config);
+uint32_t ble_hrs_client_init(struct ble_hrs_client *hrs_client,
+			     const struct ble_hrs_client_config *hrs_client_config);
 
 /**
  * @brief Handle Bluetooth LE events from the SoftDevice.
@@ -179,7 +176,7 @@ uint32_t ble_hrs_client_init(struct ble_hrs_client *ble_hrs_client,
  *          the event's data to update interval variables and, if necessary, send events to the
  *          application.
  *
- * @param[in] ble_evt Bluetooth LE event.
+ * @param[in, out] ble_evt Bluetooth LE event.
  * @param[in] ctx Heart Rate Client structure.
  */
 void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);
@@ -190,16 +187,17 @@ void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);
  * @details This function enables notification of the Heart Rate Measurement at the peer
  *          by writing to the CCCD of the Heart Rate Measurement characteristic.
  *
- * @param ble_hrs_client Heart Rate Client structure.
+ * @param hrs_client Heart Rate Client structure.
  *
- * @retval NRF_SUCCESS If the SoftDevice is requested to write to the CCCD of the peer.
+ * @retval NRF_SUCCESS On success.
  * @retval NRF_ERROR_NULL If @p ble_hrs_client is NULL.
  * @retval NRF_ERROR_INVALID_STATE If the connection handle or CCCD handle has not been
- *         assigned (e.g. @ref ble_hrs_client_handles_assign has not been called, or
+ *         assigned (for example, @ref ble_hrs_client_handles_assign has not been called, or
  *         the peer has disconnected).
- * @return Otherwise, this function propagates the error code returned by the GATT queue.
+ * @return In addition, this function may return any error returned by the following functions:
+ *         - @ref ble_gq_item_add()
  */
-uint32_t ble_hrs_client_hrm_notif_enable(struct ble_hrs_client *ble_hrs_client);
+uint32_t ble_hrs_client_hrm_notif_enable(struct ble_hrs_client *hrs_client);
 
 /**
  * @brief Request the peer to stop sending notification of Heart Rate Measurement.
@@ -207,16 +205,17 @@ uint32_t ble_hrs_client_hrm_notif_enable(struct ble_hrs_client *ble_hrs_client);
  * @details This function disables notification of the Heart Rate Measurement at the peer
  *          by writing to the CCCD of the Heart Rate Measurement characteristic.
  *
- * @param ble_hrs_client Heart Rate Client structure.
+ * @param hrs_client Heart Rate Client structure.
  *
- * @retval NRF_SUCCESS If the SoftDevice is requested to write to the CCCD of the peer.
+ * @retval NRF_SUCCESS On success.
  * @retval NRF_ERROR_NULL If @p ble_hrs_client is NULL.
  * @retval NRF_ERROR_INVALID_STATE If the connection handle or CCCD handle has not been
- *         assigned (e.g. @ref ble_hrs_client_handles_assign has not been called, or
+ *         assigned (for example, @ref ble_hrs_client_handles_assign has not been called, or
  *         the peer has disconnected).
- * @return Otherwise, this function propagates the error code returned by the GATT queue.
+ * @return In addition, this function may return any error returned by the following functions:
+ *         - @ref ble_gq_item_add()
  */
-uint32_t ble_hrs_client_hrm_notif_disable(struct ble_hrs_client *ble_hrs_client);
+uint32_t ble_hrs_client_hrm_notif_disable(struct ble_hrs_client *hrs_client);
 
 /**
  * @brief Handle events from the Database Discovery module.
@@ -228,12 +227,12 @@ uint32_t ble_hrs_client_hrm_notif_disable(struct ble_hrs_client *ble_hrs_client)
  *          Service was discovered at the peer. The function also populates the event with
  *          service-related information before providing it to the application.
  *
- * @param[in] ble_hrs_client Heart Rate Client structure instance for
+ * @param[in, out] hrs_client Heart Rate Client structure instance for
  * associating the link.
  * @param[in] evt Event received from the Database Discovery module.
  *
  */
-void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
+void ble_hrs_on_db_disc_evt(struct ble_hrs_client *hrs_client,
 			    const struct ble_db_discovery_evt *evt);
 
 /**
@@ -245,16 +244,20 @@ void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
  *          instance of this module. The connection handle and attribute handles are
  *          provided from the discovery event @ref BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE.
  *
- * @param[in] ble_hrs_client Heart Rate Client structure instance for
+ * @param[in, out] hrs_client Heart Rate Client structure instance for
  * associating the link.
  * @param[in] conn_handle Connection handle to associate with the given Heart Rate
- * Client Instance.
+ * Client instance.
  * @param[in] peer_hrs_handles Attribute handles for the HRS server you want this HRS_C
  * client to interact with.
+ *
+ * @retval NRF_SUCCESS On success.
+ * @retval NRF_ERROR_NULL If @c hrs_client is NULL.
+ * @return In addition, this function may return any error returned by the following functions:
+ *         - @ref ble_gq_conn_handle_register()
  */
-uint32_t ble_hrs_client_handles_assign(struct ble_hrs_client *ble_hrs_client,
-					uint16_t conn_handle,
-					const struct hrs_db *peer_hrs_handles);
+uint32_t ble_hrs_client_handles_assign(struct ble_hrs_client *hrs_client, uint16_t conn_handle,
+				       const struct ble_hrs_handles *peer_hrs_handles);
 
 #ifdef __cplusplus
 }

--- a/lib/bluetooth/ble_scan/Kconfig
+++ b/lib/bluetooth/ble_scan/Kconfig
@@ -5,11 +5,10 @@
 #
 
 menuconfig BLE_SCAN
-	bool "Bluetooth LE Scan [EXPERIMENTAL]"
+	bool "Bluetooth LE Scan"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_ADV_DATA
-	select EXPERIMENTAL
 
 if BLE_SCAN
 

--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -161,7 +161,7 @@ static void on_ble_evt(const ble_evt_t *ble_evt, void *ctx)
 		break;
 
 	case BLE_GATTC_EVT_TIMEOUT:
-		LOG_INF("GATT Client Timeout.");
+		LOG_INF("GATT Client Timeout");
 		nrf_err = sd_ble_gap_disconnect(ble_evt->evt.gattc_evt.conn_handle,
 					    BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 		if (nrf_err) {
@@ -170,7 +170,7 @@ static void on_ble_evt(const ble_evt_t *ble_evt, void *ctx)
 		break;
 
 	case BLE_GATTS_EVT_TIMEOUT:
-		LOG_INF("GATT Server Timeout.");
+		LOG_INF("GATT Server Timeout");
 		nrf_err = sd_ble_gap_disconnect(ble_evt->evt.gatts_evt.conn_handle,
 					    BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 		if (nrf_err) {
@@ -240,7 +240,7 @@ static uint32_t delete_bonds(void)
 static void allow_list_disable(void)
 {
 	if (!allow_list_disabled) {
-		LOG_INF("allow list temporarily disabled.");
+		LOG_INF("allow list temporarily disabled");
 		allow_list_disabled = true;
 		ble_scan_stop(&ble_scan);
 		scan_start(false);
@@ -264,17 +264,17 @@ static void button_handler_disconnect(uint8_t pin, uint8_t action)
 	}
 }
 
-static void hrs_c_evt_handler(struct ble_hrs_client *hrs, struct ble_hrs_client_evt *evt)
+static void hrs_c_evt_handler(struct ble_hrs_client *hrs, const struct ble_hrs_client_evt *evt)
 {
 
 	uint32_t nrf_err;
 
 	switch (evt->evt_type) {
 	case BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE:
-		LOG_INF("Heart rate service discovered.");
+		LOG_INF("Heart rate service discovered");
 
 		nrf_err = ble_hrs_client_handles_assign(hrs, evt->conn_handle,
-							 &evt->peer_db);
+							&evt->discovery_complete.handles);
 		if (nrf_err != 0) {
 			LOG_ERR("ble_hrs_client_handles_assign failed, nrf_error %#x", nrf_err);
 		}
@@ -288,20 +288,20 @@ static void hrs_c_evt_handler(struct ble_hrs_client *hrs, struct ble_hrs_client_
 		break;
 
 	case BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION:
-		LOG_INF("Heart Rate %d.", evt->hrm.hr_value);
-		if (evt->hrm.rr_intervals_cnt != 0) {
+		LOG_INF("Heart Rate %d.", evt->hrm_notification.hr_value);
+		if (evt->hrm_notification.rr_intervals_cnt != 0) {
 			uint32_t rr_avg = 0;
 
-			for (uint32_t i = 0; i < evt->hrm.rr_intervals_cnt; i++) {
-				rr_avg += evt->hrm.rr_intervals[i];
+			for (uint32_t i = 0; i < evt->hrm_notification.rr_intervals_cnt; i++) {
+				rr_avg += evt->hrm_notification.rr_intervals[i];
 			}
-			rr_avg = rr_avg / evt->hrm.rr_intervals_cnt;
+			rr_avg = rr_avg / evt->hrm_notification.rr_intervals_cnt;
 			LOG_INF("rr_interval (avg) %d", rr_avg);
 		}
 		break;
 
 	default:
-		LOG_WRN("Unhandled hrs event %d", evt->evt_type);
+		LOG_WRN("Unhandled HRS event %d", evt->evt_type);
 		break;
 	}
 }
@@ -434,12 +434,12 @@ static void conn_params_evt_handler(const struct ble_conn_params_evt *evt)
 {
 	switch (evt->evt_type) {
 	case BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED:
-		LOG_INF("GATT ATT MTU on connection %#x changed to %d.", evt->conn_handle,
+		LOG_INF("GATT ATT MTU on connection %#x changed to %d", evt->conn_handle,
 			evt->att_mtu);
 		break;
 
 	case BLE_CONN_PARAMS_EVT_DATA_LENGTH_UPDATED:
-		LOG_INF("Data length for connection %#x updated to %d.", evt->conn_handle,
+		LOG_INF("Data length for connection %#x updated to %d", evt->conn_handle,
 			evt->data_length.rx);
 		break;
 
@@ -461,7 +461,7 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 	case BLE_SCAN_EVT_ALLOW_LIST_REQUEST:
 		on_allow_list_req();
 		allow_list_disabled = false;
-		LOG_INF("allow list request.");
+		LOG_INF("Allow list request");
 		break;
 
 	case BLE_SCAN_EVT_CONNECTING_ERROR:
@@ -470,7 +470,7 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 		break;
 
 	case BLE_SCAN_EVT_SCAN_TIMEOUT:
-		LOG_INF("Scan timed out.");
+		LOG_INF("Scan timed out");
 		scan_start(false);
 		break;
 
@@ -479,7 +479,7 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 		break;
 
 	case BLE_SCAN_EVT_ALLOW_LIST_ADV_REPORT:
-		LOG_INF("allow list advertise report.");
+		LOG_INF("Allow list advertise report");
 		break;
 
 	case BLE_SCAN_EVT_CONNECTED: {
@@ -671,11 +671,11 @@ int main(void)
 	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 	LOG_INF("BLE HRS Central sample initialized");
 
+idle:
 	while (true) {
 #if defined(CONFIG_PM_LESC)
 		(void)nrf_ble_lesc_request_handler();
 #endif
-idle:
 		log_flush();
 
 		k_cpu_idle();

--- a/subsys/bluetooth/services/ble_hrs_client/Kconfig
+++ b/subsys/bluetooth/services/ble_hrs_client/Kconfig
@@ -5,12 +5,11 @@
 #
 
 menuconfig BLE_HRS_CLIENT
-	bool "Bluetooth LE Heart rate service client [EXPERIMENTAL]"
+	bool "Bluetooth LE Heart rate service client"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_DB_DISCOVERY
 	depends on BLE_GATT_QUEUE
-	select EXPERIMENTAL
 	help
 	  Heart rate service client library.
 

--- a/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
+++ b/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -31,7 +31,7 @@ static
 #endif
 void ble_hrs_client_on_ble_gq_event(const struct ble_gq_req *req, struct ble_gq_evt *gq_evt)
 {
-	struct ble_hrs_client *ble_hrs_client = (struct ble_hrs_client *)req->ctx;
+	struct ble_hrs_client *hrs_client = (struct ble_hrs_client *)req->ctx;
 	struct ble_hrs_client_evt evt = {
 		.evt_type = BLE_HRS_CLIENT_EVT_ERROR,
 		.conn_handle = gq_evt->conn_handle,
@@ -40,35 +40,35 @@ void ble_hrs_client_on_ble_gq_event(const struct ble_gq_req *req, struct ble_gq_
 
 	switch (gq_evt->evt_type) {
 	case BLE_GQ_EVT_ERROR:
-		ble_hrs_client->evt_handler(ble_hrs_client, &evt);
+		hrs_client->evt_handler(hrs_client, &evt);
 		break;
 	}
 }
 
-static void on_hvx(struct ble_hrs_client *ble_hrs_client, const ble_evt_t *ble_evt)
+static void on_hvx(struct ble_hrs_client *hrs_client, const ble_evt_t *ble_evt)
 {
 	uint8_t flags;
 	uint32_t min_len;
 	uint32_t index;
 	const ble_gattc_evt_hvx_t *hvx = &ble_evt->evt.gattc_evt.params.hvx;
-	struct ble_hrs_client_evt ble_hrs_client_evt = {
+	struct ble_hrs_client_evt hrs_client_evt = {
 		.evt_type = BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION,
-		.conn_handle = ble_hrs_client->conn_handle,
-		.hrm.rr_intervals_cnt = 0,
+		.conn_handle = hrs_client->conn_handle,
+		.hrm_notification.rr_intervals_cnt = 0,
 	};
 
 	/* Check if the event is on the link for this instance. */
-	if (ble_hrs_client->conn_handle != ble_evt->evt.gattc_evt.conn_handle) {
+	if (hrs_client->conn_handle != ble_evt->evt.gattc_evt.conn_handle) {
 		return;
 	}
 
 	/* Check if this is a heart rate notification. */
-	if (hvx->handle != ble_hrs_client->peer_hrs_db.hrm_handle) {
+	if (hvx->handle != hrs_client->handles.hrm_handle) {
 		return;
 	}
 
 	LOG_DBG("HVX link: %#x hrm_handle: %#x",
-		hvx->handle, ble_hrs_client->peer_hrs_db.hrm_handle);
+		hvx->handle, hrs_client->handles.hrm_handle);
 
 	/* Need at least 1 byte to read the flags. */
 	if (hvx->len < 1) {
@@ -90,10 +90,10 @@ static void on_hvx(struct ble_hrs_client *ble_hrs_client, const ble_evt_t *ble_e
 	/* All mandatory bytes are guaranteed present from here. */
 	if (!(flags & HRM_FLAG_MASK_HR_16BIT)) {
 		/* 8-bit heart rate value received. */
-		ble_hrs_client_evt.hrm.hr_value = hvx->data[index++];
+		hrs_client_evt.hrm_notification.hr_value = hvx->data[index++];
 	} else {
 		/* 16-bit heart rate value received. */
-		ble_hrs_client_evt.hrm.hr_value = sys_get_le16(&hvx->data[index]);
+		hrs_client_evt.hrm_notification.hr_value = sys_get_le16(&hvx->data[index]);
 		index += sizeof(uint16_t);
 	}
 
@@ -103,53 +103,55 @@ static void on_hvx(struct ble_hrs_client *ble_hrs_client, const ble_evt_t *ble_e
 			if ((index + sizeof(uint16_t)) > hvx->len) {
 				break;
 			}
-			ble_hrs_client_evt.hrm.rr_intervals[i] =
+			hrs_client_evt.hrm_notification.rr_intervals[i] =
 				sys_get_le16(&hvx->data[index]);
 			index += sizeof(uint16_t);
-			ble_hrs_client_evt.hrm.rr_intervals_cnt++;
+			hrs_client_evt.hrm_notification.rr_intervals_cnt++;
 		}
 	}
 
-	ble_hrs_client->evt_handler(ble_hrs_client, &ble_hrs_client_evt);
+	hrs_client->evt_handler(hrs_client, &hrs_client_evt);
 }
 
-static void on_disconnected(struct ble_hrs_client *ble_hrs_client, const ble_evt_t *ble_evt)
+static void on_disconnected(struct ble_hrs_client *hrs_client, const ble_evt_t *ble_evt)
 {
-	if (ble_hrs_client->conn_handle == ble_evt->evt.gap_evt.conn_handle) {
-		ble_hrs_client->conn_handle = BLE_CONN_HANDLE_INVALID;
-		ble_hrs_client->peer_hrs_db.hrm_cccd_handle = BLE_GATT_HANDLE_INVALID;
-		ble_hrs_client->peer_hrs_db.hrm_handle = BLE_GATT_HANDLE_INVALID;
+	if (hrs_client->conn_handle == ble_evt->evt.gap_evt.conn_handle) {
+		hrs_client->conn_handle = BLE_CONN_HANDLE_INVALID;
+		hrs_client->handles.hrm_cccd_handle = BLE_GATT_HANDLE_INVALID;
+		hrs_client->handles.hrm_handle = BLE_GATT_HANDLE_INVALID;
 	}
 }
 
-void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
-			    const struct ble_db_discovery_evt *evt)
+void ble_hrs_on_db_disc_evt(struct ble_hrs_client *hrs_client,
+			    const struct ble_db_discovery_evt *db_discovery_evt)
 {
-	__ASSERT(ble_hrs_client, "HRS client instance is NULL");
-	__ASSERT(evt, "Discovery event is NULL");
+	__ASSERT(hrs_client, "HRS client instance is NULL");
+	__ASSERT(db_discovery_evt, "Discovery event is NULL");
 
 	const struct ble_gatt_db_char *db_char;
-	struct ble_hrs_client_evt hrs_c_evt = {
+	struct ble_hrs_client_evt hrs_client_evt = {
 		.evt_type = BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE,
-		.conn_handle = evt->conn_handle,
+		.conn_handle = db_discovery_evt->conn_handle,
 	};
-	struct hrs_db *hrs_db = &ble_hrs_client->peer_hrs_db;
+	struct ble_hrs_handles *handles = &hrs_client->handles;
 
 	/* Check if the Heart Rate Service was discovered. */
-	if (evt->evt_type != BLE_DB_DISCOVERY_COMPLETE ||
-	    evt->discovered_db->srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
-	    evt->discovered_db->srv_uuid.type != BLE_UUID_TYPE_BLE) {
+	if (db_discovery_evt->evt_type != BLE_DB_DISCOVERY_COMPLETE ||
+	    db_discovery_evt->discovered_db->srv_uuid.uuid != BLE_UUID_HEART_RATE_SERVICE ||
+	    db_discovery_evt->discovered_db->srv_uuid.type != BLE_UUID_TYPE_BLE) {
 		return;
 	}
 
 	/* Find the CCCD Handle of the Heart Rate Measurement characteristic. */
-	for (uint32_t i = 0; i < evt->discovered_db->char_count; i++) {
-		db_char = &evt->discovered_db->characteristics[i];
+	for (uint32_t i = 0; i < db_discovery_evt->discovered_db->char_count; i++) {
+		db_char = &db_discovery_evt->discovered_db->characteristics[i];
 
 		if (db_char->characteristic.uuid.uuid == BLE_UUID_HEART_RATE_MEASUREMENT_CHAR) {
 			/* Found Heart Rate characteristic. Store CCCD handle and break. */
-			hrs_c_evt.peer_db.hrm_cccd_handle = db_char->cccd_handle;
-			hrs_c_evt.peer_db.hrm_handle = db_char->characteristic.handle_value;
+			hrs_client_evt.discovery_complete.handles.hrm_cccd_handle =
+				db_char->cccd_handle;
+			hrs_client_evt.discovery_complete.handles.hrm_handle =
+				db_char->characteristic.handle_value;
 			break;
 		}
 	}
@@ -157,67 +159,67 @@ void ble_hrs_on_db_disc_evt(struct ble_hrs_client *ble_hrs_client,
 	LOG_DBG("HRS discovered");
 
 	/* If the instance has been assigned prior to db_discovery, assign the db_handles. */
-	if (ble_hrs_client->conn_handle != BLE_CONN_HANDLE_INVALID) {
-		if ((hrs_db->hrm_cccd_handle == BLE_GATT_HANDLE_INVALID) &&
-		    (hrs_db->hrm_handle == BLE_GATT_HANDLE_INVALID)) {
-			ble_hrs_client->peer_hrs_db = hrs_c_evt.peer_db;
+	if (hrs_client->conn_handle != BLE_CONN_HANDLE_INVALID) {
+		if ((handles->hrm_cccd_handle == BLE_GATT_HANDLE_INVALID) &&
+		    (handles->hrm_handle == BLE_GATT_HANDLE_INVALID)) {
+			hrs_client->handles = hrs_client_evt.discovery_complete.handles;
 		}
 	}
 
-	ble_hrs_client->evt_handler(ble_hrs_client, &hrs_c_evt);
+	hrs_client->evt_handler(hrs_client, &hrs_client_evt);
 }
 
-uint32_t ble_hrs_client_init(struct ble_hrs_client *ble_hrs_client,
-			      struct ble_hrs_client_config *ble_hrs_client_init)
+uint32_t ble_hrs_client_init(struct ble_hrs_client *hrs_client,
+			     const struct ble_hrs_client_config *hrs_client_config)
 {
 	ble_uuid_t hrs_uuid = {
 		.type = BLE_UUID_TYPE_BLE,
 		.uuid = BLE_UUID_HEART_RATE_SERVICE,
 	};
 
-	if (!ble_hrs_client || !ble_hrs_client_init) {
+	if (!hrs_client || !hrs_client_config) {
 		return NRF_ERROR_NULL;
 	}
 
-	if (!ble_hrs_client_init->evt_handler || !ble_hrs_client_init->gatt_queue) {
+	if (!hrs_client_config->evt_handler || !hrs_client_config->gatt_queue) {
 		return NRF_ERROR_NULL;
 	}
 
-	ble_hrs_client->evt_handler = ble_hrs_client_init->evt_handler;
-	ble_hrs_client->gatt_queue = ble_hrs_client_init->gatt_queue;
-	ble_hrs_client->conn_handle = BLE_CONN_HANDLE_INVALID;
-	ble_hrs_client->peer_hrs_db.hrm_cccd_handle = BLE_GATT_HANDLE_INVALID;
-	ble_hrs_client->peer_hrs_db.hrm_handle = BLE_GATT_HANDLE_INVALID;
+	hrs_client->evt_handler = hrs_client_config->evt_handler;
+	hrs_client->gatt_queue = hrs_client_config->gatt_queue;
+	hrs_client->conn_handle = BLE_CONN_HANDLE_INVALID;
+	hrs_client->handles.hrm_cccd_handle = BLE_GATT_HANDLE_INVALID;
+	hrs_client->handles.hrm_handle = BLE_GATT_HANDLE_INVALID;
 
-	return ble_db_discovery_service_register(ble_hrs_client_init->db_discovery, &hrs_uuid);
+	return ble_db_discovery_service_register(hrs_client_config->db_discovery, &hrs_uuid);
 }
 
-void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hrs_client)
+void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *hrs_client)
 {
 	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(ble_hrs_client, "HRS central instance is NULL");
+	__ASSERT(hrs_client, "HRS central instance is NULL");
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTC_EVT_HVX:
-		on_hvx(ble_hrs_client, ble_evt);
+		on_hvx(hrs_client, ble_evt);
 		break;
 	case BLE_GAP_EVT_DISCONNECTED:
-		on_disconnected(ble_hrs_client, ble_evt);
+		on_disconnected(hrs_client, ble_evt);
 		break;
 	default:
 		break;
 	}
 }
 
-static uint32_t cccd_configure(struct ble_hrs_client *ble_hrs_client, bool enable)
+static uint32_t cccd_configure(struct ble_hrs_client *hrs_client, bool enable)
 {
-	if (ble_hrs_client->conn_handle == BLE_CONN_HANDLE_INVALID ||
-	    ble_hrs_client->peer_hrs_db.hrm_cccd_handle == BLE_GATT_HANDLE_INVALID) {
+	if (hrs_client->conn_handle == BLE_CONN_HANDLE_INVALID ||
+	    hrs_client->handles.hrm_cccd_handle == BLE_GATT_HANDLE_INVALID) {
 		return NRF_ERROR_INVALID_STATE;
 	}
 
 	LOG_DBG("CCCD cfg cccd_handle: %#x conn_handle; %#x",
-		ble_hrs_client->peer_hrs_db.hrm_cccd_handle, ble_hrs_client->conn_handle);
+		hrs_client->handles.hrm_cccd_handle, hrs_client->conn_handle);
 
 	uint8_t cccd[BLE_CCCD_VALUE_LEN];
 
@@ -225,48 +227,48 @@ static uint32_t cccd_configure(struct ble_hrs_client *ble_hrs_client, bool enabl
 	struct ble_gq_req hrs_c_req = {
 		.type = BLE_GQ_REQ_GATTC_WRITE,
 		.evt_handler = ble_hrs_client_on_ble_gq_event,
-		.ctx = ble_hrs_client,
-		.gattc_write.handle = ble_hrs_client->peer_hrs_db.hrm_cccd_handle,
+		.ctx = hrs_client,
+		.gattc_write.handle = hrs_client->handles.hrm_cccd_handle,
 		.gattc_write.len = BLE_CCCD_VALUE_LEN,
 		.gattc_write.p_value = cccd,
 		.gattc_write.write_op = BLE_GATT_OP_WRITE_REQ,
 	};
 
-	return ble_gq_item_add(ble_hrs_client->gatt_queue, &hrs_c_req,
-			       ble_hrs_client->conn_handle);
+	return ble_gq_item_add(hrs_client->gatt_queue, &hrs_c_req,
+			       hrs_client->conn_handle);
 }
 
-uint32_t ble_hrs_client_hrm_notif_enable(struct ble_hrs_client *ble_hrs_client)
+uint32_t ble_hrs_client_hrm_notif_enable(struct ble_hrs_client *hrs_client)
 {
-	if (!ble_hrs_client) {
+	if (!hrs_client) {
 		return NRF_ERROR_NULL;
 	}
 
-	return cccd_configure(ble_hrs_client, true);
+	return cccd_configure(hrs_client, true);
 }
 
-uint32_t ble_hrs_client_hrm_notif_disable(struct ble_hrs_client *ble_hrs_client)
+uint32_t ble_hrs_client_hrm_notif_disable(struct ble_hrs_client *hrs_client)
 {
-	if (!ble_hrs_client) {
+	if (!hrs_client) {
 		return NRF_ERROR_NULL;
 	}
 
-	return cccd_configure(ble_hrs_client, false);
+	return cccd_configure(hrs_client, false);
 }
 
-uint32_t ble_hrs_client_handles_assign(struct ble_hrs_client *ble_hrs_client,
+uint32_t ble_hrs_client_handles_assign(struct ble_hrs_client *hrs_client,
 					uint16_t conn_handle,
-					const struct hrs_db *p_peer_hrs_handles)
+					const struct ble_hrs_handles *handles)
 {
-	if (!ble_hrs_client) {
+	if (!hrs_client) {
 		return NRF_ERROR_NULL;
 	}
 
-	ble_hrs_client->conn_handle = conn_handle;
+	hrs_client->conn_handle = conn_handle;
 
-	if (p_peer_hrs_handles) {
-		ble_hrs_client->peer_hrs_db = *p_peer_hrs_handles;
+	if (handles) {
+		hrs_client->handles = *handles;
 	}
 
-	return ble_gq_conn_handle_register(ble_hrs_client->gatt_queue, conn_handle);
+	return ble_gq_conn_handle_register(hrs_client->gatt_queue, conn_handle);
 }

--- a/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs_client/src/unity_test.c
@@ -39,7 +39,8 @@ static struct ble_db_discovery db_discovery;
 static struct ble_hrs_client_evt last_evt;
 static int evt_handler_called;
 
-static void hrs_client_evt_handler(struct ble_hrs_client *ble_hrs_c, struct ble_hrs_client_evt *evt)
+static void hrs_client_evt_handler(struct ble_hrs_client *hrs_client,
+				   const struct ble_hrs_client_evt *evt)
 {
 	evt_handler_called = 1;
 	last_evt = *evt;
@@ -48,7 +49,7 @@ static void hrs_client_evt_handler(struct ble_hrs_client *ble_hrs_c, struct ble_
 void test_ble_hrs_client_init_null(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -58,42 +59,42 @@ void test_ble_hrs_client_init_null(void)
 	nrf_err = ble_hrs_client_init(NULL, &config);
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, NULL);
+	nrf_err = ble_hrs_client_init(&hrs_client, NULL);
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
 void test_ble_hrs_client_init_null_evt_handler(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = NULL,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
 void test_ble_hrs_client_init_null_gatt_queue(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = NULL,
 		.db_discovery = &db_discovery,
 	};
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
 void test_ble_hrs_client_init_service_register_fails(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -103,14 +104,14 @@ void test_ble_hrs_client_init_service_register_fails(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, ERROR);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(ERROR, nrf_err);
 }
 
 void test_ble_hrs_client_init_success(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -120,14 +121,14 @@ void test_ble_hrs_client_init_success(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void test_ble_hrs_client_handles_assign_null(void)
 {
 	uint32_t nrf_err;
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -139,13 +140,13 @@ void test_ble_hrs_client_handles_assign_null(void)
 void test_ble_hrs_client_handles_assign(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -156,12 +157,12 @@ void test_ble_hrs_client_handles_assign(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* Verify by behaviour: HRM notification is received after assign */
@@ -173,17 +174,17 @@ void test_ble_hrs_client_handles_assign(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
 }
 
 void test_ble_hrs_client_handles_assign_null_peer_handles(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -196,12 +197,12 @@ void test_ble_hrs_client_handles_assign_null_peer_handles(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, NULL);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, NULL);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* Verify by behaviour: no peer handles means HVX does not produce HRM event */
@@ -213,7 +214,7 @@ void test_ble_hrs_client_handles_assign_null_peer_handles(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -229,13 +230,13 @@ void test_ble_hrs_client_hrm_notif_enable_null(void)
 void test_ble_hrs_client_hrm_notif_enable_success(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -243,18 +244,18 @@ void test_ble_hrs_client_hrm_notif_enable_success(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_item_add_ExpectAndReturn(&gatt_queue, NULL, CONN_HANDLE, NRF_SUCCESS);
 	__cmock_ble_gq_item_add_IgnoreArg_req();
 
-	nrf_err = ble_hrs_client_hrm_notif_enable(&ble_hrs_c);
+	nrf_err = ble_hrs_client_hrm_notif_enable(&hrs_client);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
@@ -269,13 +270,13 @@ void test_ble_hrs_client_hrm_notif_disable_null(void)
 void test_ble_hrs_client_hrm_notif_disable_success(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -283,25 +284,25 @@ void test_ble_hrs_client_hrm_notif_disable_success(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_item_add_ExpectAndReturn(&gatt_queue, NULL, CONN_HANDLE, NRF_SUCCESS);
 	__cmock_ble_gq_item_add_IgnoreArg_req();
 
-	nrf_err = ble_hrs_client_hrm_notif_disable(&ble_hrs_c);
+	nrf_err = ble_hrs_client_hrm_notif_disable(&hrs_client);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
 void test_ble_hrs_client_hrm_notif_enable_not_connected(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -311,18 +312,18 @@ void test_ble_hrs_client_hrm_notif_enable_not_connected(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* No handles_assign called, conn_handle is BLE_CONN_HANDLE_INVALID. */
-	nrf_err = ble_hrs_client_hrm_notif_enable(&ble_hrs_c);
+	nrf_err = ble_hrs_client_hrm_notif_enable(&hrs_client);
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_hrs_client_hrm_notif_disable_not_connected(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -332,24 +333,24 @@ void test_ble_hrs_client_hrm_notif_disable_not_connected(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	/* No handles_assign called, conn_handle is BLE_CONN_HANDLE_INVALID. */
-	nrf_err = ble_hrs_client_hrm_notif_disable(&ble_hrs_c);
+	nrf_err = ble_hrs_client_hrm_notif_disable(&hrs_client);
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
 }
 
 void test_ble_hrs_client_on_ble_gq_event_error_delivers_evt(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct ble_gq_req req = { .ctx = &ble_hrs_c };
+	struct ble_gq_req req = { .ctx = &hrs_client };
 	struct ble_gq_evt gq_evt = {
 		.evt_type = BLE_GQ_EVT_ERROR,
 		.conn_handle = CONN_HANDLE,
@@ -359,7 +360,7 @@ void test_ble_hrs_client_on_ble_gq_event_error_delivers_evt(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
@@ -374,7 +375,7 @@ void test_ble_hrs_client_on_ble_gq_event_error_delivers_evt(void)
 void test_ble_hrs_on_db_disc_evt_wrong_service_ignored(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -396,11 +397,11 @@ void test_ble_hrs_on_db_disc_evt_wrong_service_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &evt);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -408,7 +409,7 @@ void test_ble_hrs_on_db_disc_evt_wrong_service_ignored(void)
 void test_ble_hrs_on_db_disc_evt_srv_not_found_ignored(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -429,11 +430,11 @@ void test_ble_hrs_on_db_disc_evt_srv_not_found_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &evt);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -441,7 +442,7 @@ void test_ble_hrs_on_db_disc_evt_srv_not_found_ignored(void)
 void test_ble_hrs_on_db_disc_evt_complete_with_hrm_char(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -470,23 +471,23 @@ void test_ble_hrs_on_db_disc_evt_complete_with_hrm_char(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &evt);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE, last_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, last_evt.conn_handle);
-	TEST_ASSERT_EQUAL(HRM_CCCD_HANDLE, last_evt.peer_db.hrm_cccd_handle);
-	TEST_ASSERT_EQUAL(HRM_HANDLE, last_evt.peer_db.hrm_handle);
+	TEST_ASSERT_EQUAL(HRM_CCCD_HANDLE, last_evt.discovery_complete.handles.hrm_cccd_handle);
+	TEST_ASSERT_EQUAL(HRM_HANDLE, last_evt.discovery_complete.handles.hrm_handle);
 }
 
 void test_ble_hrs_on_db_disc_evt_hrm_char_at_index_one(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -520,16 +521,16 @@ void test_ble_hrs_on_db_disc_evt_hrm_char_at_index_one(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &evt);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(HRM_CCCD_HANDLE, last_evt.peer_db.hrm_cccd_handle);
-	TEST_ASSERT_EQUAL(HRM_HANDLE, last_evt.peer_db.hrm_handle);
+	TEST_ASSERT_EQUAL(HRM_CCCD_HANDLE, last_evt.discovery_complete.handles.hrm_cccd_handle);
+	TEST_ASSERT_EQUAL(HRM_HANDLE, last_evt.discovery_complete.handles.hrm_handle);
 }
 
 void test_ble_hrs_on_db_disc_evt_complete_hrs_no_hrm_char(void)
@@ -538,7 +539,7 @@ void test_ble_hrs_on_db_disc_evt_complete_hrs_no_hrm_char(void)
 	 * loop runs, no match, event still delivered
 	 */
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -560,36 +561,37 @@ void test_ble_hrs_on_db_disc_evt_complete_hrs_no_hrm_char(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &evt);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE, last_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, last_evt.conn_handle);
-	/* No HRM char found: peer_db handles remain invalid (zero) */
-	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, last_evt.peer_db.hrm_cccd_handle);
-	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, last_evt.peer_db.hrm_handle);
+	/* No HRM char found: handles handles remain invalid (zero) */
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID,
+			  last_evt.discovery_complete.handles.hrm_cccd_handle);
+	TEST_ASSERT_EQUAL(BLE_GATT_HANDLE_INVALID, last_evt.discovery_complete.handles.hrm_handle);
 }
 
-void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigned(void)
+void test_ble_hrs_on_db_disc_evt_does_not_overwrite_handles_when_already_assigned(void)
 {
-	/* conn_handle set and peer_hrs_db already valid.
-	 * discovery must not overwrite peer_hrs_db
+	/* conn_handle set and ble_hrs_handles already valid.
+	 * discovery must not overwrite ble_hrs_handles
 	 */
 	uint32_t nrf_err;
 	uint8_t hrm_data[] = { 0x00, 0x48 };
 	uint8_t evt_buf[sizeof(ble_evt_t) + sizeof(hrm_data)] = {0};
 	ble_evt_t *evt = (ble_evt_t *)evt_buf;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -617,21 +619,21 @@ void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigne
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &disc_evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &disc_evt);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE, last_evt.evt_type);
 
-	/* peer_hrs_db must not have been overwritten.
+	/* ble_hrs_handles must not have been overwritten.
 	 * HVX with original HRM_HANDLE still works
 	 */
 
@@ -642,20 +644,20 @@ void test_ble_hrs_on_db_disc_evt_does_not_overwrite_peer_db_when_already_assigne
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
 }
 
-void test_ble_hrs_on_db_disc_evt_assigns_peer_db_when_conn_handle_set(void)
+void test_ble_hrs_on_db_disc_evt_assigns_handles_when_conn_handle_set(void)
 {
 	uint32_t nrf_err;
 	uint8_t hrm_data[] = { 0x00, 0x48 };
 	uint8_t evt_buf[sizeof(ble_evt_t) + sizeof(hrm_data)] = {0};
 	ble_evt_t *evt = (ble_evt_t *)evt_buf;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
@@ -684,24 +686,24 @@ void test_ble_hrs_on_db_disc_evt_assigns_peer_db_when_conn_handle_set(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, NULL);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, NULL);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	/* peer_hrs_db is still invalid.
+	/* ble_hrs_handles is still invalid.
 	 * discovery with HRS found should assign it
 	 */
 	evt_handler_called = 0;
-	ble_hrs_on_db_disc_evt(&ble_hrs_c, &disc_evt);
+	ble_hrs_on_db_disc_evt(&hrs_client, &disc_evt);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_DISCOVERY_COMPLETE, last_evt.evt_type);
 
-	/* Verify peer_db was assigned so that HVX is now accepted. */
+	/* Verify handles was assigned so that HVX is now accepted. */
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
 	evt->evt.gattc_evt.conn_handle = CONN_HANDLE;
@@ -710,11 +712,11 @@ void test_ble_hrs_on_db_disc_evt_assigns_peer_db_when_conn_handle_set(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
 }
 
 void test_ble_hrs_client_on_ble_evt_disconnected_clears_handles(void)
@@ -723,13 +725,13 @@ void test_ble_hrs_client_on_ble_evt_disconnected_clears_handles(void)
 	uint8_t hrm_data[] = { 0x00, 0x48 };
 	uint8_t evt_buf[sizeof(ble_evt_t) + sizeof(hrm_data)] = {0};
 	ble_evt_t *hvx_evt = (ble_evt_t *)evt_buf;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -741,15 +743,15 @@ void test_ble_hrs_client_on_ble_evt_disconnected_clears_handles(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	ble_hrs_client_on_ble_evt(&disc_evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(&disc_evt, &hrs_client);
 
 	/* Verify by behaviour: after disconnect, HVX for same conn no longer delivers HRM event. */
 
@@ -760,7 +762,7 @@ void test_ble_hrs_client_on_ble_evt_disconnected_clears_handles(void)
 	memcpy(hvx_evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(hvx_evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(hvx_evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -771,13 +773,13 @@ void test_ble_hrs_client_on_ble_evt_disconnected_wrong_conn_ignored(void)
 	uint8_t hrm_data[] = { 0x00, 0x48 };
 	uint8_t evt_buf[sizeof(ble_evt_t) + sizeof(hrm_data)] = {0};
 	ble_evt_t *hvx_evt = (ble_evt_t *)evt_buf;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -789,15 +791,15 @@ void test_ble_hrs_client_on_ble_evt_disconnected_wrong_conn_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
-	ble_hrs_client_on_ble_evt(&disc_evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(&disc_evt, &hrs_client);
 
 	/* Verify by behaviour: disconnect for other conn does not affect receiving HVX */
 
@@ -808,24 +810,24 @@ void test_ble_hrs_client_on_ble_evt_disconnected_wrong_conn_ignored(void)
 	memcpy(hvx_evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(hvx_evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(hvx_evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
 }
 
 void test_ble_hrs_client_on_ble_evt_hvx_8bit_hr(void)
 {
 	uint32_t nrf_err;
 	uint8_t hrm_data[] = { 0x00, 0x48 }; /* flags: 0 = 8-bit HR, value = 72 */
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE
 	};
@@ -836,12 +838,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_8bit_hr(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -851,12 +853,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_8bit_hr(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
-	TEST_ASSERT_EQUAL(0, last_evt.hrm.rr_intervals_cnt);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
+	TEST_ASSERT_EQUAL(0, last_evt.hrm_notification.rr_intervals_cnt);
 }
 
 void test_ble_hrs_client_on_ble_evt_hvx_16bit_hr(void)
@@ -864,13 +866,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_16bit_hr(void)
 	uint32_t nrf_err;
 	/* flags 0x01 = 16-bit HR, value 0x1234 little-endian */
 	uint8_t hrm_data[] = { 0x01, 0x34, 0x12 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE
 	};
@@ -880,11 +882,11 @@ void test_ble_hrs_client_on_ble_evt_hvx_16bit_hr(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
@@ -895,11 +897,11 @@ void test_ble_hrs_client_on_ble_evt_hvx_16bit_hr(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x1234, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x1234, last_evt.hrm_notification.hr_value);
 }
 
 void test_ble_hrs_client_on_ble_evt_hvx_with_rr_intervals(void)
@@ -909,13 +911,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_with_rr_intervals(void)
 	 * 8-bit HR 72, two RR intervals (256, 512) little-endian
 	 */
 	uint8_t hrm_data[] = { 0x10, 0x48, 0x00, 0x01, 0x00, 0x02 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE
 	};
@@ -925,12 +927,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_with_rr_intervals(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -940,26 +942,26 @@ void test_ble_hrs_client_on_ble_evt_hvx_with_rr_intervals(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
-	TEST_ASSERT_EQUAL(2, last_evt.hrm.rr_intervals_cnt);
-	TEST_ASSERT_EQUAL(256, last_evt.hrm.rr_intervals[0]);
-	TEST_ASSERT_EQUAL(512, last_evt.hrm.rr_intervals[1]);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
+	TEST_ASSERT_EQUAL(2, last_evt.hrm_notification.rr_intervals_cnt);
+	TEST_ASSERT_EQUAL(256, last_evt.hrm_notification.rr_intervals[0]);
+	TEST_ASSERT_EQUAL(512, last_evt.hrm_notification.rr_intervals[1]);
 }
 
 void test_ble_hrs_client_on_ble_evt_hvx_zero_len_ignored(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -969,12 +971,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_zero_len_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -983,7 +985,7 @@ void test_ble_hrs_client_on_ble_evt_hvx_zero_len_ignored(void)
 	evt->evt.gattc_evt.params.hvx.len = 0;
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -993,13 +995,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_8bit_ignored(void)
 	uint32_t nrf_err;
 	/* flags=0x00 (8-bit HR) but only 1 byte total -- missing the HR value */
 	uint8_t hrm_data[] = { 0x00 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -1009,12 +1011,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_8bit_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -1024,7 +1026,7 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_8bit_ignored(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -1034,13 +1036,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_16bit_ignored(void)
 	uint32_t nrf_err;
 	/* flags=0x01 (16-bit HR) but only 2 bytes total -- need 3 */
 	uint8_t hrm_data[] = { 0x01, 0x34 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -1050,12 +1052,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_16bit_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -1065,7 +1067,7 @@ void test_ble_hrs_client_on_ble_evt_hvx_too_short_16bit_ignored(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -1077,13 +1079,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_rr_truncated(void)
 	 * 8-bit HR 0x48, one complete RR (256) + 1 trailing byte (truncated pair)
 	 */
 	uint8_t hrm_data[] = { 0x10, 0x48, 0x00, 0x01, 0xFF };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -1093,12 +1095,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_rr_truncated(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -1108,27 +1110,27 @@ void test_ble_hrs_client_on_ble_evt_hvx_rr_truncated(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
 	TEST_ASSERT_EQUAL(BLE_HRS_CLIENT_EVT_HRM_NOTIFICATION, last_evt.evt_type);
-	TEST_ASSERT_EQUAL(0x48, last_evt.hrm.hr_value);
+	TEST_ASSERT_EQUAL(0x48, last_evt.hrm_notification.hr_value);
 	/* Only 1 complete RR pair; the trailing byte is ignored */
-	TEST_ASSERT_EQUAL(1, last_evt.hrm.rr_intervals_cnt);
-	TEST_ASSERT_EQUAL(256, last_evt.hrm.rr_intervals[0]);
+	TEST_ASSERT_EQUAL(1, last_evt.hrm_notification.rr_intervals_cnt);
+	TEST_ASSERT_EQUAL(256, last_evt.hrm_notification.rr_intervals[0]);
 }
 
 void test_ble_hrs_client_on_ble_evt_hvx_wrong_handle_ignored(void)
 {
 	uint32_t nrf_err;
 	uint8_t hrm_data[] = { 0x00, 0x48 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE
 	};
@@ -1138,12 +1140,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_handle_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -1153,7 +1155,7 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_handle_ignored(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -1162,13 +1164,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_conn_ignored(void)
 {
 	uint32_t nrf_err;
 	uint8_t hrm_data[] = { 0x00, 0x48 };
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE
 	};
@@ -1178,12 +1180,12 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_conn_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt->header.evt_id = BLE_GATTC_EVT_HVX;
@@ -1193,7 +1195,7 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_conn_ignored(void)
 	memcpy(evt->evt.gattc_evt.params.hvx.data, hrm_data, sizeof(hrm_data));
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }
@@ -1201,13 +1203,13 @@ void test_ble_hrs_client_on_ble_evt_hvx_wrong_conn_ignored(void)
 void test_ble_hrs_client_on_ble_evt_unhandled_evt_ignored(void)
 {
 	uint32_t nrf_err;
-	struct ble_hrs_client ble_hrs_c = {0};
+	struct ble_hrs_client hrs_client = {0};
 	struct ble_hrs_client_config config = {
 		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &gatt_queue,
 		.db_discovery = &db_discovery,
 	};
-	struct hrs_db peer_handles = {
+	struct ble_hrs_handles peer_handles = {
 		.hrm_cccd_handle = HRM_CCCD_HANDLE,
 		.hrm_handle = HRM_HANDLE,
 	};
@@ -1219,16 +1221,16 @@ void test_ble_hrs_client_on_ble_evt_unhandled_evt_ignored(void)
 	__cmock_ble_db_discovery_service_register_ExpectAndReturn(&db_discovery, NULL, NRF_SUCCESS);
 	__cmock_ble_db_discovery_service_register_IgnoreArg_uuid();
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_c, &config);
+	nrf_err = ble_hrs_client_init(&hrs_client, &config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	__cmock_ble_gq_conn_handle_register_ExpectAndReturn(&gatt_queue, CONN_HANDLE, NRF_SUCCESS);
 
-	nrf_err = ble_hrs_client_handles_assign(&ble_hrs_c, CONN_HANDLE, &peer_handles);
+	nrf_err = ble_hrs_client_handles_assign(&hrs_client, CONN_HANDLE, &peer_handles);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 
 	evt_handler_called = 0;
-	ble_hrs_client_on_ble_evt(&evt, &ble_hrs_c);
+	ble_hrs_client_on_ble_evt(&evt, &hrs_client);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 }


### PR DESCRIPTION
Cleanup HRS client to align with other client services.
* Changes to HRS Client API, including events and function signatures.
* Rename of ble_hrs_client.c to hrs_client.c