### PR TITLE
treewide: use Bluetooth LE instead of BLE in documentation

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/Kconfig
+++ b/applications/firmware_loader/ble_mcumgr/Kconfig
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE MCUmgr sample"
+menu "Bluetooth LE MCUmgr sample"
 
 config APP_FIRMWARE_LOADER_BLE_DEVICE_NAME
 	string "Device name"
 	default "nRF_BM_MCUmgr"
 
 module=APP
-module-str=BLE MCUmgr Sample
+module-str=Bluetooth LE MCUmgr Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE MCUmgr sample"
+endmenu # "Bluetooth LE MCUmgr sample"
 
 source "Kconfig.zephyr"

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -46,9 +46,9 @@ static struct mgmt_callback os_mgmt_reboot_callback = {
 };
 
 /**
- * @brief BLE event handler.
+ * @brief Bluetooth LE event handler.
  *
- * @param[in] evt BLE event.
+ * @param[in] evt Bluetooth LE event.
  * @param[in] ctx Context.
  */
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)

--- a/doc/nrf-bm/boards/memory_layout.rst
+++ b/doc/nrf-bm/boards/memory_layout.rst
@@ -49,7 +49,7 @@ RRAM partitions
      - Firmware loader / secondary slot for DFU. Present only in MCUboot configurations.
    * - SoftDevice
      - ``softdevice``
-     - Nordic SoftDevice BLE stack binary.
+     - Nordic SoftDevice Bluetooth LE stack binary.
    * - Metadata
      - ``metadata``
      - MCUboot metadata region. Present only in MCUboot configurations.

--- a/doc/nrf-bm/libraries/bluetooth/ble_gatt_queue.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_gatt_queue.rst
@@ -7,13 +7,13 @@ Bluetooth: GATT Queue
    :local:
    :depth: 2
 
-The Bluetooth Low Energy® GATT Queue library can be used to buffer BLE GATT requests if the SoftDevice is not able to handle them at the moment.
+The Bluetooth Low Energy® GATT Queue library can be used to buffer Bluetooth LE GATT requests if the SoftDevice is not able to handle them at the moment.
 
 Overview
 ********
 
-If the SoftDevice is not able to handle the GATT request at the moment, the BLE GATT Queue library buffers the request.
-Later on, when the corresponding BLE event indicates that the SoftDevice may be free, the request is retried.
+If the SoftDevice is not able to handle the GATT request at the moment, the Bluetooth LE GATT Queue library buffers the request.
+Later on, when the corresponding Bluetooth LE event indicates that the SoftDevice may be free, the request is retried.
 This library can be used in multiple connections scenario.
 
 The library currently handles the following types of GATT requests:
@@ -25,7 +25,7 @@ The library currently handles the following types of GATT requests:
 * Descriptor Discovery (See ``sd_ble_gattc_descriptors_discover``)
 * Notify or Indicate an attribute value. (See ``sd_ble_gatts_hvx``)
 
-The BLE GATT Queue can be used with BLE service clients and other BLE libraries that issue GATT requests to the SoftDevice.
+The GATT Queue can be used with Bluetooth LE service clients and other libraries that issue GATT requests to the SoftDevice.
 
 Configuration
 *************
@@ -51,11 +51,11 @@ The module does not require other initialization than adding the library instanc
 Usage
 *****
 
-Once defined, you can register a connection handle in the BLE Gatt Queue (BLE GQ) instance by calling the :c:func:`ble_gq_conn_handle_register` function.
-From this point forward, the BLE GQ instance can handle GATT requests associated with the handle until the connection is no longer valid (for example when a disconnect event occurs).
+Once defined, you can register a connection handle in the Bluetooth LE GATT Queue instance by calling the :c:func:`ble_gq_conn_handle_register` function.
+From this point forward, the GATT Queue instance can handle GATT requests associated with the handle until the connection is no longer valid (for example when a disconnect event occurs).
 
-To add a GATT request to the BLE GQ instance, call the :c:func:`ble_gq_item_add` function.
-This function adds a request to the BLE GQ instance and allocates the necessary memory for data that can be held within the request descriptor.
+To add a GATT request to the Gatt Queue instance, call the :c:func:`ble_gq_item_add` function.
+This function adds a request to the GATT Queue instance and allocates the necessary memory for data that can be held within the request descriptor.
 If the SoftDevice is free and the queue is empty, the request will be processed immediately.
 Otherwise, the request is queued and processed later.
 

--- a/doc/nrf-bm/libraries/bluetooth/ble_qwr.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_qwr.rst
@@ -49,7 +49,7 @@ When it receives an Execute Write request, it calls the callback function with a
 
 * To authorize the request, the callback function must return ``BLE_GATT_STATUS_SUCCESS``.
   The module then writes all received data and notifies the GATT server that the data is ready to use by calling the callback function again, this time with a :c:enum:`BLE_QWR_EVT_EXECUTE_WRITE` event.
-* To reject the request (for example, because the received data is not valid or the application is busy), the callback function must return a BLE GATT status code other than ``BLE_GATT_STATUS_SUCCESS``.
+* To reject the request (for example, because the received data is not valid or the application is busy), the callback function must return a Bluetooth LE GATT status code other than ``BLE_GATT_STATUS_SUCCESS``.
   The module then deletes the received data.
 
 Dependencies

--- a/doc/nrf-bm/release_notes/release_notes_1.0.0.rst
+++ b/doc/nrf-bm/release_notes/release_notes_1.0.0.rst
@@ -96,7 +96,7 @@ SoftDevice Handler
   * The :kconfig:option:`CONFIG_NRF_SDH_CLOCK_HFCLK_LATENCY` Kconfig option to inform the SoftDevice about the ramp-up time of the high-frequency crystal oscillator.
   * The :kconfig:option:`CONFIG_NRF_SDH_SOC_RAND_SEED` Kconfig option to control whether to automatically respond to SoftDevice random seed requests.
   * Priority levels for SoftDevice event observers: HIGHEST, HIGH, USER, USER_LOW, LOWEST.
-  * The :c:func:`nrf_sdh_ble_evt_to_str` function to stringify a BLE event.
+  * The :c:func:`nrf_sdh_ble_evt_to_str` function to stringify a Bluetooth LE event.
   * The :c:func:`nrf_sdh_soc_evt_to_str` function to stringify a SoC event.
   * The :c:func:`nrf_sdh_observer_ready` function to prepare an observer for a SoftDevice state change.
 

--- a/include/bm/bluetooth/ble_adv.h
+++ b/include/bm/bluetooth/ble_adv.h
@@ -6,11 +6,11 @@
 
 /** @file
  *
- * @defgroup ble_adv BLE advertising library
+ * @defgroup ble_adv Bluetooth LE advertising library
  * @{
- * @brief Library for handling connectable BLE advertising.
+ * @brief Library for handling connectable Bluetooth LE advertising.
  *
- *  The BLE advertising library supports only applications with a single peripheral link.
+ *  The Bluetooth LE advertising library supports only applications with a single peripheral link.
  */
 
 #ifndef BLE_ADV_H__
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Declare an instance of a BLE advertising library.
+ * @brief Declare an instance of a Bluetooth LE advertising library.
  */
 #define BLE_ADV_DEF(instance)                                                                      \
 	static struct ble_adv instance;                                                            \
@@ -140,12 +140,12 @@ struct ble_adv_evt {
 struct ble_adv;
 
 /**
- * @brief BLE advertising event handler.
+ * @brief Bluetooth LE advertising event handler.
  */
 typedef void (*ble_adv_evt_handler_t)(struct ble_adv *adv, const struct ble_adv_evt *adv_evt);
 
 /**
- * @brief BLE advertising instance.
+ * @brief Bluetooth LE advertising instance.
  */
 struct ble_adv {
 	/**
@@ -165,7 +165,7 @@ struct ble_adv {
 	 */
 	uint8_t adv_handle;
 	/**
-	 * @brief BLE connection handle.
+	 * @brief Bluetooth LE connection handle.
 	 */
 	uint16_t conn_handle;
 	/**
@@ -238,17 +238,17 @@ struct ble_adv_config {
 };
 
 /**
- * @brief Library's BLE event handler.
+ * @brief Library's Bluetooth LE event handler.
  *
- * @param[in] ble_evt BLE stack event.
+ * @param[in] ble_evt Bluetooth LE stack event.
  * @param[in] ble_adv Advertising Module instance.
  */
 void ble_adv_on_ble_evt(const ble_evt_t *ble_evt, void *ble_adv);
 
 /**
- * @brief Initialize the BLE advertising library.
+ * @brief Initialize the Bluetooth LE advertising library.
  *
- * @param[in] ble_adv BLE advertising instance.
+ * @param[in] ble_adv Bluetooth LE advertising instance.
  * @param[in] ble_adv_config Initialization configuration.
  *
  * @retval NRF_SUCCESS On success.
@@ -260,7 +260,7 @@ uint32_t ble_adv_init(struct ble_adv *ble_adv, const struct ble_adv_config *ble_
 /**
  * @brief Set the connection configuration tag used for connections.
  *
- * @param[in] ble_adv BLE advertising instance.
+ * @param[in] ble_adv Bluetooth LE advertising instance.
  * @param[in] ble_cfg_tag Connection configuration tag.
  *
  * @retval NRF_SUCCESS On success.
@@ -274,7 +274,7 @@ uint32_t ble_adv_conn_cfg_tag_set(struct ble_adv *ble_adv, uint8_t ble_cfg_tag);
  * If the given advertising mode @p mode is not enabled,
  * advertising is started in the next supported mode.
  *
- * @param[in] ble_adv BLE advertising instance.
+ * @param[in] ble_adv Bluetooth LE advertising instance.
  * @param[in] mode Desired advertising mode.
  *
  * @retval NRF_SUCCESS On success.

--- a/include/bm/bluetooth/ble_adv_data.h
+++ b/include/bm/bluetooth/ble_adv_data.h
@@ -181,7 +181,7 @@ struct ble_adv_data {
  * of Advertising packet or Scan Response packet, or a payload of NFC message intended for
  * initiating the Out-of-Band pairing.
  *
- * @param[in] ble_adv_data BLE advertising data context.
+ * @param[in] ble_adv_data Bluetooth LE advertising data context.
  * @param[out] buf  Output buffer.
  * @param[in,out] len Size of @p buf on input, length of encoded data on output.
  *

--- a/include/bm/bluetooth/ble_conn_params.h
+++ b/include/bm/bluetooth/ble_conn_params.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @defgroup ble_conn_params BLE Connection Parameter Library
+ * @defgroup ble_conn_params Bluetooth LE Connection Parameter Library
  * @{
- * @brief API for the BLE Connection Parameter library in BareMetal option.
+ * @brief API for the Bluetooth LE Connection Parameter library in BareMetal option.
  */
 
 #ifndef BLE_CONN_PARAMS_H__
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 /**
- * @brief BLE connection parameter event types.
+ * @brief Bluetooth LE connection parameter event types.
  */
 enum ble_conn_params_evt_type {
 	/**
@@ -66,7 +66,7 @@ struct ble_conn_params_data_length {
 };
 
 /**
- * @brief BLE connection parameter event.
+ * @brief Bluetooth LE connection parameter event.
  */
 struct ble_conn_params_evt {
 	/**
@@ -113,7 +113,7 @@ struct ble_conn_params_evt {
 };
 
 /**
- * @brief BLE connection parameters event handler prototype.
+ * @brief Bluetooth LE connection parameters event handler prototype.
  */
 typedef void (*ble_conn_params_evt_handler_t)(const struct ble_conn_params_evt *evt);
 

--- a/include/bm/bluetooth/ble_conn_state.h
+++ b/include/bm/bluetooth/ble_conn_state.h
@@ -10,10 +10,10 @@
  * @defgroup ble_conn_state Connection state
  * @ingroup ble_sdk_lib
  * @{
- * @brief Module for storing data on BLE connections.
+ * @brief Module for storing data on Bluetooth LE connections.
  *
  * @details This module stores certain states for each connection, which can be queried by
- *          connection handle. The module uses BLE events to keep the states updated.
+ *          connection handle. The module uses Bluetooth LE events to keep the states updated.
  *
  *          In addition to the preprogrammed states, this module can also keep track of a number of
  *          binary user states, or user flags. These are reset to 0 for new connections, but
@@ -72,7 +72,7 @@ struct ble_conn_state_conn_handle_list {
 typedef void (*ble_conn_state_user_function_t)(uint16_t conn_handle, void *ctx);
 
 /**
- * @defgroup ble_conn_state_functions BLE connection state functions
+ * @defgroup ble_conn_state_functions Bluetooth LE connection state functions
  * @{
  */
 

--- a/include/bm/bluetooth/ble_date_time.h
+++ b/include/bm/bluetooth/ble_date_time.h
@@ -6,7 +6,7 @@
 
 /** @file
  *
- * @defgroup ble_date_time_char BLE Date Time characteristic type
+ * @defgroup ble_date_time_char Bluetooth LE Date Time characteristic type
  * @{
  * @brief Definition of struct ble_date_time type.
  */

--- a/include/bm/bluetooth/ble_db_discovery.h
+++ b/include/bm/bluetooth/ble_db_discovery.h
@@ -6,7 +6,7 @@
 
 /** @file
  *
- * @defgroup ble_db_discovery BLE Nordic database discovery library
+ * @defgroup ble_db_discovery Bluetooth LE Nordic database discovery library
  * @{
  * @brief Library for discovery of a service and its characteristics at the peer server.
  */
@@ -31,7 +31,7 @@
 	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_db_discovery_on_ble_evt, &_name, HIGH)
 
 /**
- * @brief BLE database discovery event type.
+ * @brief Bluetooth LE database discovery event type.
  */
 enum ble_db_discovery_evt_type {
 	/**
@@ -56,7 +56,7 @@ enum ble_db_discovery_evt_type {
 };
 
 /**
- * @brief BLE database discovery event.
+ * @brief Bluetooth LE database discovery event.
  */
 struct ble_db_discovery_evt {
 	/**
@@ -103,7 +103,7 @@ typedef void (*ble_db_discovery_evt_handler)(struct ble_db_discovery *db_discove
 					     struct ble_db_discovery_evt *evt);
 
 /**
- * @brief BLE database discovery configuration.
+ * @brief Bluetooth LE database discovery configuration.
  */
 struct ble_db_discovery_config {
 	/**
@@ -111,13 +111,13 @@ struct ble_db_discovery_config {
 	 */
 	ble_db_discovery_evt_handler evt_handler;
 	/**
-	 * @brief Pointer to BLE GATT Queue instance.
+	 * @brief Pointer to Bluetooth LE GATT Queue instance.
 	 */
 	const struct ble_gq *gatt_queue;
 };
 
 /**
- * @brief BLE database discovery.
+ * @brief Bluetooth LE database discovery.
  */
 struct ble_db_discovery {
 	/**
@@ -135,7 +135,7 @@ struct ble_db_discovery {
 	 */
 	ble_db_discovery_evt_handler evt_handler;
 	/**
-	 * @brief BLE GATT Queue instance.
+	 * @brief Bluetooth LE GATT Queue instance.
 	 */
 	const struct ble_gq *gatt_queue;
 	/**
@@ -241,10 +241,10 @@ uint32_t ble_db_discovery_service_register(struct ble_db_discovery *db_discovery
 					   const ble_uuid_t *uuid);
 
 /**
- * @brief Application's BLE Stack event handler.
+ * @brief Application's Bluetooth LE Stack event handler.
  *
- * @param[in] ble_evt BLE event received.
- * @param[in,out] context BLE DB discovery instance.
+ * @param[in] ble_evt Event received.
+ * @param[in,out] context DB discovery instance.
  */
 void ble_db_discovery_on_ble_evt(const ble_evt_t *ble_evt, void *context);
 

--- a/include/bm/bluetooth/ble_gq.h
+++ b/include/bm/bluetooth/ble_gq.h
@@ -8,11 +8,11 @@
  *
  * @defgroup ble_gq GATT Queue
  * @{
- * @brief  Queue for the BLE GATT requests.
+ * @brief  Queue for the Bluetooth LE GATT requests.
  *
- * @details The BLE GATT Queue (BGQ) module can be used to queue BLE GATT requests if the
+ * @details The Bluetooth LE GATT Queue module can be used to queue GATT requests if the
  *          SoftDevice is not able to handle them at the moment. In this case, processing of
- *          the queued request is postponed. Later on, when the corresponding BLE event indicates
+ *          the queued request is postponed. Later on, when the corresponding event indicates
  *          that the SoftDevice may be free, the request is retried.
  */
 
@@ -33,7 +33,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Macro for defining a BLE GATT queue instance with default parameters from Kconfig.
+ * @brief Macro for defining a Bluetooth LE GATT queue instance with default parameters from
+ *        Kconfig.
  *
  * @param _name Name of the instance.
  */
@@ -42,7 +43,7 @@ extern "C" {
 			  (CONFIG_BLE_GQ_MAX_CONNECTIONS * CONFIG_BLE_GQ_QUEUE_SIZE))
 
 /**
- * @brief Macro for defining a BLE GATT queue instance.
+ * @brief Macro for defining a Bluetooth LE GATT queue instance.
  *
  * @param _name            Name of the instance.
  * @param _max_conns       Maximum number of connection handles that can be registered.
@@ -92,7 +93,7 @@ extern "C" {
 #define BLE_GQ_REQ_QUEUE_INIT(i, _name) SYS_SLIST_STATIC_INIT(&((_name)[i]))
 
 /**
- * @brief BLE GATT request types.
+ * @brief Bluetooth LE GATT request types.
  */
 enum ble_gq_req_type {
 	/**
@@ -163,7 +164,7 @@ struct ble_gq_req;
 typedef void (*ble_gq_evt_handler_t)(const struct ble_gq_req *req, struct ble_gq_evt *evt);
 
 /**
- * @brief Structure to hold a BLE GATT request.
+ * @brief Structure to hold a Bluetooth LE GATT request.
  */
 struct ble_gq_req {
 	/**
@@ -232,7 +233,7 @@ struct ble_gq_req {
 };
 
 /**
- * @brief BLE GATT Queue.
+ * @brief Bluetooth LE GATT Queue.
  */
 struct ble_gq {
 	/**
@@ -299,13 +300,13 @@ uint32_t ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req
 uint32_t ble_gq_conn_handle_register(const struct ble_gq *gatt_queue, uint16_t conn_handle);
 
 /**
- * @brief Handle BLE events from the SoftDevice.
+ * @brief Handle Bluetooth LE events from the SoftDevice.
  *
- * @details This function handles the BLE events received from the SoftDevice. If a BLE
+ * @details This function handles the Bluetooth LE events received from the SoftDevice. If an
  *          event is relevant to the BGQ module, it is used to update internal variables,
  *          process queued GATT requests and, if necessary, send errors to the application.
  *
- * @param[in] ble_evt     Pointer to the BLE event.
+ * @param[in] ble_evt     Pointer to the event.
  * @param[in] gatt_queue  Pointer to the @ref ble_gq instance.
  */
 void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *gatt_queue);

--- a/include/bm/bluetooth/ble_qwr.h
+++ b/include/bm/bluetooth/ble_qwr.h
@@ -14,7 +14,7 @@
  * @details This module handles prepare write, execute write, and cancel write
  * commands. It also manages memory requests related to these operations.
  *
- * @note The application must propagate BLE stack events to this module by calling
+ * @note The application must propagate Bluetooth LE stack events to this module by calling
  *       @ref ble_qwr_on_ble_evt().
  */
 
@@ -180,11 +180,12 @@ uint32_t ble_qwr_init(struct ble_qwr *qwr, const struct ble_qwr_config *qwr_conf
 uint32_t ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle);
 
 /**
- * @brief Function for handling BLE stack events.
+ * @brief Function for handling Bluetooth LE stack events.
  *
- * @details Handles all events from the BLE stack that are of interest to the Queued Writes module.
+ * @details Handles all events from the Bluetooth LE stack that are of interest to the
+ *          Queued Writes module.
  *
- * @param[in] ble_evt Event received from the BLE stack.
+ * @param[in] ble_evt Event received.
  * @param[in] context Queued Writes structure.
  */
 void ble_qwr_on_ble_evt(const ble_evt_t *ble_evt, void *context);

--- a/include/bm/bluetooth/ble_scan.h
+++ b/include/bm/bluetooth/ble_scan.h
@@ -9,7 +9,7 @@
  *
  * @defgroup ble_scan Scan Library
  * @{
- * @brief Library for handling the BLE scanning.
+ * @brief Library for handling the Bluetooth LE scanning.
  *
  * @details The Scan Library offers several criteria for filtering the devices available for
  *          connection. It can also be used without filtering.
@@ -215,7 +215,7 @@ struct ble_scan_evt {
 };
 
 /**
- * @brief BLE Scan event handler type.
+ * @brief Bluetooth LE Scan event handler type.
  */
 typedef void (*ble_scan_evt_handler_t)(const struct ble_scan_evt *scan_evt);
 
@@ -359,7 +359,7 @@ struct ble_scan_filters {
  * @brief Scan instance configuration.
  */
 struct ble_scan_config {
-	/** BLE GAP scan parameters required to initialize the module.
+	/** Bluetooth LE GAP scan parameters required to initialize the module.
 	 *  Can be set to @c BLE_SCAN_SCAN_PARAMS_DEFAULT for default configuration.
 	 */
 	ble_gap_scan_params_t scan_params;
@@ -565,9 +565,9 @@ uint32_t ble_scan_all_filter_remove(struct ble_scan *scan);
 uint32_t ble_scan_params_set(struct ble_scan *scan, const ble_gap_scan_params_t *scan_params);
 
 /**
- * @brief Handler for BLE stack events.
+ * @brief Handler for Bluetooth LE stack events.
  *
- * @param[in] ble_evt BLE event.
+ * @param[in] ble_evt Bluetooth LE event.
  * @param[in,out] scan Scan library instance.
  */
 void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *scan);

--- a/include/bm/bluetooth/peer_manager/nrf_ble_lesc.h
+++ b/include/bm/bluetooth/peer_manager/nrf_ble_lesc.h
@@ -112,11 +112,11 @@ void nrf_ble_lesc_peer_oob_data_handler_set(nrf_ble_lesc_peer_oob_data_handler h
 uint32_t nrf_ble_lesc_request_handler(void);
 
 /**
- * @brief Handle BLE stack events.
+ * @brief Handle Bluetooth LE stack events.
  *
- * @details This function handles events from the BLE stack that are of interest to the module.
+ * @details This function handles events from the Bluetooth LE stack that are of interest.
  *
- * @param[in] ble_evt  Event received from the BLE stack.
+ * @param[in] ble_evt  Event received from the Bluetooth LE stack.
  */
 void nrf_ble_lesc_on_ble_evt(const ble_evt_t *ble_evt);
 

--- a/include/bm/bluetooth/peer_manager/peer_manager.h
+++ b/include/bm/bluetooth/peer_manager/peer_manager.h
@@ -9,9 +9,9 @@
  *
  * @defgroup peer_manager Peer Manager
  * @{
- * @brief Module for managing BLE bonding, which includes controlling encryption and pairing
- *        procedures as well as persistently storing different pieces of data that must be stored
- *        when bonded.
+ * @brief Module for managing Bluetooth LE bonding, which includes controlling encryption and
+ *        pairing procedures as well as persistently storing different pieces of data that must be
+ *        stored when bonded.
  *
  * @details The API consists of functions for configuring the pairing and encryption behavior of the
  *          device and functions for manipulating the stored data.
@@ -141,12 +141,12 @@ uint32_t pm_sec_params_set(ble_gap_sec_params_t *sec_params);
 uint32_t pm_conn_secure(uint16_t conn_handle, bool force_repairing);
 
 /**
- * @brief Exclude a connection from the BLE event flow that is handled inside the Peer Manager.
+ * @brief Exclude a connection from the Bluetooth LE event flow handled inside the Peer Manager.
  *
  * @details This function is optional, and must be called in reply to a @ref PM_EVT_CONN_CONFIG_REQ
  *          event, before the Peer Manager event handler returns. If it is not called in time,
- *          BLE events for a connection handle passed in the @ref PM_EVT_CONN_CONFIG_REQ event will
- *          be normally handled by the Peer Manager.
+ *          Bluetooth LE events for a connection handle passed in the
+ *          @ref PM_EVT_CONN_CONFIG_REQ event will be normally handled by the Peer Manager.
  *
  * @param[in] conn_handle  The connection to be excluded.
  * @param[in] context      The context found in the request event that this function replies to.
@@ -357,7 +357,7 @@ uint32_t pm_device_identities_list_set(const uint16_t *peers, uint32_t peer_cnt)
  * @retval NRF_SUCCESS                     If the identity address was set successfully.
  * @retval NRF_ERROR_NULL                  If @p addr is NULL.
  * @retval NRF_ERROR_INVALID_ADDR          If the @p addr pointer is invalid.
- * @retval BLE_ERROR_GAP_INVALID_BLE_ADDR  If the BLE address is invalid.
+ * @retval BLE_ERROR_GAP_INVALID_BLE_ADDR  If the Bluetooth LE address is invalid.
  * @retval NRF_ERROR_BUSY                  If the SoftDevice was busy. Process SoftDevice events
  *                                         and retry.
  * @retval NRF_ERROR_INVALID_STATE         If the Peer Manager is not initialized or if this
@@ -397,7 +397,7 @@ uint32_t pm_id_addr_get(ble_gap_addr_t *addr);
  * @retval NRF_ERROR_BUSY           If the operation could not be performed at this time.
  *                                  Process SoftDevice events and retry.
  * @retval NRF_ERROR_INVALID_PARAM  If the address type is invalid.
- * @retval NRF_ERROR_INVALID_STATE  If this function is called while BLE roles using
+ * @retval NRF_ERROR_INVALID_STATE  If this function is called while Bluetooth LE roles using
  *                                  privacy are enabled.
  * @retval NRF_ERROR_INVALID_STATE  If the Peer Manager is not initialized.
  */

--- a/include/bm/bluetooth/peer_manager/peer_manager_handler.h
+++ b/include/bm/bluetooth/peer_manager/peer_manager_handler.h
@@ -10,7 +10,7 @@
  * @defgroup pm_handler Peer Manager Standard Event Handlers
  * @ingroup peer_manager
  * @{
- * @brief Standard event handlers implementing some best practices for BLE security.
+ * @brief Standard event handlers implementing some best practices for Bluetooth LE security.
  */
 
 #ifndef PEER_MANAGER_HANDLER_H__
@@ -107,9 +107,9 @@ void pm_handler_disconnect_on_insufficient_sec(const struct pm_evt *pm_evt,
  * This function starts security when receiving a @ref BLE_GAP_EVT_CONNECTED event. This is
  * affected by @ref PM_HANDLER_SEC_DELAY_MS.
  *
- * @note In normal circumstances, this function should be called for every BLE event.
+ * @note In normal circumstances, this function should be called for every Bluetooth LE event.
  *
- * @param[in] ble_evt  BLE event to handle.
+ * @param[in] ble_evt Event to handle.
  */
 void pm_handler_secure_on_connection(const ble_evt_t *ble_evt);
 
@@ -126,9 +126,9 @@ void pm_handler_secure_on_connection(const ble_evt_t *ble_evt);
  *       the server does not send any response, even on error. Instead, the write will be
  *       silently dropped by the server.
  *
- * @note In normal circumstances, this function should be called for every BLE event.
+ * @note In normal circumstances, this function should be called for every Bluetooth LE event.
  *
- * @param[in] ble_evt  BLE event to handle.
+ * @param[in] ble_evt Event to handle.
  */
 void pm_handler_secure_on_error(const ble_evt_t *ble_evt);
 

--- a/include/bm/bluetooth/peer_manager/peer_manager_types.h
+++ b/include/bm/bluetooth/peer_manager/peer_manager_types.h
@@ -167,7 +167,9 @@ struct pm_conn_sec_config {
 
 /** @brief Data associated with a bond to a peer. */
 struct pm_peer_data_bonding {
-	/** @brief The BLE role of the local device during bonding. See @ref BLE_GAP_ROLES. */
+	/** @brief The Bluetooth LE role of the local device during bonding.
+	 *  See @ref BLE_GAP_ROLES.
+	 */
 	uint8_t own_role;
 	/** @brief The peer's Bluetooth address and identity resolution key (IRK). */
 	ble_gap_id_key_t peer_ble_id;
@@ -222,8 +224,8 @@ enum pm_evt_id {
 	/**
 	 * @brief A new connection has been established. This event is a wrapper for
 	 *        @ref BLE_GAP_EVT_CONNECTED event and contains its parameters. Reply with
-	 *        @ref pm_conn_exclude before the event handler returns to exclude BLE events
-	 *        targeting this connection from being handled by the Peer Manager
+	 *        @ref pm_conn_exclude before the event handler returns to exclude Bluetooth LE
+	 *        events targeting this connection from being handled by the Peer Manager.
 	 */
 	PM_EVT_CONN_CONFIG_REQ,
 	/**

--- a/include/bm/bluetooth/services/ble_bms.h
+++ b/include/bm/bluetooth/services/ble_bms.h
@@ -238,7 +238,7 @@ struct ble_bms;
 
 /** @brief BMS event handler type.
  *
- * The event handler returns a @ref BLE_GATT_STATUS_CODES "BLE GATT status code".
+ * The event handler returns a @ref BLE_GATT_STATUS_CODES "Bluetooth LE GATT status code".
  */
 typedef void (*ble_bms_evt_handler_t)(struct ble_bms *bms, struct ble_bms_evt *evt);
 
@@ -268,9 +268,9 @@ struct ble_bms_config {
 
 /**@brief Status information for the service. */
 struct ble_bms {
-	/** Handle of the Bond Management Service (as provided by the BLE stack). */
+	/** Handle of the Bond Management Service (as provided by the Bluetooth LE stack). */
 	uint16_t service_handle;
-	/** Handle of the current connection (as provided by the BLE stack).
+	/** Handle of the current connection (as provided by the Bluetooth LE stack).
 	 * @ref BLE_CONN_HANDLE_INVALID if not in a connection.
 	 */
 	uint16_t conn_handle;
@@ -314,12 +314,12 @@ uint32_t ble_bms_auth_response(struct ble_bms *bms, bool authorize);
 uint32_t ble_bms_init(struct ble_bms *bms, struct ble_bms_config *bms_config);
 
 /**
- * @brief   Handle Bond Management BLE stack events.
+ * @brief   Handle Bond Management Bluetooth LE stack events.
  *
- * @details This function handles all events from the BLE stack that are of interest to the
+ * @details This function handles all events from the Bluetooth LE stack that are of interest to the
  *          Bond Management Service.
  *
- * @param[in] ble_evt Event received from the BLE stack.
+ * @param[in] ble_evt Event received.
  * @param[in] context BMS structure.
  */
 void ble_bms_on_ble_evt(const ble_evt_t *ble_evt, void *context);

--- a/include/bm/bluetooth/services/ble_cgms.h
+++ b/include/bm/bluetooth/services/ble_cgms.h
@@ -400,7 +400,7 @@ struct ble_cgms_status {
 struct ble_cgms_config {
 	/** Event handler to be called for handling events in the CGM Service. */
 	ble_cgms_evt_handler_t evt_handler;
-	/** Pointer to BLE GATT Queue instance. */
+	/** Pointer to Bluetooth LE GATT Queue instance. */
 	const struct ble_gq *gatt_queue;
 	/** Features supported by the service. */
 	struct ble_cgms_feature feature;
@@ -535,15 +535,15 @@ struct ble_cgms_char_handles {
 struct ble_cgms {
 	/** Event handler to be called for handling events in the CGM Service. */
 	ble_cgms_evt_handler_t evt_handler;
-	/** Pointer to BLE GATT Queue instance. */
+	/** Pointer to Bluetooth LE GATT Queue instance. */
 	const struct ble_gq  *gatt_queue;
 	/** Error handler to be called in case of an error from SoftDevice. */
 	ble_gq_evt_handler_t ble_gq_evt_handler;
-	/** Handle of the CGM Service (as provided by the BLE stack). */
+	/** Handle of the CGM Service (as provided by the Bluetooth LE stack). */
 	uint16_t service_handle;
 	/** GATTS characteristic handles for the different characteristics in the service. */
 	struct ble_cgms_char_handles char_handles;
-	/** Handle of the current connection (as provided by the BLE stack;
+	/** Handle of the current connection (as provided by the Bluetooth LE stack;
 	 *  @ref BLE_CONN_HANDLE_INVALID if not in a connection).
 	 */
 	uint16_t conn_handle;
@@ -590,11 +590,11 @@ struct ble_cgms {
 uint32_t ble_cgms_init(struct ble_cgms *cgms, const struct ble_cgms_config *cgms_init);
 
 /**
- * @brief Function for handling the application's BLE stack events.
+ * @brief Function for handling the application's Bluetooth LE stack events.
  *
- * @details Handles all events from the BLE stack that are of interest to the CGM Service.
+ * @details Handles all events from the Bluetooth LE stack that are of interest to the CGM Service.
  *
- * @param[in] ble_evt Event received from the BLE stack.
+ * @param[in] ble_evt Event received.
  * @param[in] context Instance of the CGM Service.
  */
 void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *context);

--- a/include/bm/bluetooth/services/ble_dis.h
+++ b/include/bm/bluetooth/services/ble_dis.h
@@ -10,8 +10,9 @@
  * @brief Device Information Service module.
  *
  * @details This module implements the Device Information Service.
- *          During initialization it adds the Device Information Service to the BLE stack database.
- *          It then encodes the supplied information, and adds the corresponding characteristics.
+ *          During initialization it adds the Device Information Service to the Bluetooth LE stack
+ *          database. It then encodes the supplied information, and adds the corresponding
+ *          characteristics.
  */
 
 #ifndef BLE_DIS_H__

--- a/include/bm/bluetooth/services/ble_hids.h
+++ b/include/bm/bluetooth/services/ble_hids.h
@@ -30,7 +30,7 @@ extern "C" {
  *
  * Define a HID service instance and register it as a Bluetooth event observer.
  *
- * @param _name Name of BLE HIDS instance.
+ * @param _name Name of Bluetooth LE HIDS instance.
  */
 #define BLE_HIDS_DEF(_name)                                                                        \
 	static struct ble_hids _name = {                                                           \
@@ -139,7 +139,7 @@ struct ble_hids_input_report {
 };
 
 /**
- * @brief BLE HID service boot keyboard input report.
+ * @brief Bluetooth LE HID service boot keyboard input report.
  */
 struct ble_hids_boot_keyboard_input_report {
 	/**
@@ -153,7 +153,7 @@ struct ble_hids_boot_keyboard_input_report {
 };
 
 /**
- * @brief BLE HID service boot mouse input report.
+ * @brief Bluetooth LE HID service boot mouse input report.
  */
 struct ble_hids_boot_mouse_input_report {
 	/**
@@ -292,7 +292,7 @@ struct ble_hids_evt {
 	 */
 	uint16_t conn_handle;
 	/**
-	 * @brief BLE event.
+	 * @brief Bluetooth LE event.
 	 */
 	const ble_evt_t *ble_evt;
 	/**
@@ -617,7 +617,7 @@ struct ble_hids {
 	 */
 	ble_hids_evt_handler_t evt_handler;
 	/**
-	 * @brief Handle of HID Service (as provided by the BLE stack).
+	 * @brief Handle of HID Service (as provided by the Bluetooth LE stack).
 	 */
 	uint16_t service_handle;
 	/**
@@ -700,14 +700,14 @@ struct ble_hids {
 };
 
 /**
- * @brief Function for handling the Application's BLE Stack events.
+ * @brief Function for handling the Application's Bluetooth LE Stack events.
  *
- * @details Handles all events from the BLE stack of interest to the HID Service.
+ * @details Handles all events from the Bluetooth LE stack of interest to the HID Service.
  *
  * @note This function is registered with a NRF_SDH_BLE_OBSERVER and is called automatically
  *       by the SoftDevice Handler.
  *
- * @param[in] ble_evt Event received from the BLE stack.
+ * @param[in] ble_evt Event received.
  * @param[in] context HID Service structure.
  */
 void ble_hids_on_ble_evt(const ble_evt_t *ble_evt, void *context);

--- a/include/bm/bluetooth/services/ble_hrs.h
+++ b/include/bm/bluetooth/services/ble_hrs.h
@@ -159,7 +159,7 @@ struct ble_hrs {
 	/**
 	 * @brief Handle of the current connection.
 	 *
-	 * Provided by the BLE stack. Is BLE_CONN_HANDLE_INVALID if not in a connection.
+	 * Provided by the Bluetooth LE stack. Is BLE_CONN_HANDLE_INVALID if not in a connection.
 	 */
 	uint16_t conn_handle;
 	/**

--- a/include/bm/bluetooth/services/ble_lbs.h
+++ b/include/bm/bluetooth/services/ble_lbs.h
@@ -113,10 +113,10 @@ struct ble_lbs_config {
 };
 
 /**
- * @brief BLE Button Service structure.
+ * @brief Bluetooth LE Button Service structure.
  */
 struct ble_lbs {
-	/** @brief Handle of LED Button Service (as provided by the BLE stack). */
+	/** @brief Handle of LED Button Service (as provided by the Bluetooth LE stack). */
 	uint16_t service_handle;
 	/** @brief Handles related to the LED Characteristic. */
 	ble_gatts_char_handles_t led_char_handles;
@@ -147,12 +147,12 @@ struct ble_lbs {
 uint32_t ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg);
 
 /**
- * @brief Function for handling the application's BLE stack events.
+ * @brief Function for handling the application's Bluetooth LE stack events.
  *
- * @details This function handles all events from the BLE stack that are of interest to the LED
- *          Button Service.
+ * @details This function handles all events from the Bluetooth LE stack that are of interest to the
+ *          LED Button Service.
  *
- * @param[in] ble_evt      Event received from the BLE stack.
+ * @param[in] ble_evt      Event received.
  * @param[in] lbs_instance LED Button Service structure.
  */
 void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs_instance);

--- a/include/bm/bluetooth/services/ble_mcumgr.h
+++ b/include/bm/bluetooth/services/ble_mcumgr.h
@@ -6,9 +6,9 @@
 
 /** @file
  *
- * @defgroup ble_mcumgr BLE MCUmgr Service library
+ * @defgroup ble_mcumgr Bluetooth LE MCUmgr Service library
  * @{
- * @brief Library for handling MCUmgr over BLE.
+ * @brief Library for handling MCUmgr over Bluetooth LE.
  */
 
 #ifndef BLE_MCUMGR_H__

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -6,9 +6,9 @@
 
 /** @file
  *
- * @defgroup ble_nus BLE Nordic UART Service library
+ * @defgroup ble_nus Bluetooth LE Nordic UART Service library
  * @{
- * @brief Library for handling UART over BLE.
+ * @brief Library for handling UART over Bluetooth LE.
  */
 
 #ifndef BLE_NUS_H__
@@ -208,7 +208,7 @@ struct ble_nus {
 uint32_t ble_nus_init(struct ble_nus *nus, const struct ble_nus_config *nus_config);
 
 /**
- * @brief Function for handling the Nordic UART Service's BLE events.
+ * @brief Function for handling the Nordic UART Service's Bluetooth LE events.
  *
  * @details The Nordic UART Service expects the application to call this function each time an
  *          event is received from the SoftDevice. This function processes the event if it

--- a/include/bm/nfc/ndef/le_oob_rec.h
+++ b/include/bm/nfc/ndef/le_oob_rec.h
@@ -51,19 +51,19 @@ enum nfc_ndef_le_oob_rec_le_role {
 };
 
 /**
- * @brief Macro for including Appearance BLE AD Type to the
+ * @brief Macro for including Appearance Bluetooth LE AD Type to the
  *        @ref nfc_ndef_le_oob_rec_payload_desc descriptor.
  */
 #define NFC_NDEF_LE_OOB_REC_APPEARANCE(value) ((uint16_t []) {value})
 
 /**
- * @brief Macro for including Flags BLE AD Type to the
+ * @brief Macro for including Flags Bluetooth LE AD Type to the
  *        @ref nfc_ndef_le_oob_rec_payload_desc descriptor.
  */
 #define NFC_NDEF_LE_OOB_REC_FLAGS(value) ((uint8_t []) {value})
 
 /**
- * @brief Macro for including LE Role BLE AD Type to the
+ * @brief Macro for including LE Role Bluetooth LE AD Type to the
  *        @ref nfc_ndef_le_oob_rec_payload_desc descriptor.
  */
 #define NFC_NDEF_LE_OOB_REC_LE_ROLE(value) \

--- a/include/bm/softdevice_handler/nrf_sdh.h
+++ b/include/bm/softdevice_handler/nrf_sdh.h
@@ -178,8 +178,8 @@ struct nrf_sdh_stack_evt_observer {
  * @brief Register a SoftDevice stack event observer.
  *
  * A SoftDevice stack event observer receives all events from the SoftDevice. These events can be
- * either BLE or SoC events. If you need to receive BLE or SoC events separately, use
- * @ref NRF_SDH_BLE_OBSERVER or @ref NRF_SDH_SOC_OBSERVER respectively.
+ * either Bluetooth LE or SoC events. If you need to receive Bluetooth LE or SoC events separately,
+ * use @ref NRF_SDH_BLE_OBSERVER or @ref NRF_SDH_SOC_OBSERVER respectively.
  *
  * @param _observer Name of the observer.
  * @param _handler Stack event handler.

--- a/include/bm/softdevice_handler/nrf_sdh_ble.h
+++ b/include/bm/softdevice_handler/nrf_sdh_ble.h
@@ -6,10 +6,10 @@
 
 /** @file
  *
- * @defgroup nrf_sdh_ble BLE support in SoftDevice Handler
+ * @defgroup nrf_sdh_ble Bluetooth LE support in SoftDevice Handler
  * @{
  * @ingroup  nrf_sdh
- * @brief    Declarations of types and functions required for BLE stack support.
+ * @brief    Declarations of types and functions required for Bluetooth LE stack support.
  */
 
 #ifndef NRF_SDH_BLE_H__
@@ -25,21 +25,21 @@ extern "C" {
 #endif
 
 /**
- * @brief Size of the buffer for a BLE event.
+ * @brief Size of the buffer for a Bluetooth LE event.
  */
 #define NRF_SDH_BLE_EVT_BUF_SIZE BLE_EVT_LEN_MAX(CONFIG_NRF_SDH_BLE_GATT_MAX_MTU_SIZE)
 
 /**
- * @brief BLE stack event handler.
+ * @brief Bluetooth LE stack event handler.
  */
 typedef void (*nrf_sdh_ble_evt_handler_t)(const ble_evt_t *ble_evt, void *context);
 
 /**
- * @brief BLE event observer.
+ * @brief Bluetooth LE event observer.
  */
 struct nrf_sdh_ble_evt_observer {
 	/**
-	 * @brief BLE event handler.
+	 * @brief Bluetooth LE event handler.
 	 */
 	nrf_sdh_ble_evt_handler_t handler;
 	/**
@@ -49,7 +49,7 @@ struct nrf_sdh_ble_evt_observer {
 };
 
 /**
- * @brief Register a SoftDevice BLE event observer.
+ * @brief Register a SoftDevice Bluetooth LE event observer.
  *
  * @param _observer Name of the observer.
  * @param _handler State request handler.
@@ -75,7 +75,7 @@ struct nrf_sdh_ble_evt_observer {
 int nrf_sdh_ble_enable(uint8_t conn_cfg_tag);
 
 /**
- * @brief Stringify a SoftDevice BLE event.
+ * @brief Stringify a SoftDevice Bluetooth LE event.
  *
  * If :option:`CONFIG_NRF_SDH_STR_TABLES` is enabled, returns the event name.
  * Otherwise, returns the supplied integer as a string.

--- a/lib/bluetooth/ble_conn_params/Kconfig
+++ b/lib/bluetooth/ble_conn_params/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 menuconfig BLE_CONN_PARAMS
-	bool "BLE Connection Parameters"
+	bool "Bluetooth LE Connection Parameters"
 	depends on SOFTDEVICE
 	depends on NRF_SDH
 	depends on NRF_SDH_BLE

--- a/lib/bluetooth/ble_db_discovery/Kconfig
+++ b/lib/bluetooth/ble_db_discovery/Kconfig
@@ -5,7 +5,7 @@
 #
 
 menuconfig BLE_DB_DISCOVERY
-	bool "BLE database discovery"
+	bool "Bluetooth LE database discovery"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_GATT_QUEUE

--- a/lib/bluetooth/ble_gq/Kconfig
+++ b/lib/bluetooth/ble_gq/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 menuconfig BLE_GATT_QUEUE
-	bool "BLE GATT Queue"
+	bool "Bluetooth LE GATT Queue"
 	depends on SOFTDEVICE
 	depends on NRF_SDH_BLE
 

--- a/lib/bluetooth/ble_racp/Kconfig
+++ b/lib/bluetooth/ble_racp/Kconfig
@@ -5,7 +5,7 @@
 #
 
 menuconfig BLE_RACP
-	bool "BLE Record Access Control Point"
+	bool "Bluetooth LE Record Access Control Point"
 
 if BLE_RACP
 

--- a/lib/bluetooth/ble_radio_notification/Kconfig
+++ b/lib/bluetooth/ble_radio_notification/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 menuconfig BLE_RADIO_NOTIFICATION
-	bool "BLE Radio Notification"
+	bool "Bluetooth LE Radio Notification"
 	depends on SOFTDEVICE
 
 if BLE_RADIO_NOTIFICATION
@@ -25,11 +25,11 @@ config BLE_RADIO_NOTIFICATION_ON_BOTH
 endchoice # BLE_RADIO_NOTIFICATION_TYPE
 
 config BLE_RADIO_NOTIFICATION_IRQ_PRIO
-	int "BLE Radio Notification IRQ priority"
+	int "Bluetooth LE Radio Notification IRQ priority"
 	range 5 7
 	default 5
 	help
-	  Sets the interrupt priority of the BLE radio notification event (SWI02).
+	  Sets the interrupt priority of the Bluetooth LE radio notification event (SWI02).
 	  Levels are from 5 (highest priority) to 7 (lowest priority).
 	  Interrupt priority level must be greater than 4 (SoftDevice low priority).
 

--- a/lib/bluetooth/peer_manager/Kconfig
+++ b/lib/bluetooth/peer_manager/Kconfig
@@ -56,8 +56,8 @@ config PM_LESC
 
 	help
 	  If enabled, you need to call nrf_ble_lesc_request_handler() in the main loop to
-	  respond to LESC-related BLE events. If LESC support is not required, disable this option
-	  to reduce memory usage.
+	  respond to LESC-related Bluetooth LE events. If LESC support is not required, disable this
+	  option to reduce memory usage.
 
 if PM_LESC
 

--- a/lib/bluetooth/peer_manager/include/modules/conn_state.h
+++ b/lib/bluetooth/peer_manager/include/modules/conn_state.h
@@ -9,10 +9,10 @@
  *
  * @defgroup pm_conn_state Peer Manager connection state
  * @{
- * @brief Module for storing data on BLE connections.
+ * @brief Module for storing data on Bluetooth LE connections.
  *
  * @details This module stores certain states for each connection, which can be queried by
- *          connection handle. The module uses BLE events to keep the states updated.
+ *          connection handle. The module uses Bluetooth LE events to keep the states updated.
  *
  *          In addition to the preprogrammed states, this module can also keep track of a number of
  *          binary user states, or user flags. These are reset to 0 for new connections, but
@@ -71,7 +71,7 @@ struct pm_conn_state_conn_handle_list {
 typedef void (*pm_conn_state_user_function_t)(uint16_t conn_handle, void *ctx);
 
 /**
- * @defgroup pm_conn_state_functions BLE connection state functions
+ * @defgroup pm_conn_state_functions Bluetooth LE connection state functions
  * @{
  */
 

--- a/lib/bluetooth/peer_manager/include/modules/id_manager.h
+++ b/lib/bluetooth/peer_manager/include/modules/id_manager.h
@@ -73,11 +73,11 @@ bool im_master_ids_compare(const ble_gap_master_id_t *master_id1,
 			   const ble_gap_master_id_t *master_id2);
 
 /**
- * @brief Function for getting the BLE address used by the peer when connecting.
+ * @brief Function for getting the Bluetooth LE address used by the peer when connecting.
  *
  * @param[in]  conn_handle  The connection handle.
- * @param[out] ble_addr     The BLE address used by the peer when the connection specified by
- *                          conn_handle was established. Cannot be NULL.
+ * @param[out] ble_addr     The Bluetooth LE address used by the peer when the connection specified
+ *                          by the conn_handle was established. Cannot be NULL.
  *
  * @retval NRF_SUCCESS                   The address was found and copied.
  * @retval BLE_ERROR_INVALID_CONN_HANDLE conn_handle does not refer to an active connection.
@@ -188,8 +188,8 @@ uint32_t im_id_addr_get(ble_gap_addr_t *addr);
  * @retval NRF_ERROR_INVALID_PARAM  If the address type is not valid.
  * @retval NRF_ERROR_BUSY           If the request could not be processed at this time.
  *                                  Process SoftDevice events and retry.
- * @retval NRF_ERROR_INVALID_STATE  Privacy settings cannot be changed while BLE roles using
- *                                  privacy are enabled.
+ * @retval NRF_ERROR_INVALID_STATE  Privacy settings cannot be changed while Bluetooth LE roles
+ *                                  using privacy are enabled.
  */
 uint32_t im_privacy_set(const ble_gap_privacy_params_t *privacy_params);
 

--- a/lib/bluetooth/peer_manager/modules/auth_status_tracker.c
+++ b/lib/bluetooth/peer_manager/modules/auth_status_tracker.c
@@ -26,7 +26,7 @@ LOG_MODULE_DECLARE(peer_manager, CONFIG_PEER_MANAGER_LOG_LEVEL);
 
 /** @brief Tracked peer state. */
 struct deny_listed_peer {
-	/** @brief BLE address, used to identify peer. */
+	/** @brief Bluetooth LE address, used to identify peer. */
 	ble_gap_addr_t peer_addr;
 	/**
 	 * @brief Accumulated reward ticks, used to decrease penality level after achieving certain

--- a/lib/bluetooth/peer_manager/modules/gatt_cache_manager.c
+++ b/lib/bluetooth/peer_manager/modules/gatt_cache_manager.c
@@ -612,9 +612,9 @@ void store_car_value(uint16_t conn_handle, bool car_value)
 }
 
 /**
- * @brief Callback function for BLE events from the SoftDevice.
+ * @brief Callback function for Bluetooth LE events from the SoftDevice.
  *
- * @param[in]  ble_evt  The BLE event from the SoftDevice.
+ * @param[in]  ble_evt  The Bluetooth LE event from the SoftDevice.
  */
 void gcm_ble_evt_handler(const ble_evt_t *ble_evt)
 {

--- a/lib/bluetooth/peer_manager/modules/id_manager.c
+++ b/lib/bluetooth/peer_manager/modules/id_manager.c
@@ -617,7 +617,7 @@ uint32_t im_allow_list_set(const uint16_t *peers, uint32_t peer_cnt)
  * @brief Function for calculating the ah() hash function described in Bluetooth core specification
  *        4.2 section 3.H.2.2.2.
  *
- * @detail  BLE uses a hash function to calculate the first half of a resolvable address
+ * @detail  Bluetooth LE uses a hash function to calculate the first half of a resolvable address
  *          from the second half of the address and an irk. This function will use the ECB
  *          periferal to hash these data according to the Bluetooth core specification.
  *

--- a/lib/bluetooth/peer_manager/modules/security_dispatcher.c
+++ b/lib/bluetooth/peer_manager/modules/security_dispatcher.c
@@ -717,7 +717,7 @@ static void conn_sec_update_process(const ble_gap_evt_t *gap_evt)
 }
 
 /**
- * @brief Function for initializing a BLE Connection State user flag.
+ * @brief Function for initializing a Bluetooth LE Connection State user flag.
  *
  * @param[out] flag_id  The flag to initialize.
  */

--- a/lib/bluetooth/peer_manager/modules/security_manager.c
+++ b/lib/bluetooth/peer_manager/modules/security_manager.c
@@ -490,7 +490,7 @@ void sm_pdb_evt_handler(struct pm_evt *event)
 }
 
 /**
- * @brief Function for initializing a BLE Connection State user flag.
+ * @brief Function for initializing a Bluetooth LE Connection State user flag.
  *
  * @param[out] flag_id  The flag to initialize.
  */

--- a/lib/bluetooth/peer_manager/peer_manager.c
+++ b/lib/bluetooth/peer_manager/peer_manager.c
@@ -288,9 +288,9 @@ static bool is_conn_handle_excluded(const ble_evt_t *ble_evt)
 }
 
 /**
- * @brief Function for handling BLE events.
+ * @brief Function for handling Bluetooth LE events.
  *
- * @param[in]   ble_evt       Event received from the BLE stack.
+ * @param[in]   ble_evt       Event received from the Bluetooth LE stack.
  * @param[in]   context       Context.
  */
 static void ble_evt_handler(const ble_evt_t *ble_evt, void *context)

--- a/lib/bm_scheduler/Kconfig
+++ b/lib/bm_scheduler/Kconfig
@@ -14,7 +14,7 @@ if BM_SCHEDULER
 
 config BM_SCHEDULER_BUF_SIZE
 	int "Event buffer size"
-	# Maximum BLE event length is 500 (w/ 247 MTU)
+	# Maximum Bluetooth LE event length is 500 (w/ 247 MTU)
 	default 512
 	help
 	  Size of the buffer that events will be copied into.

--- a/samples/bluetooth/ble_bms/Kconfig
+++ b/samples/bluetooth/ble_bms/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE BMS sample"
+menu "Bluetooth LE BMS sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -30,6 +30,6 @@ module=SAMPLE_BLE_BMS
 module-str=BLE Bond Management Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE BMS sample"
+endmenu # "Bluetooth LE BMS sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_bms/prj.conf
+++ b/samples/bluetooth/ble_bms/prj.conf
@@ -22,7 +22,7 @@ CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=1
 # Advertising library
 CONFIG_BLE_ADV=y
 
-# BLE connection parameter
+# Bluetooth LE connection parameter
 CONFIG_BLE_CONN_PARAMS=y
 
 # Device information service

--- a/samples/bluetooth/ble_cgms/Kconfig
+++ b/samples/bluetooth/ble_cgms/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE CGMS sample"
+menu "Bluetooth LE CGMS sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -42,7 +42,7 @@ config SAMPLE_GLUCOSE_CONCENTRATION_MIN
 	int "Minimum glucose concentration (mg/dL)"
 	default 5
 
-endmenu # "BLE CGMS sample"
+endmenu # "Bluetooth LE CGMS sample"
 
 module=SAMPLE_BLE_CGMS
 module-str=BLE CGMS Sample

--- a/samples/bluetooth/ble_hids_keyboard/Kconfig
+++ b/samples/bluetooth/ble_hids_keyboard/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE HIDS Keyboard sample"
+menu "Bluetooth LE HIDS Keyboard sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -18,6 +18,6 @@ module=SAMPLE_BLE_HIDS_KEYBOARD
 module-str=BLE HIDS Keyboard Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE HIDS Keyboard sample"
+endmenu # "Bluetooth LE HIDS Keyboard sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_hids_mouse/Kconfig
+++ b/samples/bluetooth/ble_hids_mouse/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE HIDS Mouse sample"
+menu "Bluetooth LE HIDS Mouse sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -14,6 +14,6 @@ module=SAMPLE_BLE_HIDS_MOUSE
 module-str=BLE HIDS Mouse Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE HIDS Mouse sample"
+endmenu # "Bluetooth LE HIDS Mouse sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_hrs/Kconfig
+++ b/samples/bluetooth/ble_hrs/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE HRS sample"
+menu "Bluetooth LE HRS sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -114,6 +114,6 @@ module=SAMPLE_BLE_HRS
 module-str=BLE Heart Rate Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE HRS sample"
+endmenu # "Bluetooth LE HRS sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_hrs_central/Kconfig
+++ b/samples/bluetooth/ble_hrs_central/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE HRS central sample"
+menu "Bluetooth LE HRS central sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -38,6 +38,6 @@ module=SAMPLE_BLE_HRS_CENTRAL
 module-str=BLE Heart Rate Central Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE HRS central sample"
+endmenu # "Bluetooth LE HRS central sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_lbs/Kconfig
+++ b/samples/bluetooth/ble_lbs/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE LBS sample"
+menu "Bluetooth LE LBS sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -14,6 +14,6 @@ module=SAMPLE_BLE_LBS
 module-str=BLE LED Button Service Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE LBS sample"
+endmenu # "Bluetooth LE LBS sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_nus/Kconfig
+++ b/samples/bluetooth/ble_nus/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE NUS sample"
+menu "Bluetooth LE NUS sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -21,7 +21,7 @@ config SAMPLE_NUS_UART_IRQ_PRIO
 	  if you want to call into SoftDevice from the interrupt driver.
 
 config SAMPLE_NUS_UART_PARITY
-	bool "BLE UART use parity"
+	bool "Bluetooth LE UART use parity"
 
 config SAMPLE_NUS_LPUARTE
 	bool "NUS Low Power UARTE"
@@ -43,7 +43,7 @@ config SAMPLE_NUS_UART_RX_BUF_SIZE
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
 module=SAMPLE_BLE_NUS
-module-str=BLE NUS Sample
+module-str=Bluetooth LE NUS Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endmenu # "BLE NUS sample"

--- a/samples/bluetooth/ble_pwr_profiling/Kconfig
+++ b/samples/bluetooth/ble_pwr_profiling/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE Power Profiling sample"
+menu "Bluetooth LE Power Profiling sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -47,6 +47,6 @@ module=SAMPLE_BLE_PWR_PROFILING
 module-str=BLE Power Profiling Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE Power Profiling sample"
+endmenu # "Bluetooth LE Power Profiling sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/ble_radio_notification/Kconfig
+++ b/samples/bluetooth/ble_radio_notification/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE Radio Notification sample"
+menu "Bluetooth LE Radio Notification sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -19,6 +19,6 @@ module=SAMPLE_BLE_RADIO_NOTIFICATION
 module-str=BLE Radio Notification Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE Radio Notification sample"
+endmenu # "Bluetooth LE Radio Notification sample"
 
 source "Kconfig.zephyr"

--- a/samples/bluetooth/peripheral_nfc_pairing/Kconfig
+++ b/samples/bluetooth/peripheral_nfc_pairing/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE Peripheral NFC Pairing sample"
+menu "Bluetooth LE Peripheral NFC Pairing sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -14,6 +14,6 @@ module=SAMPLE_BLE_PERIPHERAL_NFC_PAIRING
 module-str=BLE Peripheral NFC Pairing sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
-endmenu # "BLE Peripheral NFC Pairing sample"
+endmenu # "Bluetooth LE Peripheral NFC Pairing sample"
 
 source "Kconfig.zephyr"

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -38,9 +38,9 @@ static struct mgmt_callback os_mgmt_reboot_callback = {
 };
 
 /**
- * @brief BLE event handler.
+ * @brief Bluetooth LE event handler.
  *
- * @param[in] evt BLE event.
+ * @param[in] evt Bluetooth LE event.
  * @param[in] ctx Context.
  */
 static void on_ble_evt(const ble_evt_t *evt, void *ctx)

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "SoftDevice BLE services"
+menu "SoftDevice Bluetooth LE services"
 
 rsource "services/Kconfig"
 

--- a/subsys/bluetooth/services/ble_hrs_client/Kconfig
+++ b/subsys/bluetooth/services/ble_hrs_client/Kconfig
@@ -5,7 +5,7 @@
 #
 
 menuconfig BLE_HRS_CLIENT
-	bool "BLE Heart rate service client [EXPERIMENTAL]"
+	bool "Bluetooth LE Heart rate service client [EXPERIMENTAL]"
 	depends on SOFTDEVICE_CENTRAL
 	depends on NRF_SDH_BLE
 	depends on BLE_DB_DISCOVERY

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -11,7 +11,7 @@ config NCS_BM_SETTINGS_BLUETOOTH_NAME
 	bool "Bluetooth name [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
-	  If enabled, settings handlers for support BLE advertising name
+	  If enabled, settings handlers for support Bluetooth LE advertising name
 	  sharing under `fw_loader/adv_name` key are included into the build.
 
 endmenu

--- a/subsys/softdevice_handler/Kconfig
+++ b/subsys/softdevice_handler/Kconfig
@@ -10,7 +10,7 @@ menuconfig NRF_SDH
 if NRF_SDH
 
 config NRF_SDH_BLE
-	bool "BLE events"
+	bool "Bluetooth LE events"
 	default y
 
 choice
@@ -160,14 +160,14 @@ endmenu
 
 if NRF_SDH_BLE
 
-menu "Default BLE configuration"
+menu "Default Bluetooth LE configuration"
 
 config NRF_SDH_BLE_CONN_TAG
 	int "Connection tag"
 	range 1 255
 	default 99
 	help
-	  Connection tag to use for BLE configuration.
+	  Connection tag to use for Bluetooth LE configuration.
 
 config NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
 	int "Maximum number of peripheral links"


### PR DESCRIPTION
BLE is incorrect to use as per Bluetooth trademarks.