### PR TITLE
Boards: Combine SoftDevice RAM into one node + update board layout images

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(192) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(192) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(192) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(192) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
@@ -94,14 +94,9 @@
 	reg = <0x20000080 (DT_SIZE_K(255) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(255) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.dts
@@ -91,14 +91,9 @@
 	reg = <0x20000080 (DT_SIZE_K(255) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(255) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.dts
@@ -94,14 +94,9 @@
 	reg = <0x20000080 (DT_SIZE_K(511) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(511) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.dts
@@ -94,14 +94,9 @@
 	reg = <0x20000080 (DT_SIZE_K(511) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(511) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
@@ -62,14 +62,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
@@ -62,14 +62,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.dts
@@ -90,14 +90,9 @@
 	reg = <0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(96) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.dts
@@ -94,14 +94,9 @@
 	reg = <0x20000080 (DT_SIZE_K(191) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(191) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1080>;
-	};
-
-	softdevice_dynamic_ram: sram@1080 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1080 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4380>;
 	};
 
 	app_ram: sram@4380 {

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.dts
@@ -59,14 +59,9 @@
 &cpuapp_sram {
 	status = "okay";
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.dts
@@ -94,14 +94,9 @@
 	reg = <0x20000080 (DT_SIZE_K(191) - 0x100 - 0x80)>;
 	ranges = <0x0 0x20000080 (DT_SIZE_K(191) - 0x100 - 0x80)>;
 
-	softdevice_static_ram: sram@0 {
-		label = "softdevice_static_ram";
-		reg = <0x0 0x1480>;
-	};
-
-	softdevice_dynamic_ram: sram@1480 {
-		label = "softdevice_dynamic_ram";
-		reg = <0x1480 (DT_SIZE_K(12) + 0x300)>;
+	softdevice_ram: sram@0 {
+		label = "softdevice_ram";
+		reg = <0x0 0x4780>;
 	};
 
 	app_ram: sram@4780 {

--- a/doc/_scripts/gen_memory_layouts.py
+++ b/doc/_scripts/gen_memory_layouts.py
@@ -288,7 +288,7 @@ COLORS = {
     "metadata": "#0032a0",  # Nordic Blueslate
     "(unused)": "#d9e1e2",  # Nordic Light Grey
     "KMU reserved": "#768692",  # Nordic Middle Grey
-    "softdevice_ram": "#00a2c6",  # Nordic Blue
+    "softdevice_ram": "#0077c8",  # Nordic Lake
     "app_ram": "#6ad1e3",  # Nordic Sky
     "RetainedMem": "#0032a0",  # Nordic Blueslate
 }
@@ -304,7 +304,7 @@ DISPLAY_NAMES = {
     "metadata": "Metadata",
     "(unused)": "Unused",
     "KMU reserved": "KMU reserved",
-    "softdevice_ram": "SoftDevice RAM (static and dynamic)",
+    "softdevice_ram": "SoftDevice RAM",
     "app_ram": "Application RAM",
     "RetainedMem": "Retained RAM",
 }

--- a/doc/_scripts/gen_memory_layouts.py
+++ b/doc/_scripts/gen_memory_layouts.py
@@ -288,8 +288,7 @@ COLORS = {
     "metadata": "#0032a0",  # Nordic Blueslate
     "(unused)": "#d9e1e2",  # Nordic Light Grey
     "KMU reserved": "#768692",  # Nordic Middle Grey
-    "softdevice_static_ram": "#0077c8",  # Nordic Lake
-    "softdevice_dynamic_ram": "#00a2c6",  # Nordic Blue
+    "softdevice_ram": "#00a2c6",  # Nordic Blue
     "app_ram": "#6ad1e3",  # Nordic Sky
     "RetainedMem": "#0032a0",  # Nordic Blueslate
 }
@@ -305,8 +304,7 @@ DISPLAY_NAMES = {
     "metadata": "Metadata",
     "(unused)": "Unused",
     "KMU reserved": "KMU reserved",
-    "softdevice_static_ram": "SoftDevice Static RAM",
-    "softdevice_dynamic_ram": "SoftDevice Dynamic RAM",
+    "softdevice_ram": "SoftDevice RAM (static and dynamic)",
     "app_ram": "Application RAM",
     "RetainedMem": "Retained RAM",
 }

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (500 KB)</text>
-<rect x="90" y="204.16" width="200" height="245.84" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="331.08" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="203.6" width="200" height="246.4" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="330.8" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="330.08" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">389 KB</text>
-<rect x="90" y="173.92" width="200" height="30.240000000000002" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="193.04" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="201.16" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00061400</text>
-<text x="295" y="192.04" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="143.67999999999998" width="200" height="30.240000000000002" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="162.79999999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="170.92" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00062400</text>
-<text x="295" y="161.79999999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.559999999999974" width="200" height="85.12" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="105.11999999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="140.67999999999998" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00063400</text>
-<text x="295" y="104.11999999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
+<text x="295" y="329.8" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">390 KB</text>
+<rect x="90" y="173.35999999999999" width="200" height="30.240000000000002" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="192.48" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="200.6" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00061800</text>
+<text x="295" y="191.48" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="143.11999999999998" width="200" height="30.240000000000002" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="162.23999999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="170.35999999999999" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00062800</text>
+<text x="295" y="161.23999999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.559999999999974" width="200" height="84.56" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="104.83999999999997" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="140.11999999999998" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00063800</text>
+<text x="295" y="103.83999999999997" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
 <rect x="90" y="29.999999999999975" width="200" height="28.56" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="190.0" y="48.27999999999997" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
 <text x="86" y="55.559999999999974" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CC00</text>
 <text x="295" y="47.27999999999997" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="26.999999999999975" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.5989583333333" width="200" height="28.401041666666668" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.79947916666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.5625" width="200" height="28.4375" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.78125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.79947916666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="380.3645833333333" width="200" height="41.234375" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="404.9817708333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.5989583333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="403.9817708333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="311.4583333333333" width="200" height="68.90625" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="349.9114583333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="377.3645833333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="348.9114583333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="281.4583333333333" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="174.72916666666666" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="308.4583333333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="173.72916666666666" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">79 KB</text>
+<text x="775" y="438.78125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="334.5" width="200" height="87.0625" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="382.03125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.5625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="381.03125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="304.5" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="186.25" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="331.5" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="185.25" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">79 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (500 KB)</text>
-<rect x="90" y="411.584" width="200" height="38.416" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="434.79200000000003" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="409.848" width="200" height="40.152" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="433.92400000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="433.79200000000003" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="382.24" width="200" height="29.344" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="400.91200000000003" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="408.584" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="399.91200000000003" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="352.896" width="200" height="29.344" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="371.56800000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="379.24" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="370.56800000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="324.56" width="200" height="28.336" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="342.728" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="349.896" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="341.728" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="199.12" width="200" height="125.44" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="265.84000000000003" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="321.56" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="264.84000000000003" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">290 KB</text>
-<rect x="90" y="149.61599999999999" width="200" height="49.504000000000005" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="178.368" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="196.12" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00052800</text>
-<text x="295" y="177.368" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="121.27999999999999" width="200" height="28.336" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="139.44799999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="146.61599999999999" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00062800</text>
-<text x="295" y="138.44799999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.167999999999985" width="200" height="63.112" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="93.72399999999999" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="118.27999999999999" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00062C00</text>
-<text x="295" y="92.72399999999999" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.168" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.08399999999999" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.167999999999985" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CE00</text>
-<text x="295" y="47.08399999999999" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
+<text x="295" y="432.92400000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="380.28000000000003" width="200" height="29.568" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="399.064" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="406.848" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="398.064" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="350.71200000000005" width="200" height="29.568" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="369.49600000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="377.28000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="368.49600000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="322.32000000000005" width="200" height="28.392" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.5160000000001" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="347.71200000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="339.5160000000001" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="179.85600000000005" width="200" height="142.464" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="255.08800000000005" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="319.32000000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="254.08800000000005" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">292 KB</text>
+<rect x="90" y="126.76800000000006" width="200" height="53.088" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="157.31200000000007" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="176.85600000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00053000</text>
+<text x="295" y="156.31200000000007" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.196000000000055" width="200" height="68.572" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="96.48200000000006" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="123.76800000000006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00063000</text>
+<text x="295" y="95.48200000000006" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="30.000000000000053" width="200" height="28.196" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.098000000000056" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.196000000000055" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CE00</text>
+<text x="295" y="47.098000000000056" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.000000000000053" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.6354166666667" width="200" height="28.364583333333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.81770833333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.59580052493436" width="200" height="28.404199475065617" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.7979002624672" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.81770833333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="381.6041666666667" width="200" height="40.03125" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="405.6197916666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.6354166666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="404.6197916666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="316.4166666666667" width="200" height="65.1875" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="353.0104166666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="378.6041666666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="352.0104166666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="60.916666666666686" width="200" height="255.5" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="192.66666666666669" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="313.4166666666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="191.66666666666669" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
-<rect x="570" y="30.000000000000018" width="200" height="30.916666666666668" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="49.45833333333335" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="57.916666666666686" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017C00</text>
-<text x="775" y="48.45833333333335" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="27.000000000000018" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
+<text x="775" y="438.7979002624672" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="339.0288713910761" width="200" height="82.56692913385827" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="384.31233595800524" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.59580052493436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="383.31233595800524" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.80839895013122" width="200" height="280.2204724409449" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="202.91863517060366" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="336.0288713910761" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="201.91863517060366" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
+<rect x="570" y="29.999999999999986" width="200" height="28.808398950131235" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.4041994750656" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.80839895013122" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017F00</text>
+<text x="775" y="47.4041994750656" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (500 KB)</text>
-<rect x="90" y="225.44" width="200" height="224.56" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="341.72" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="223.76000000000002" width="200" height="226.23999999999998" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.88" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="340.72" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">351 KB</text>
-<rect x="90" y="195.2" width="200" height="30.240000000000002" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="214.32" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="222.44" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00057C00</text>
-<text x="295" y="213.32" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="164.95999999999998" width="200" height="30.240000000000002" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="184.07999999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="192.2" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00058C00</text>
-<text x="295" y="183.07999999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.559999999999974" width="200" height="106.4" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="115.75999999999998" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="161.95999999999998" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00059C00</text>
-<text x="295" y="114.75999999999998" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
-<rect x="90" y="29.999999999999975" width="200" height="28.56" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.27999999999997" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.559999999999974" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CC00</text>
-<text x="295" y="47.27999999999997" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.999999999999975" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
+<text x="295" y="339.88" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">354 KB</text>
+<rect x="90" y="193.52" width="200" height="30.240000000000002" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="212.64000000000001" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="220.76000000000002" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00058800</text>
+<text x="295" y="211.64000000000001" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="163.28" width="200" height="30.240000000000002" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="182.4" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="190.52" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00059800</text>
+<text x="295" y="181.4" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.56" width="200" height="104.72" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="114.92" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="160.28" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005A800</text>
+<text x="295" y="113.92" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<rect x="90" y="30.000000000000004" width="200" height="28.56" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.28" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.56" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CC00</text>
+<text x="295" y="47.28" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="27.000000000000004" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.5989583333333" width="200" height="28.401041666666668" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.79947916666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.5625" width="200" height="28.4375" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.78125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.79947916666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="377.15625" width="200" height="44.44270833333333" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="403.3776041666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.5989583333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="402.3776041666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="308.25" width="200" height="68.90625" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="346.703125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="374.15625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="345.703125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="278.25" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="173.125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="305.25" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="172.125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
+<text x="775" y="438.78125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="331.0" width="200" height="90.5625" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="380.28125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.5625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="379.28125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="30.0" width="200" height="301.0" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="184.5" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="328.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="183.5" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (500 KB)</text>
-<rect x="90" y="411.584" width="200" height="38.416" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="434.79200000000003" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="409.848" width="200" height="40.152" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="433.92400000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="433.79200000000003" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="382.24" width="200" height="29.344" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="400.91200000000003" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="408.584" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="399.91200000000003" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="352.896" width="200" height="29.344" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="371.56800000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="379.24" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="370.56800000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="324.56" width="200" height="28.336" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="342.728" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="349.896" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="341.728" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="211.888" width="200" height="112.672" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="272.224" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="321.56" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="271.224" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">252 KB</text>
-<rect x="90" y="162.38400000000001" width="200" height="49.504000000000005" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="191.13600000000002" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="208.88800000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00049000</text>
-<text x="295" y="190.13600000000002" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="134.048" width="200" height="28.336" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="152.216" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="159.38400000000001" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00059000</text>
-<text x="295" y="151.216" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.168000000000006" width="200" height="75.88" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="100.108" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="131.048" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00059400</text>
-<text x="295" y="99.108" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="30.000000000000007" width="200" height="28.168" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.084" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.168000000000006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CE00</text>
-<text x="295" y="47.084" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="27.000000000000007" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
+<text x="295" y="432.92400000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="380.28000000000003" width="200" height="29.568" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="399.064" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="406.848" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="398.064" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="350.71200000000005" width="200" height="29.568" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="369.49600000000004" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="377.28000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="368.49600000000004" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="322.32000000000005" width="200" height="28.392" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.5160000000001" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="347.71200000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="339.5160000000001" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="193.96800000000005" width="200" height="128.352" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="262.14400000000006" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="319.32000000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="261.14400000000006" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 KB</text>
+<rect x="90" y="140.88000000000005" width="200" height="53.088" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="171.42400000000006" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="190.96800000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0004A000</text>
+<text x="295" y="170.42400000000006" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.196000000000055" width="200" height="82.684" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="103.53800000000005" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="137.88000000000005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005A000</text>
+<text x="295" y="102.53800000000005" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="30.000000000000053" width="200" height="28.196" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.098000000000056" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.196000000000055" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007CE00</text>
+<text x="295" y="47.098000000000056" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.000000000000053" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.6354166666667" width="200" height="28.364583333333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.81770833333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.59580052493436" width="200" height="28.404199475065617" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.7979002624672" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.81770833333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="378.6875" width="200" height="42.947916666666664" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="404.1614583333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.6354166666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="403.1614583333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="313.5" width="200" height="65.1875" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="350.09375" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="375.6875" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="349.09375" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="60.91666666666666" width="200" height="252.58333333333334" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="191.20833333333331" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="310.5" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="190.20833333333331" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">77 KB</text>
-<rect x="570" y="29.99999999999999" width="200" height="30.916666666666668" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="49.45833333333332" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="57.91666666666666" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017C00</text>
-<text x="775" y="48.45833333333332" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.99999999999999" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
+<text x="775" y="438.7979002624672" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="335.79527559055117" width="200" height="85.80052493438319" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="382.69553805774274" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.59580052493436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="381.69553805774274" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.80839895013122" width="200" height="276.98687664041995" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="201.3018372703412" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="332.79527559055117" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="200.3018372703412" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">77 KB</text>
+<rect x="570" y="29.999999999999986" width="200" height="28.808398950131235" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.4041994750656" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.80839895013122" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017F00</text>
+<text x="775" y="47.4041994750656" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="172.71146245059288" width="200" height="277.2885375494071" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="315.35573122529644" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="172.43478260869563" width="200" height="277.5652173913044" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="315.2173913043478" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="314.35573122529644" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">901 KB</text>
-<rect x="90" y="143.60474308300394" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="162.1581027667984" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="169.71146245059288" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E1400</text>
-<text x="295" y="161.1581027667984" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="114.498023715415" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="133.05138339920947" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="140.60474308300394" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2400</text>
-<text x="295" y="132.05138339920947" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.27667984189722" width="200" height="56.22134387351778" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="90.38735177865611" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="111.498023715415" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3400</text>
-<text x="295" y="89.38735177865611" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.1383399209486" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.27667984189722" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
-<text x="295" y="47.1383399209486" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="314.2173913043478" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">902 KB</text>
+<rect x="90" y="143.3280632411067" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="161.88142292490116" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="169.43478260869563" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E1800</text>
+<text x="295" y="160.88142292490116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="114.22134387351775" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="132.77470355731222" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="140.3280632411067" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2800</text>
+<text x="295" y="131.77470355731222" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.2766798418972" width="200" height="55.944664031620555" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="90.24901185770747" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="111.22134387351775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3800</text>
+<text x="295" y="89.24901185770747" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<rect x="90" y="29.999999999999964" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.13833992094858" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.2766798418972" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
+<text x="295" y="47.13833992094858" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.7994791666667" width="200" height="28.200520833333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.89973958333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.78125" width="200" height="28.21875" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.890625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.89973958333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="387.1822916666667" width="200" height="34.6171875" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.4908854166667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.7994791666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.4908854166667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="338.7291666666667" width="200" height="48.453125" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="366.9557291666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="384.1822916666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="365.9557291666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="308.7291666666667" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="188.36458333333334" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="335.7291666666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="187.36458333333334" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">175 KB</text>
+<text x="775" y="438.890625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="364.25" width="200" height="57.53125" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="397.015625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.78125" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="396.015625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="334.25" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="201.125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="361.25" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="200.125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">175 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="416.85375494071144" width="200" height="33.14624505928854" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="437.4268774703557" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="415.99604743083006" width="200" height="34.00395256916996" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="436.99802371541506" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="436.4268774703557" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="388.18972332015807" width="200" height="28.66403162055336" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="406.52173913043475" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="413.85375494071144" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="405.52173913043475" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="359.5256916996047" width="200" height="28.66403162055336" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="377.8577075098814" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="385.18972332015807" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="376.8577075098814" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="331.3596837944664" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="349.44268774703556" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="356.5256916996047" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="348.44268774703556" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="170.22134387351775" width="200" height="161.13833992094862" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="254.79051383399207" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="328.3596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="253.79051383399207" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">802 KB</text>
-<rect x="90" y="131.596837944664" width="200" height="38.62450592885375" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="154.90909090909088" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="167.22134387351775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D2800</text>
-<text x="295" y="153.90909090909088" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="103.43083003952566" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="121.51383399209483" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="128.596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2800</text>
-<text x="295" y="120.51383399209483" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.083003952569136" width="200" height="45.34782608695652" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="84.7569169960474" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="100.43083003952566" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2C00</text>
-<text x="295" y="83.7569169960474" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="29.999999999999964" width="200" height="28.08300395256917" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.04150197628455" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.083003952569136" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
-<text x="295" y="47.04150197628455" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="435.99802371541506" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="387.2213438735178" width="200" height="28.774703557312254" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="405.60869565217394" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="412.99604743083006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="404.60869565217394" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="358.44664031620556" width="200" height="28.774703557312254" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="376.8339920948617" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="384.2213438735178" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="375.8339920948617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="330.2529644268775" width="200" height="28.193675889328063" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="348.3498023715415" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="355.44664031620556" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="347.3498023715415" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="146.53754940711465" width="200" height="183.71541501976284" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="242.39525691699606" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="327.2529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="241.39525691699606" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">804 KB</text>
+<rect x="90" y="106.1422924901186" width="200" height="40.39525691699605" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="130.33992094861662" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="143.53754940711465" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D3000</text>
+<text x="295" y="129.33992094861662" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.09683794466406" width="200" height="48.04545454545455" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="86.11956521739134" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="103.1422924901186" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3000</text>
+<text x="295" y="85.11956521739134" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.09683794466403" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.048418972332044" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
+<text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.8177083333333" width="200" height="28.182291666666668" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.90885416666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7986928104575" width="200" height="28.201307189542483" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89934640522875" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.90885416666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="387.8020833333333" width="200" height="34.015625" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.8098958333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.8177083333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.8098958333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="341.2083333333333" width="200" height="46.59375" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="368.5052083333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="384.8020833333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="367.5052083333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.458333333333314" width="200" height="281.75" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="204.33333333333331" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="338.2083333333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="203.33333333333331" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174 KB</text>
-<rect x="570" y="29.999999999999982" width="200" height="29.458333333333332" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.72916666666665" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.458333333333314" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
-<text x="775" y="47.72916666666665" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.999999999999982" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
+<text x="775" y="438.89934640522875" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="366.6222222222222" width="200" height="55.1764705882353" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="398.21045751633983" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.7986928104575" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="397.21045751633983" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.40261437908498" width="200" height="308.2196078431372" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="216.5124183006536" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="363.6222222222222" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="215.5124183006536" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174 KB</text>
+<rect x="570" y="30.000000000000014" width="200" height="28.402614379084966" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.2013071895425" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.40261437908498" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FF00</text>
+<text x="775" y="47.2013071895425" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000014" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="183.22529644268775" width="200" height="266.77470355731225" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="320.6126482213439" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="182.39525691699606" width="200" height="267.60474308300394" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="320.197628458498" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="319.6126482213439" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">863 KB</text>
-<rect x="90" y="154.1185770750988" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="172.67193675889328" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="180.22529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D7C00</text>
-<text x="295" y="171.67193675889328" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="125.01185770750988" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="143.56521739130434" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="151.1185770750988" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D8C00</text>
-<text x="295" y="142.56521739130434" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.27667984189722" width="200" height="66.73517786561266" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="95.64426877470355" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="122.01185770750988" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9C00</text>
-<text x="295" y="94.64426877470355" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.1383399209486" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.27667984189722" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
-<text x="295" y="47.1383399209486" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="319.197628458498" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">866 KB</text>
+<rect x="90" y="153.28853754940712" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="171.8418972332016" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="179.39525691699606" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D8800</text>
+<text x="295" y="170.8418972332016" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="124.18181818181819" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="142.73517786561266" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="150.28853754940712" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9800</text>
+<text x="295" y="141.73517786561266" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.27667984189725" width="200" height="65.90513833992094" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="95.22924901185772" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="121.18181818181819" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000DA800</text>
+<text x="295" y="94.22924901185772" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<rect x="90" y="30.000000000000014" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.13833992094863" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.27667984189725" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
+<text x="295" y="47.13833992094863" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="27.000000000000014" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.7994791666667" width="200" height="28.200520833333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.89973958333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.78125" width="200" height="28.21875" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.890625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.89973958333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="385.578125" width="200" height="36.221354166666664" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="407.6888020833333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.7994791666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="406.6888020833333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="337.125" width="200" height="48.453125" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="365.3515625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="382.578125" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="364.3515625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="307.125" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="187.5625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="334.125" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="186.5625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174 KB</text>
+<text x="775" y="438.890625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="362.5" width="200" height="59.28125" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="396.140625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.78125" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="395.140625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="30.0" width="200" height="332.5" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="200.25" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="359.5" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="199.25" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="416.85375494071144" width="200" height="33.14624505928854" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="437.4268774703557" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="415.99604743083006" width="200" height="34.00395256916996" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="436.99802371541506" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="436.4268774703557" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="388.18972332015807" width="200" height="28.66403162055336" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="406.52173913043475" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="413.85375494071144" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="405.52173913043475" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="359.5256916996047" width="200" height="28.66403162055336" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="377.8577075098814" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="385.18972332015807" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="376.8577075098814" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="331.3596837944664" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="349.44268774703556" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="356.5256916996047" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="348.44268774703556" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="176.5296442687747" width="200" height="154.8300395256917" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="257.9446640316205" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="328.3596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="256.9446640316205" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">764 KB</text>
-<rect x="90" y="137.90513833992094" width="200" height="38.62450592885375" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="161.2173913043478" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="173.5296442687747" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000C9000</text>
-<text x="295" y="160.2173913043478" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="109.7391304347826" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="127.82213438735177" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="134.90513833992094" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9000</text>
-<text x="295" y="126.82213438735177" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.08300395256916" width="200" height="51.65612648221344" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="87.91106719367588" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="106.7391304347826" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9400</text>
-<text x="295" y="86.91106719367588" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.08300395256917" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.04150197628457" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.08300395256916" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
-<text x="295" y="47.04150197628457" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="435.99802371541506" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="387.2213438735178" width="200" height="28.774703557312254" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="405.60869565217394" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="412.99604743083006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="404.60869565217394" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="358.44664031620556" width="200" height="28.774703557312254" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="376.8339920948617" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="384.2213438735178" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="375.8339920948617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="330.2529644268775" width="200" height="28.193675889328063" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="348.3498023715415" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="355.44664031620556" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="347.3498023715415" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="153.50988142292493" width="200" height="176.74308300395256" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="245.88142292490122" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="327.2529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="244.88142292490122" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">768 KB</text>
+<rect x="90" y="113.11462450592889" width="200" height="40.39525691699605" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="137.3122529644269" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="150.50988142292493" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000CA000</text>
+<text x="295" y="136.3122529644269" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.09683794466406" width="200" height="55.01778656126483" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="89.60573122529647" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="110.11462450592889" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000DA000</text>
+<text x="295" y="88.60573122529647" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.09683794466403" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.048418972332044" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
+<text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.8177083333333" width="200" height="28.182291666666675" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.90885416666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7986928104575" width="200" height="28.201307189542483" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89934640522875" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.90885416666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="386.34375" width="200" height="35.47395833333334" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.0807291666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.81770833333337" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.0807291666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="339.75" width="200" height="46.59375000000001" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="367.046875" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="383.34375" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="366.046875" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.458333333333314" width="200" height="280.2916666666667" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="203.60416666666666" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="336.75" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="202.60416666666666" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173 KB</text>
-<rect x="570" y="29.999999999999975" width="200" height="29.45833333333334" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.72916666666664" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.458333333333314" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
-<text x="775" y="47.72916666666664" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.999999999999975" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
+<text x="775" y="438.89934640522875" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="365.01176470588234" width="200" height="56.78692810457517" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="397.4052287581699" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.7986928104575" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="396.4052287581699" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.40261437908498" width="200" height="306.60915032679736" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="215.70718954248366" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="362.01176470588234" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="214.70718954248366" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173 KB</text>
+<rect x="570" y="30.000000000000014" width="200" height="28.402614379084966" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.2013071895425" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.40261437908498" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FF00</text>
+<text x="775" y="47.2013071895425" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000014" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20030000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1524 KB)</text>
-<rect x="90" y="162.3937007874016" width="200" height="287.6062992125984" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="310.1968503937008" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="162.20997375328085" width="200" height="287.79002624671915" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="310.1049868766404" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="309.1968503937008" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1413 KB</text>
-<rect x="90" y="133.65879265091866" width="200" height="28.734908136482936" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="152.02624671916013" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="159.3937007874016" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00161400</text>
-<text x="295" y="151.02624671916013" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="104.92388451443571" width="200" height="28.734908136482936" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="123.29133858267718" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="130.65879265091866" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00162400</text>
-<text x="295" y="122.29133858267718" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.18372703412076" width="200" height="46.740157480314956" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="85.55380577427823" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="101.92388451443571" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00163400</text>
-<text x="295" y="84.55380577427823" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
-<rect x="90" y="30.000000000000025" width="200" height="28.183727034120732" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.09186351706039" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.18372703412076" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
-<text x="295" y="47.09186351706039" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="27.000000000000025" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
+<text x="295" y="309.1049868766404" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1414 KB</text>
+<rect x="90" y="133.4750656167979" width="200" height="28.73490813648294" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="151.84251968503938" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="159.20997375328085" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00161800</text>
+<text x="295" y="150.84251968503938" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="104.74015748031496" width="200" height="28.73490813648294" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="123.10761154855643" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="130.4750656167979" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00162800</text>
+<text x="295" y="122.10761154855643" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.183727034120736" width="200" height="46.55643044619423" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="85.46194225721786" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="101.74015748031496" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00163800</text>
+<text x="295" y="84.46194225721786" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<rect x="90" y="30.0" width="200" height="28.183727034120736" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.09186351706037" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.183727034120736" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
+<text x="295" y="47.09186351706037" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
-<rect x="570" y="421.8493150684931" width="200" height="28.15068493150685" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.92465753424653" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.83561643835617" width="200" height="28.164383561643834" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9178082191781" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.92465753424653" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="388.8767123287671" width="200" height="32.97260273972603" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="409.3630136986301" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.8493150684931" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="408.3630136986301" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="345.50684931506845" width="200" height="43.36986301369863" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="371.19178082191775" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="385.8767123287671" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="370.19178082191775" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="29.999999999999943" width="200" height="315.5068493150685" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="191.7534246575342" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="342.50684931506845" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="190.7534246575342" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">238.5 KB</text>
-<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FE00</text>
+<text x="775" y="438.9178082191781" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="371.64383561643837" width="200" height="50.1917808219178" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="400.7397260273973" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.83561643835617" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="399.7397260273973" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="341.64383561643837" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="204.82191780821918" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="368.64383561643837" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="203.82191780821918" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">238.5 KB</text>
+<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FE00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1524 KB)</text>
-<rect x="90" y="418.5826771653543" width="200" height="31.41732283464567" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="438.29133858267716" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="418.01312335958005" width="200" height="31.986876640419947" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="438.00656167979" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="437.29133858267716" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="390.14173228346453" width="200" height="28.440944881889763" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="408.3622047244094" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="415.5826771653543" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="407.3622047244094" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="361.70078740157476" width="200" height="28.440944881889763" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="379.92125984251965" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="387.14173228346453" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="378.92125984251965" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="333.59055118110234" width="200" height="28.11023622047244" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="351.64566929133855" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="358.70078740157476" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="350.64566929133855" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="160.74015748031493" width="200" height="172.8503937007874" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="251.16535433070862" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="330.59055118110234" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="250.16535433070862" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1314 KB</text>
-<rect x="90" y="125.68503937007871" width="200" height="35.05511811023622" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="147.21259842519683" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="157.74015748031493" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00152800</text>
-<text x="295" y="146.21259842519683" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="97.57480314960627" width="200" height="28.11023622047244" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="115.62992125984249" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="122.68503937007871" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00162800</text>
-<text x="295" y="114.62992125984249" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.055118110236194" width="200" height="39.519685039370074" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="81.81496062992123" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="94.57480314960627" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00162C00</text>
-<text x="295" y="80.81496062992123" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="29.99999999999997" width="200" height="28.055118110236222" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.02755905511808" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.055118110236194" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
-<text x="295" y="47.02755905511808" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.99999999999997" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
+<text x="295" y="437.00656167979" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="389.498687664042" width="200" height="28.514435695538058" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="407.755905511811" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="415.01312335958005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="406.755905511811" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="360.98425196850394" width="200" height="28.514435695538058" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="379.24146981627297" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="386.498687664042" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="378.24146981627297" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="332.85564304461946" width="200" height="28.128608923884514" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="350.9199475065617" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="357.98425196850394" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="349.9199475065617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="135.60629921259846" width="200" height="197.249343832021" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="238.23097112860896" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="329.85564304461946" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="237.23097112860896" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1316 KB</text>
+<rect x="90" y="99.37532808398953" width="200" height="36.23097112860893" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="121.490813648294" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="132.60629921259846" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00153000</text>
+<text x="295" y="120.490813648294" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.064304461942285" width="200" height="41.311023622047244" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="82.71981627296591" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="96.37532808398953" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00163000</text>
+<text x="295" y="81.71981627296591" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.064304461942257" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.03215223097116" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.064304461942285" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
+<text x="295" y="47.03215223097116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
-<rect x="570" y="421.8627450980392" width="200" height="28.137254901960784" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.9313725490196" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.8485742379548" width="200" height="28.151425762045232" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9242871189774" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.9313725490196" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="389.33333333333337" width="200" height="32.529411764705884" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="409.5980392156863" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.8627450980392" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="408.5980392156863" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="347.33333333333337" width="200" height="42.0" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="372.33333333333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="386.33333333333337" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="371.33333333333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.0980392156863" width="200" height="288.2352941176471" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="207.21568627450984" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="344.33333333333337" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="206.21568627450984" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">237 KB</text>
-<rect x="570" y="30.000000000000025" width="200" height="29.098039215686274" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.549019607843164" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.0980392156863" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003F800</text>
-<text x="775" y="47.549019607843164" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="27.000000000000025" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FC00</text>
+<text x="775" y="438.9242871189774" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="373.4060963618486" width="200" height="48.442477876106196" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="401.6273352999017" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.8485742379548" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="400.6273352999017" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.3028515240905" width="200" height="315.1032448377581" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="219.85447394296955" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="370.4060963618486" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="218.85447394296955" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">237 KB</text>
+<rect x="570" y="30.000000000000036" width="200" height="28.302851524090464" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.151425762045264" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.3028515240905" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FB00</text>
+<text x="775" y="47.151425762045264" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000036" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1524 KB)</text>
-<rect x="90" y="169.37532808398953" width="200" height="280.62467191601047" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="313.68766404199476" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="168.82414698162728" width="200" height="281.1758530183727" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="313.41207349081367" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="312.68766404199476" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1375 KB</text>
-<rect x="90" y="140.6404199475066" width="200" height="28.73490813648294" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="159.00787401574806" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="166.37532808398953" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00157C00</text>
-<text x="295" y="158.00787401574806" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="111.90551181102364" width="200" height="28.73490813648294" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="130.27296587926512" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="137.6404199475066" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00158C00</text>
-<text x="295" y="129.27296587926512" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.18372703412076" width="200" height="53.72178477690289" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="89.0446194225722" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="108.90551181102364" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00159C00</text>
-<text x="295" y="88.0446194225722" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
-<rect x="90" y="30.00000000000002" width="200" height="28.183727034120736" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.09186351706039" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.18372703412076" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
-<text x="295" y="47.09186351706039" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="27.00000000000002" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
+<text x="295" y="312.41207349081367" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1378 KB</text>
+<rect x="90" y="140.08923884514434" width="200" height="28.73490813648294" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="158.4566929133858" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="165.82414698162728" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00158800</text>
+<text x="295" y="157.4566929133858" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="111.3543307086614" width="200" height="28.73490813648294" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="129.72178477690287" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="137.08923884514434" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00159800</text>
+<text x="295" y="128.72178477690287" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.18372703412071" width="200" height="53.170603674540686" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="88.76902887139104" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="108.3543307086614" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0015A800</text>
+<text x="295" y="87.76902887139104" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<rect x="90" y="29.99999999999997" width="200" height="28.183727034120736" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.09186351706034" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.18372703412071" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
+<text x="295" y="47.09186351706034" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.99999999999997" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
-<rect x="570" y="421.8493150684931" width="200" height="28.15068493150685" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.92465753424653" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.83561643835617" width="200" height="28.164383561643834" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9178082191781" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.92465753424653" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="387.6712328767123" width="200" height="34.178082191780824" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.7602739726027" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.8493150684931" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.7602739726027" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="344.30136986301363" width="200" height="43.36986301369863" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="369.98630136986293" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="384.6712328767123" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="368.98630136986293" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="29.999999999999943" width="200" height="314.3013698630137" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="191.1506849315068" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="341.30136986301363" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="190.1506849315068" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">237.5 KB</text>
-<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FE00</text>
+<text x="775" y="438.9178082191781" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="370.32876712328766" width="200" height="51.50684931506849" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="400.0821917808219" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.83561643835617" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="399.0821917808219" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="30.0" width="200" height="340.32876712328766" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="204.16438356164383" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="367.32876712328766" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="203.16438356164383" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">237.5 KB</text>
+<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FE00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1524 KB)</text>
-<rect x="90" y="418.5826771653543" width="200" height="31.41732283464567" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="438.29133858267716" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="418.01312335958005" width="200" height="31.986876640419947" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="438.00656167979" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="437.29133858267716" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="390.14173228346453" width="200" height="28.440944881889763" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="408.3622047244094" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="415.5826771653543" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="407.3622047244094" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="361.70078740157476" width="200" height="28.440944881889763" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="379.92125984251965" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="387.14173228346453" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="378.92125984251965" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="333.59055118110234" width="200" height="28.11023622047244" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="351.64566929133855" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="358.70078740157476" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="350.64566929133855" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="164.9291338582677" width="200" height="168.66141732283464" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="253.25984251968504" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="330.59055118110234" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="252.25984251968504" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1276 KB</text>
-<rect x="90" y="129.87401574803147" width="200" height="35.05511811023622" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="151.40157480314957" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="161.92913385826768" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00149000</text>
-<text x="295" y="150.40157480314957" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="101.76377952755902" width="200" height="28.11023622047244" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="119.81889763779525" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="126.87401574803147" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00159000</text>
-<text x="295" y="118.81889763779525" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.05511811023619" width="200" height="43.70866141732284" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="83.9094488188976" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="98.76377952755902" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00159400</text>
-<text x="295" y="82.9094488188976" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="29.999999999999964" width="200" height="28.055118110236222" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.027559055118076" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.05511811023619" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
-<text x="295" y="47.027559055118076" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
+<text x="295" y="437.00656167979" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="389.498687664042" width="200" height="28.514435695538058" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="407.755905511811" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="415.01312335958005" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="406.755905511811" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="360.98425196850394" width="200" height="28.514435695538058" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="379.24146981627297" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="386.498687664042" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="378.24146981627297" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="332.85564304461946" width="200" height="28.128608923884514" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="350.9199475065617" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="357.98425196850394" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="349.9199475065617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="140.23622047244098" width="200" height="192.61942257217848" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="240.54593175853023" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="329.85564304461946" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="239.54593175853023" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1280 KB</text>
+<rect x="90" y="104.00524934383205" width="200" height="36.23097112860893" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="126.12073490813651" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="137.23622047244098" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0014A000</text>
+<text x="295" y="125.12073490813651" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.064304461942285" width="200" height="45.94094488188976" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="85.03477690288716" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="101.00524934383205" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0015A000</text>
+<text x="295" y="84.03477690288716" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.064304461942257" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.03215223097116" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.064304461942285" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
+<text x="295" y="47.03215223097116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
-<rect x="570" y="421.8627450980392" width="200" height="28.137254901960784" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.9313725490196" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.8485742379548" width="200" height="28.151425762045232" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9242871189774" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.9313725490196" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="388.2352941176471" width="200" height="33.627450980392155" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="409.04901960784315" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.8627450980392" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="408.04901960784315" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="346.2352941176471" width="200" height="42.0" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="371.2352941176471" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="385.2352941176471" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="370.2352941176471" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.0980392156863" width="200" height="287.1372549019608" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="206.66666666666669" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="343.2352941176471" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="205.66666666666669" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">236 KB</text>
-<rect x="570" y="30.000000000000025" width="200" height="29.098039215686274" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.549019607843164" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.0980392156863" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003F800</text>
-<text x="775" y="47.549019607843164" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="27.000000000000025" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FC00</text>
+<text x="775" y="438.9242871189774" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="372.19469026548677" width="200" height="49.65388397246804" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="401.0216322517208" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.84857423795484" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="400.0216322517208" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.3028515240905" width="200" height="313.89183874139627" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="219.24877089478863" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="369.19469026548677" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="218.24877089478863" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">236 KB</text>
+<rect x="570" y="30.000000000000036" width="200" height="28.302851524090464" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.151425762045264" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.3028515240905" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FB00</text>
+<text x="775" y="47.151425762045264" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000036" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2003FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.svg
@@ -4,39 +4,35 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="130.64864864864865" width="200" height="319.35135135135135" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="294.3243243243243" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="130.49729729729728" width="200" height="319.5027027027027" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="294.24864864864867" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="293.3243243243243" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1925 KB</text>
-<rect x="90" y="102.04324324324324" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="120.34594594594594" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="127.64864864864865" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E1400</text>
-<text x="295" y="119.34594594594594" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="73.43783783783783" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="91.74054054054054" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="99.04324324324324" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2400</text>
-<text x="295" y="90.74054054054054" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="29.999999999999993" width="200" height="43.43783783783784" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="55.71891891891892" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="70.43783783783783" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E3400</text>
-<text x="295" y="54.71891891891892" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
-<text x="86" y="26.999999999999993" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
+<text x="295" y="293.24864864864867" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1926 KB</text>
+<rect x="90" y="101.89189189189187" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="120.19459459459458" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="127.49729729729728" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E1800</text>
+<text x="295" y="119.19459459459458" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="73.28648648648647" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="91.58918918918917" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="98.89189189189187" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2800</text>
+<text x="295" y="90.58918918918917" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="29.99999999999998" width="200" height="43.28648648648649" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="55.64324324324322" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="70.28648648648647" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E3800</text>
+<text x="295" y="54.64324324324322" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<text x="86" y="26.99999999999998" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
-<rect x="570" y="421.92470358146926" width="200" height="28.075296418530748" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.96235179073466" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.9178584525119" width="200" height="28.08214154748808" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9589292262559" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.96235179073466" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="391.43992176995476" width="200" height="30.48478181151449" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="410.682312675712" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.92470358146926" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="409.682312675712" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="355.75968707981906" width="200" height="35.680234690135684" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="377.5998044248869" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="388.43992176995476" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="376.5998044248869" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="29.999999999999943" width="200" height="325.7596870798191" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="196.8798435399095" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="352.75968707981906" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="195.8798435399095" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">494.3 KB</text>
-<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FD40</text>
+<text x="775" y="438.9589292262559" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="382.8287495416208" width="200" height="39.089108910891085" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="406.3733039970664" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.9178584525119" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="405.3733039970664" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="352.8287495416208" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="210.4143747708104" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="379.8287495416208" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="209.4143747708104" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">494.3 KB</text>
+<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FD40</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="419.4420432220039" width="200" height="30.557956777996072" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="438.72102161100196" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="419.0157170923379" width="200" height="30.98428290766208" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="438.50785854616896" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="437.72102161100196" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="391.11198428290766" width="200" height="28.33005893909627" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="409.2770137524558" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="416.4420432220039" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="408.2770137524558" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="362.7819253438114" width="200" height="28.33005893909627" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="380.9469548133595" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="388.11198428290766" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="379.9469548133595" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="334.69941060903733" width="200" height="28.082514734774065" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="352.74066797642433" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="359.7819253438114" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="351.74066797642433" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="156.02750491159134" width="200" height="178.671905697446" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="249.36345776031433" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="331.69941060903733" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="248.36345776031433" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1826 KB</text>
-<rect x="90" y="122.74656188605107" width="200" height="33.280943025540275" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="143.38703339882122" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="153.02750491159134" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D2800</text>
-<text x="295" y="142.38703339882122" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="94.664047151277" width="200" height="28.082514734774065" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="112.70530451866404" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="119.74656188605107" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2800</text>
-<text x="295" y="111.70530451866404" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.041257367387026" width="200" height="36.62278978388998" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="80.35265225933202" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="91.664047151277" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2C00</text>
-<text x="295" y="79.35265225933202" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="29.999999999999993" width="200" height="28.041257367387033" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.02062868369351" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.041257367387026" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
-<text x="295" y="47.02062868369351" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999993" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
+<text x="295" y="437.50785854616896" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="390.63064833005893" width="200" height="28.38506876227898" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="408.8231827111984" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="416.0157170923379" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="407.8231827111984" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="362.24557956777994" width="200" height="28.38506876227898" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="380.4381139489194" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="387.63064833005893" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="379.4381139489194" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="334.1493123772102" width="200" height="28.096267190569744" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="352.1974459724951" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="359.24557956777994" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="351.1974459724951" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="130.1728880157171" width="200" height="203.97642436149312" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="236.16110019646365" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="331.1493123772102" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="235.16110019646365" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1828 KB</text>
+<rect x="90" y="96.01178781925344" width="200" height="34.16110019646365" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="117.09233791748527" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="127.17288801571709" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D3000</text>
+<text x="295" y="116.09233791748527" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.04813359528488" width="200" height="37.96365422396856" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="81.02996070726917" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="93.01178781925344" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E3000</text>
+<text x="295" y="80.02996070726917" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="30.000000000000007" width="200" height="28.048133595284874" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.02406679764245" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.04813359528488" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
+<text x="295" y="47.02406679764245" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.000000000000007" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
-<rect x="570" y="421.93150684931504" width="200" height="28.068493150684933" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.9657534246575" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.92454679078884" width="200" height="28.075453209211172" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.96227339539445" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.9657534246575" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="391.6712328767123" width="200" height="30.26027397260274" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="410.80136986301363" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.93150684931504" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="409.80136986301363" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="356.68493150684924" width="200" height="34.986301369863014" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="378.17808219178073" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="388.6712328767122" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="377.17808219178073" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="58.54794520547938" width="200" height="298.13698630136986" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="211.6164383561643" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="353.68493150684924" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="210.6164383561643" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">493 KB</text>
-<rect x="570" y="29.99999999999993" width="200" height="28.54794520547945" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.273972602739654" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="55.54794520547938" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007F800</text>
-<text x="775" y="47.273972602739654" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.99999999999993" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FC00</text>
+<text x="775" y="438.96227339539445" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="383.73836354728076" width="200" height="38.18618324350808" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="406.8314551690348" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.92454679078884" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="405.8314551690348" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.15090641842232" width="200" height="325.58745712885843" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="224.94463498285154" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="380.73836354728076" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="223.94463498285154" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">493 KB</text>
+<rect x="570" y="29.999999999999982" width="200" height="28.15090641842234" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.075453209211155" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.15090641842232" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FB00</text>
+<text x="775" y="47.075453209211155" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="26.999999999999982" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.svg
@@ -4,39 +4,35 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="136.40000000000003" width="200" height="313.59999999999997" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="297.20000000000005" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="135.94594594594594" width="200" height="314.05405405405406" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="296.97297297297297" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="296.20000000000005" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1887 KB</text>
-<rect x="90" y="107.79459459459463" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="126.09729729729733" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="133.40000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D7C00</text>
-<text x="295" y="125.09729729729733" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="79.18918918918922" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="97.49189189189192" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="104.79459459459463" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D8C00</text>
-<text x="295" y="96.49189189189192" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="30.00000000000003" width="200" height="49.18918918918919" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="58.594594594594625" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="76.18918918918922" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9C00</text>
-<text x="295" y="57.594594594594625" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
-<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
+<text x="295" y="295.97297297297297" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1890 KB</text>
+<rect x="90" y="107.34054054054053" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="125.64324324324323" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="132.94594594594594" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D8800</text>
+<text x="295" y="124.64324324324323" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="78.73513513513512" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="97.03783783783783" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="104.34054054054053" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9800</text>
+<text x="295" y="96.03783783783783" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="29.999999999999986" width="200" height="48.73513513513514" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="58.367567567567555" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="75.73513513513512" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001DA800</text>
+<text x="295" y="57.367567567567555" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
-<rect x="570" y="421.92470358146926" width="200" height="28.07529641853074" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.9623517907346" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.9178584525119" width="200" height="28.08214154748809" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.9589292262559" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.9623517907346" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="390.83755042170884" width="200" height="31.08715315976042" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="410.38112700158905" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.92470358146926" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="409.38112700158905" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="355.15731573157314" width="200" height="35.68023469013568" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="376.99743307664096" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="387.8375504217088" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="375.99743307664096" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="325.15731573157314" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="196.57865786578657" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="352.15731573157314" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="195.57865786578657" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">493.3 KB</text>
-<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FD40</text>
+<text x="775" y="438.9589292262559" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="382.17161716171614" width="200" height="39.74624129079575" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="406.044737807114" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.9178584525119" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="405.044737807114" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="29.999999999999943" width="200" height="352.1716171617162" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="210.08580858085804" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="379.17161716171614" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="209.08580858085804" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">493.3 KB</text>
+<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FD40</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="419.4420432220039" width="200" height="30.557956777996072" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="438.72102161100196" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="419.0157170923379" width="200" height="30.98428290766208" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="438.50785854616896" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="437.72102161100196" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="391.11198428290766" width="200" height="28.33005893909627" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="409.2770137524558" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="416.4420432220039" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="408.2770137524558" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="362.7819253438114" width="200" height="28.33005893909627" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="380.9469548133595" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="388.11198428290766" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="379.9469548133595" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="334.69941060903733" width="200" height="28.082514734774065" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="352.74066797642433" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="359.7819253438114" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="351.74066797642433" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="159.16306483300588" width="200" height="175.53634577603145" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="250.9312377210216" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="331.69941060903733" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="249.9312377210216" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1788 KB</text>
-<rect x="90" y="125.88212180746561" width="200" height="33.280943025540275" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="146.52259332023576" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="156.16306483300588" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001C9000</text>
-<text x="295" y="145.52259332023576" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="97.79960707269154" width="200" height="28.082514734774065" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="115.84086444007858" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="122.88212180746561" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9000</text>
-<text x="295" y="114.84086444007858" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.041257367387026" width="200" height="39.75834970530452" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="81.92043222003929" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="94.79960707269154" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9400</text>
-<text x="295" y="80.92043222003929" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="29.999999999999993" width="200" height="28.041257367387033" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.02062868369351" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.041257367387026" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
-<text x="295" y="47.02062868369351" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999993" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
+<text x="295" y="437.50785854616896" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="390.63064833005893" width="200" height="28.38506876227898" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="408.8231827111984" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="416.0157170923379" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="407.8231827111984" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="362.24557956777994" width="200" height="28.38506876227898" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="380.4381139489194" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="387.63064833005893" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="379.4381139489194" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="334.1493123772102" width="200" height="28.096267190569744" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="352.1974459724951" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="359.24557956777994" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="351.1974459724951" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="133.6385068762279" width="200" height="200.51080550098231" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="237.89390962671905" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="331.1493123772102" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="236.89390962671905" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1792 KB</text>
+<rect x="90" y="99.47740667976424" width="200" height="34.16110019646365" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="120.55795677799607" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="130.6385068762279" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001CA000</text>
+<text x="295" y="119.55795677799607" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.048133595284874" width="200" height="41.42927308447937" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="82.76277013752456" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="96.47740667976424" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001DA000</text>
+<text x="295" y="81.76277013752456" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="30.0" width="200" height="28.048133595284874" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.02406679764243" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.048133595284874" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
+<text x="295" y="47.02406679764243" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
-<rect x="570" y="421.93150684931504" width="200" height="28.068493150684933" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.9657534246575" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.92454679078884" width="200" height="28.075453209211172" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.96227339539445" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.9657534246575" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="391.12328767123284" width="200" height="30.80821917808219" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="410.5273972602739" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.93150684931504" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="409.5273972602739" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="356.1369863013698" width="200" height="34.986301369863014" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="377.6301369863013" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="388.1232876712328" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="376.6301369863013" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="58.54794520547938" width="200" height="297.5890410958904" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="211.3424657534246" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="353.1369863013698" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="210.3424657534246" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">492 KB</text>
-<rect x="570" y="29.99999999999993" width="200" height="28.54794520547945" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.273972602739654" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="55.54794520547938" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007F800</text>
-<text x="775" y="47.273972602739654" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.99999999999993" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FC00</text>
+<text x="775" y="438.96227339539445" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="383.1347378735914" width="200" height="38.78980891719745" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="406.5296423321901" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.92454679078884" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="405.5296423321901" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.15090641842238" width="200" height="324.983831455169" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="224.6428221460069" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="380.1347378735914" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="223.6428221460069" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">492 KB</text>
+<rect x="570" y="30.00000000000004" width="200" height="28.15090641842234" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.07545320921121" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.15090641842238" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FB00</text>
+<text x="775" y="47.07545320921121" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.00000000000004" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2007FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (508 KB)</text>
-<rect x="90" y="203.1811023622047" width="200" height="246.8188976377953" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="330.59055118110234" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="202.62992125984252" width="200" height="247.37007874015748" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="330.31496062992125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="329.59055118110234" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">397 KB</text>
-<rect x="90" y="172.97637795275588" width="200" height="30.20472440944882" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="192.0787401574803" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="200.1811023622047" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00063400</text>
-<text x="295" y="191.0787401574803" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="142.77165354330705" width="200" height="30.20472440944882" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="161.87401574803147" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="169.97637795275588" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00064400</text>
-<text x="295" y="160.87401574803147" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.551181102362165" width="200" height="84.22047244094489" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="104.66141732283461" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="139.77165354330705" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00065400</text>
-<text x="295" y="103.66141732283461" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
-<rect x="90" y="29.99999999999996" width="200" height="28.551181102362204" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.27559055118106" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.551181102362165" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EC00</text>
-<text x="295" y="47.27559055118106" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.99999999999996" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
+<text x="295" y="329.31496062992125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">398 KB</text>
+<rect x="90" y="172.4251968503937" width="200" height="30.20472440944882" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="191.5275590551181" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="199.62992125984252" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00063800</text>
+<text x="295" y="190.5275590551181" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="142.22047244094486" width="200" height="30.20472440944882" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="161.32283464566927" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="169.4251968503937" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00064800</text>
+<text x="295" y="160.32283464566927" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.55118110236218" width="200" height="83.66929133858268" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="104.38582677165351" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="139.22047244094486" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00065800</text>
+<text x="295" y="103.38582677165351" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<rect x="90" y="29.999999999999975" width="200" height="28.551181102362204" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.275590551181075" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.55118110236218" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EC00</text>
+<text x="295" y="47.275590551181075" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.999999999999975" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.5989583333333" width="200" height="28.401041666666668" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.79947916666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.5625" width="200" height="28.4375" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.78125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.79947916666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="380.3645833333333" width="200" height="41.234375" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="404.9817708333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.5989583333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="403.9817708333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="311.4583333333333" width="200" height="68.90625" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="349.9114583333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="377.3645833333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="348.9114583333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="281.4583333333333" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="174.72916666666666" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="308.4583333333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="173.72916666666666" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">79 KB</text>
+<text x="775" y="438.78125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="334.5" width="200" height="87.0625" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="382.03125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.5625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="381.03125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="304.5" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="186.25" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="331.5" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="185.25" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">79 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (508 KB)</text>
-<rect x="90" y="411.748031496063" width="200" height="38.25196850393701" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="434.8740157480315" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="410.03937007874015" width="200" height="39.960629921259844" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="434.0196850393701" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="433.8740157480315" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="382.4251968503937" width="200" height="29.322834645669293" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="401.0866141732284" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="408.748031496063" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="400.0866141732284" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="353.10236220472444" width="200" height="29.322834645669293" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="371.7637795275591" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="379.4251968503937" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="370.7637795275591" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="324.77165354330714" width="200" height="28.330708661417322" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="342.9370078740158" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="350.10236220472444" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="341.9370078740158" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="198.22047244094495" width="200" height="126.5511811023622" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="265.49606299212604" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="321.77165354330714" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="264.49606299212604" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">298 KB</text>
-<rect x="90" y="149.0551181102363" width="200" height="49.16535433070866" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="177.63779527559063" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="195.22047244094495" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00054800</text>
-<text x="295" y="176.63779527559063" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="120.72440944881897" width="200" height="28.330708661417322" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="138.88976377952764" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="146.0551181102363" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00064800</text>
-<text x="295" y="137.88976377952764" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.16535433070874" width="200" height="62.55905511811024" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="93.44488188976385" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="117.72440944881897" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00064C00</text>
-<text x="295" y="92.44488188976385" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="30.000000000000075" width="200" height="28.165354330708663" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.082677165354404" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.16535433070874" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EE00</text>
-<text x="295" y="47.082677165354404" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="27.000000000000075" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
+<text x="295" y="433.0196850393701" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="380.496062992126" width="200" height="29.543307086614174" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="399.26771653543307" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="407.03937007874015" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="398.26771653543307" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="350.9527559055118" width="200" height="29.543307086614174" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="369.7244094488189" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="377.496062992126" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="368.7244094488189" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="322.56692913385825" width="200" height="28.385826771653544" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.75984251968504" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="347.9527559055118" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="339.75984251968504" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="178.81889763779526" width="200" height="143.748031496063" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="254.69291338582676" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="319.56692913385825" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="253.69291338582676" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">300 KB</text>
+<rect x="90" y="126.12598425196849" width="200" height="52.69291338582677" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="156.47244094488187" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="175.81889763779526" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00055000</text>
+<text x="295" y="155.47244094488187" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.192913385826756" width="200" height="67.93307086614173" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="96.15944881889763" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="123.12598425196849" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00065000</text>
+<text x="295" y="95.15944881889763" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="29.999999999999986" width="200" height="28.19291338582677" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.09645669291337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.192913385826756" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EE00</text>
+<text x="295" y="47.09645669291337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.6354166666667" width="200" height="28.364583333333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.81770833333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.59580052493436" width="200" height="28.404199475065617" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.7979002624672" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.81770833333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="381.6041666666667" width="200" height="40.03125" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="405.6197916666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.6354166666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="404.6197916666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="316.4166666666667" width="200" height="65.1875" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="353.0104166666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="378.6041666666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="352.0104166666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="60.916666666666686" width="200" height="255.5" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="192.66666666666669" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="313.4166666666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="191.66666666666669" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
-<rect x="570" y="30.000000000000018" width="200" height="30.916666666666668" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="49.45833333333335" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="57.916666666666686" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017C00</text>
-<text x="775" y="48.45833333333335" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="27.000000000000018" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
+<text x="775" y="438.7979002624672" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="339.0288713910761" width="200" height="82.56692913385827" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="384.31233595800524" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.59580052493436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="383.31233595800524" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.80839895013122" width="200" height="280.2204724409449" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="202.91863517060366" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="336.0288713910761" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="201.91863517060366" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
+<rect x="570" y="29.999999999999986" width="200" height="28.808398950131235" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.4041994750656" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.80839895013122" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017F00</text>
+<text x="775" y="47.4041994750656" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (508 KB)</text>
-<rect x="90" y="224.1259842519685" width="200" height="225.8740157480315" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="341.06299212598424" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="222.4724409448819" width="200" height="227.5275590551181" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.23622047244095" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="340.06299212598424" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">359 KB</text>
-<rect x="90" y="193.92125984251967" width="200" height="30.20472440944882" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="213.0236220472441" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="221.1259842519685" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00059C00</text>
-<text x="295" y="212.0236220472441" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="163.71653543307085" width="200" height="30.20472440944882" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="182.81889763779526" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="190.92125984251967" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005AC00</text>
-<text x="295" y="181.81889763779526" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.55118110236218" width="200" height="105.16535433070867" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="115.1338582677165" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="160.71653543307085" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005BC00</text>
-<text x="295" y="114.1338582677165" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
+<text x="295" y="339.23622047244095" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">362 KB</text>
+<rect x="90" y="192.26771653543307" width="200" height="30.20472440944882" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="211.37007874015748" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="219.4724409448819" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005A800</text>
+<text x="295" y="210.37007874015748" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="162.06299212598424" width="200" height="30.20472440944882" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="181.16535433070865" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="189.26771653543307" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005B800</text>
+<text x="295" y="180.16535433070865" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.55118110236218" width="200" height="103.51181102362206" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="114.30708661417322" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="159.06299212598424" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005C800</text>
+<text x="295" y="113.30708661417322" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
 <rect x="90" y="29.999999999999975" width="200" height="28.551181102362204" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="190.0" y="48.275590551181075" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
 <text x="86" y="55.55118110236218" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EC00</text>
 <text x="295" y="47.275590551181075" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="26.999999999999975" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.5989583333333" width="200" height="28.401041666666668" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.79947916666663" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.5625" width="200" height="28.4375" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.78125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.79947916666663" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="377.15625" width="200" height="44.44270833333333" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="403.3776041666667" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.5989583333333" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="402.3776041666667" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="308.25" width="200" height="68.90625" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="346.703125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="374.15625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="345.703125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="30.0" width="200" height="278.25" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="173.125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="305.25" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="172.125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
+<text x="775" y="438.78125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="331.0" width="200" height="90.5625" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="380.28125" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.5625" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="379.28125" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="30.0" width="200" height="301.0" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="184.5" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="328.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="183.5" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">78 KB</text>
 <text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (508 KB)</text>
-<rect x="90" y="411.748031496063" width="200" height="38.25196850393701" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="434.8740157480315" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="410.03937007874015" width="200" height="39.960629921259844" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="434.0196850393701" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="433.8740157480315" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="382.4251968503937" width="200" height="29.322834645669293" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="401.0866141732284" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="408.748031496063" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="400.0866141732284" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="353.10236220472444" width="200" height="29.322834645669293" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="371.7637795275591" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="379.4251968503937" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="370.7637795275591" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="324.77165354330714" width="200" height="28.330708661417322" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="342.9370078740158" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="350.10236220472444" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="341.9370078740158" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="210.7874015748032" width="200" height="113.98425196850394" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="271.77952755905517" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="321.77165354330714" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="270.77952755905517" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">260 KB</text>
-<rect x="90" y="161.62204724409455" width="200" height="49.16535433070866" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="190.2047244094489" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="207.7874015748032" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0004B000</text>
-<text x="295" y="189.2047244094489" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="133.2913385826772" width="200" height="28.330708661417322" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="151.45669291338587" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="158.62204724409455" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005B000</text>
-<text x="295" y="150.45669291338587" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.16535433070871" width="200" height="75.1259842519685" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="99.72834645669296" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="130.2913385826772" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005B400</text>
-<text x="295" y="98.72834645669296" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="30.000000000000046" width="200" height="28.165354330708663" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.082677165354376" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.16535433070871" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EE00</text>
-<text x="295" y="47.082677165354376" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="27.000000000000046" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
+<text x="295" y="433.0196850393701" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="380.496062992126" width="200" height="29.543307086614174" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="399.26771653543307" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="407.03937007874015" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="398.26771653543307" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="350.9527559055118" width="200" height="29.543307086614174" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="369.7244094488189" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="377.496062992126" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="368.7244094488189" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="322.56692913385825" width="200" height="28.385826771653544" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="340.75984251968504" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="347.9527559055118" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="339.75984251968504" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="192.70866141732284" width="200" height="129.8582677165354" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="261.6377952755905" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="319.56692913385825" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="260.6377952755905" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">264 KB</text>
+<rect x="90" y="140.01574803149606" width="200" height="52.69291338582677" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="170.36220472440945" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="189.70866141732284" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0004C000</text>
+<text x="295" y="169.36220472440945" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.192913385826756" width="200" height="81.8228346456693" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="103.10433070866141" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="137.01574803149606" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0005C000</text>
+<text x="295" y="102.10433070866141" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="29.999999999999986" width="200" height="28.19291338582677" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.09645669291337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.192913385826756" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007EE00</text>
+<text x="295" y="47.09645669291337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0007F000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (96 KB)</text>
-<rect x="570" y="421.6354166666667" width="200" height="28.364583333333332" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.81770833333337" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.59580052493436" width="200" height="28.404199475065617" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.7979002624672" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.81770833333337" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="378.6875" width="200" height="42.947916666666664" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="404.1614583333333" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.6354166666667" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="403.1614583333333" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="313.5" width="200" height="65.1875" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="350.09375" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="375.6875" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="349.09375" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="60.91666666666666" width="200" height="252.58333333333334" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="191.20833333333331" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="310.5" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="190.20833333333331" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">77 KB</text>
-<rect x="570" y="29.99999999999999" width="200" height="30.916666666666668" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="49.45833333333332" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="57.91666666666666" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017C00</text>
-<text x="775" y="48.45833333333332" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.99999999999999" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
+<text x="775" y="438.7979002624672" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="335.79527559055117" width="200" height="85.80052493438319" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="382.69553805774274" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.59580052493436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="381.69553805774274" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.80839895013122" width="200" height="276.98687664041995" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="201.3018372703412" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="332.79527559055117" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="200.3018372703412" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">77 KB</text>
+<rect x="570" y="29.999999999999986" width="200" height="28.808398950131235" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.4041994750656" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.80839895013122" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20017F00</text>
+<text x="775" y="47.4041994750656" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20018000</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="172.71146245059288" width="200" height="277.2885375494071" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="315.35573122529644" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="172.43478260869563" width="200" height="277.5652173913044" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="315.2173913043478" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="314.35573122529644" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">901 KB</text>
-<rect x="90" y="143.60474308300394" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="162.1581027667984" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="169.71146245059288" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E1400</text>
-<text x="295" y="161.1581027667984" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="114.498023715415" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="133.05138339920947" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="140.60474308300394" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2400</text>
-<text x="295" y="132.05138339920947" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.27667984189722" width="200" height="56.22134387351778" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="90.38735177865611" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="111.498023715415" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3400</text>
-<text x="295" y="89.38735177865611" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">102 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.1383399209486" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.27667984189722" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
-<text x="295" y="47.1383399209486" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="314.2173913043478" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">902 KB</text>
+<rect x="90" y="143.3280632411067" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="161.88142292490116" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="169.43478260869563" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E1800</text>
+<text x="295" y="160.88142292490116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="114.22134387351775" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="132.77470355731222" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="140.3280632411067" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2800</text>
+<text x="295" y="131.77470355731222" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.2766798418972" width="200" height="55.944664031620555" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="90.24901185770747" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="111.22134387351775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3800</text>
+<text x="295" y="89.24901185770747" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<rect x="90" y="29.999999999999964" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.13833992094858" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.2766798418972" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
+<text x="295" y="47.13833992094858" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.7987585756289" width="200" height="28.20124142437112" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.89937928781444" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7804639006861" width="200" height="28.21953609931395" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89023195034304" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.89937928781444" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="387.1577915713819" width="200" height="34.640967004246974" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.47827507350536" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.7987585756289" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.47827507350536" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="338.63116628552757" width="200" height="48.526625285854294" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="366.8944789284547" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="384.15779157138184" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="365.8944789284547" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="29.999999999999943" width="200" height="308.6311662855276" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="188.31558314276376" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="335.63116628552757" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="187.31558314276376" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174.3 KB</text>
-<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FD40</text>
+<text x="775" y="438.89023195034304" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="364.14309049330285" width="200" height="57.63737340738321" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="396.96177719699443" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.7804639006861" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="395.96177719699443" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="30.0" width="200" height="334.14309049330285" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="201.07154524665143" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="361.14309049330285" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="200.07154524665143" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">174.3 KB</text>
+<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FD40</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="416.85375494071144" width="200" height="33.14624505928854" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="437.4268774703557" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="415.99604743083006" width="200" height="34.00395256916996" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="436.99802371541506" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="436.4268774703557" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="388.18972332015807" width="200" height="28.66403162055336" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="406.52173913043475" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="413.85375494071144" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="405.52173913043475" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="359.5256916996047" width="200" height="28.66403162055336" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="377.8577075098814" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="385.18972332015807" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="376.8577075098814" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="331.3596837944664" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="349.44268774703556" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="356.5256916996047" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="348.44268774703556" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="170.22134387351775" width="200" height="161.13833992094862" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="254.79051383399207" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="328.3596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="253.79051383399207" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">802 KB</text>
-<rect x="90" y="131.596837944664" width="200" height="38.62450592885375" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="154.90909090909088" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="167.22134387351775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D2800</text>
-<text x="295" y="153.90909090909088" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="103.43083003952566" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="121.51383399209483" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="128.596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2800</text>
-<text x="295" y="120.51383399209483" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.083003952569136" width="200" height="45.34782608695652" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="84.7569169960474" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="100.43083003952566" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E2C00</text>
-<text x="295" y="83.7569169960474" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">104.5 KB</text>
-<rect x="90" y="29.999999999999964" width="200" height="28.08300395256917" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.04150197628455" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.083003952569136" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
-<text x="295" y="47.04150197628455" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="435.99802371541506" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="387.2213438735178" width="200" height="28.774703557312254" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="405.60869565217394" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="412.99604743083006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="404.60869565217394" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="358.44664031620556" width="200" height="28.774703557312254" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="376.8339920948617" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="384.2213438735178" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="375.8339920948617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="330.2529644268775" width="200" height="28.193675889328063" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="348.3498023715415" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="355.44664031620556" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="347.3498023715415" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="146.53754940711465" width="200" height="183.71541501976284" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="242.39525691699606" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="327.2529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="241.39525691699606" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">804 KB</text>
+<rect x="90" y="106.1422924901186" width="200" height="40.39525691699605" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="130.33992094861662" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="143.53754940711465" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D3000</text>
+<text x="295" y="129.33992094861662" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.09683794466406" width="200" height="48.04545454545455" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="86.11956521739134" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="103.1422924901186" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000E3000</text>
+<text x="295" y="85.11956521739134" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">103.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.09683794466403" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.048418972332044" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
+<text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.81675392670155" width="200" height="28.18324607329843" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.90837696335075" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7976346911958" width="200" height="28.202365308804204" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89881734559793" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.90837696335075" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="387.76963350785337" width="200" height="34.047120418848166" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.79319371727746" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.81675392670155" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.79319371727746" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4.1 KB</text>
-<rect x="570" y="341.0785340314136" width="200" height="46.69109947643979" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="368.4240837696335" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="384.76963350785337" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001100</text>
-<text x="775" y="367.4240837696335" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.46596858638742" width="200" height="281.6125654450262" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="204.2722513089005" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="338.0785340314136" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
-<text x="775" y="203.2722513089005" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173 KB</text>
-<rect x="570" y="29.999999999999986" width="200" height="29.465968586387433" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.7329842931937" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.46596858638742" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002F800</text>
-<text x="775" y="47.7329842931937" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
+<text x="775" y="438.89881734559793" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="366.47831800262816" width="200" height="55.319316688567675" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="398.137976346912" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.7976346911958" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="397.137976346912" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">16.9 KB</text>
+<rect x="570" y="58.404730617608436" width="200" height="308.0735873850197" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="216.4415243101183" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="363.47831800262816" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004400</text>
+<text x="775" y="215.4415243101183" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173 KB</text>
+<rect x="570" y="30.000000000000025" width="200" height="28.40473061760841" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.20236530880423" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.404730617608436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FB00</text>
+<text x="775" y="47.20236530880423" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000025" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.svg
@@ -4,43 +4,39 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="183.22529644268775" width="200" height="266.77470355731225" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="320.6126482213439" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<rect x="90" y="182.39525691699606" width="200" height="267.60474308300394" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="320.197628458498" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="319.6126482213439" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">863 KB</text>
-<rect x="90" y="154.1185770750988" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="172.67193675889328" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="180.22529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D7C00</text>
-<text x="295" y="171.67193675889328" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="125.01185770750988" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="143.56521739130434" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="151.1185770750988" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D8C00</text>
-<text x="295" y="142.56521739130434" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="58.27667984189722" width="200" height="66.73517786561266" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="95.64426877470355" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="122.01185770750988" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9C00</text>
-<text x="295" y="94.64426877470355" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">140 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.1383399209486" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="55.27667984189722" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
-<text x="295" y="47.1383399209486" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="319.197628458498" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">866 KB</text>
+<rect x="90" y="153.28853754940712" width="200" height="29.106719367588934" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="171.8418972332016" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="179.39525691699606" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D8800</text>
+<text x="295" y="170.8418972332016" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="124.18181818181819" width="200" height="29.106719367588934" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="142.73517786561266" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="150.28853754940712" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9800</text>
+<text x="295" y="141.73517786561266" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.27667984189725" width="200" height="65.90513833992094" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="95.22924901185772" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="121.18181818181819" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000DA800</text>
+<text x="295" y="94.22924901185772" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<rect x="90" y="30.000000000000014" width="200" height="28.276679841897234" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.13833992094863" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.27667984189725" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
+<text x="295" y="47.13833992094863" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="27.000000000000014" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.7987585756289" width="200" height="28.20124142437112" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.89937928781444" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7804639006861" width="200" height="28.21953609931395" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89023195034304" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.89937928781444" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="385.54786017641294" width="200" height="36.25089839921594" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="407.67330937602094" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.7987585756289" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="406.67330937602094" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="337.0212348905586" width="200" height="48.526625285854294" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="365.28454753348575" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="382.5478601764129" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="364.28454753348575" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="29.999999999999943" width="200" height="307.0212348905587" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="187.51061744527928" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="334.0212348905586" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="186.51061744527928" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173.3 KB</text>
-<text x="566" y="26.999999999999943" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FD40</text>
+<text x="775" y="438.89023195034304" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="362.38680169879126" width="200" height="59.393662201894806" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="396.08363279973867" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.7804639006861" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="395.08363279973867" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="30.0" width="200" height="332.38680169879126" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="200.19340084939563" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="359.38680169879126" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="199.19340084939563" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">173.3 KB</text>
+<text x="566" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FD40</text>
 </svg>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.svg
@@ -4,63 +4,55 @@
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
   <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (1012 KB)</text>
-<rect x="90" y="416.85375494071144" width="200" height="33.14624505928854" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="437.4268774703557" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
+<rect x="90" y="415.99604743083006" width="200" height="34.00395256916996" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="436.99802371541506" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="436.4268774703557" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
-<rect x="90" y="388.18972332015807" width="200" height="28.66403162055336" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="406.52173913043475" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="413.85375494071144" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
-<text x="295" y="405.52173913043475" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="359.5256916996047" width="200" height="28.66403162055336" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="377.8577075098814" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="385.18972332015807" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
-<text x="295" y="376.8577075098814" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="331.3596837944664" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="349.44268774703556" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="356.5256916996047" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
-<text x="295" y="348.44268774703556" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="176.5296442687747" width="200" height="154.8300395256917" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="257.9446640316205" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
-<text x="86" y="328.3596837944664" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
-<text x="295" y="256.9446640316205" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">764 KB</text>
-<rect x="90" y="137.90513833992094" width="200" height="38.62450592885375" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="161.2173913043478" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
-<text x="86" y="173.5296442687747" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000C9000</text>
-<text x="295" y="160.2173913043478" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
-<rect x="90" y="109.7391304347826" width="200" height="28.16600790513834" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="127.82213438735177" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
-<text x="86" y="134.90513833992094" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9000</text>
-<text x="295" y="126.82213438735177" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<rect x="90" y="58.08300395256916" width="200" height="51.65612648221344" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="87.91106719367588" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="106.7391304347826" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000D9400</text>
-<text x="295" y="86.91106719367588" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">142.5 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="28.08300395256917" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="48.04150197628457" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
-<text x="86" y="55.08300395256916" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
-<text x="295" y="47.04150197628457" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
+<text x="295" y="435.99802371541506" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">31 KB</text>
+<rect x="90" y="387.2213438735178" width="200" height="28.774703557312254" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="405.60869565217394" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="412.99604743083006" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00007C00</text>
+<text x="295" y="404.60869565217394" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="358.44664031620556" width="200" height="28.774703557312254" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="376.8339920948617" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="384.2213438735178" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00008C00</text>
+<text x="295" y="375.8339920948617" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="330.2529644268775" width="200" height="28.193675889328063" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="348.3498023715415" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="355.44664031620556" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00009C00</text>
+<text x="295" y="347.3498023715415" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<rect x="90" y="153.50988142292493" width="200" height="176.74308300395256" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="245.88142292490122" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+<text x="86" y="327.2529644268775" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0000A000</text>
+<text x="295" y="244.88142292490122" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">768 KB</text>
+<rect x="90" y="113.11462450592889" width="200" height="40.39525691699605" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="137.3122529644269" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Firmware Loader (slot1)</text>
+<text x="86" y="150.50988142292493" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000CA000</text>
+<text x="295" y="136.3122529644269" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">64 KB</text>
+<rect x="90" y="58.09683794466406" width="200" height="55.01778656126483" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="89.60573122529647" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="110.11462450592889" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000DA000</text>
+<text x="295" y="88.60573122529647" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">139.5 KB</text>
+<rect x="90" y="30.00000000000003" width="200" height="28.09683794466403" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.048418972332044" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Metadata</text>
+<text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
+<text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
+<text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
   <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
-<rect x="570" y="421.81675392670155" width="200" height="28.18324607329843" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="439.90837696335075" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
+<rect x="570" y="421.7976346911958" width="200" height="28.202365308804204" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="439.89881734559793" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>
-<text x="775" y="438.90837696335075" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
-<rect x="570" y="386.30366492146595" width="200" height="35.5130890052356" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="408.0602094240837" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Static RAM</text>
-<text x="566" y="418.81675392670155" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
-<text x="775" y="407.0602094240837" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">5.1 KB</text>
-<rect x="570" y="339.6125654450262" width="200" height="46.69109947643979" fill="#00a2c6" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="366.9581151832461" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice Dynamic RAM</text>
-<text x="566" y="383.30366492146595" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20001500</text>
-<text x="775" y="365.9581151832461" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">12.8 KB</text>
-<rect x="570" y="59.46596858638742" width="200" height="280.14659685863876" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="203.5392670157068" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
-<text x="566" y="336.6125654450262" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
-<text x="775" y="202.5392670157068" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">172 KB</text>
-<rect x="570" y="29.999999999999986" width="200" height="29.465968586387433" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="670.0" y="48.7329842931937" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
-<text x="566" y="56.46596858638742" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002F800</text>
-<text x="775" y="47.7329842931937" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
-<text x="566" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
+<text x="775" y="438.89881734559793" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">128 B</text>
+<rect x="570" y="364.8593955321945" width="200" height="56.93823915900131" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="397.3285151116952" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice RAM</text>
+<text x="566" y="418.79763469119587" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000080</text>
+<text x="775" y="396.3285151116952" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">17.9 KB</text>
+<rect x="570" y="58.404730617608436" width="200" height="306.4546649145861" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="215.63206307490148" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application RAM</text>
+<text x="566" y="361.8593955321945" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20004800</text>
+<text x="775" y="214.63206307490148" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">172 KB</text>
+<rect x="570" y="30.000000000000025" width="200" height="28.40473061760841" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="670.0" y="48.20236530880423" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Retained RAM</text>
+<text x="566" y="55.404730617608436" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FB00</text>
+<text x="775" y="47.20236530880423" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">256 B</text>
+<text x="566" y="27.000000000000025" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x2002FC00</text>
 </svg>

--- a/doc/nrf-bm/boards/memory_layout.rst
+++ b/doc/nrf-bm/boards/memory_layout.rst
@@ -67,12 +67,9 @@ SRAM partitions
    * - KMU reserved
      - —
      - 128 bytes reserved by the Key Management Unit at the start of SRAM (synthetic region, no partition label in DTS).
-   * - SoftDevice Static RAM
-     - ``softdevice_static_ram``
-     - Statically allocated RAM for the SoftDevice. Size depends on the SoftDevice variant (S115 vs S145).
-   * - SoftDevice Dynamic RAM
-     - ``softdevice_dynamic_ram``
-     - Dynamically allocated RAM for the SoftDevice (connections, buffers).
+   * - SoftDevice RAM
+     - ``softdevice_ram``
+     - Allocated RAM for the SoftDevice. Consists of SoftDevice static RAM with a size depending on the SoftDevice variant (S115 vs S145) and SoftDevice Dynamic RAM with a size depending on the number of connections and required buffer sizes.
    * - Application RAM
      - ``app_ram``
      - RAM available for the application.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -56,6 +56,7 @@ Boards
    * The SRAM sizes for the ``bm_nrf54l15dk`` board target to not overlap with VPR context.
    * The board memory layout for all boards to align with the new SoftDevice.
    * The LPUARTE pins in ``board-config.h`` for ``bm_nrf54l15dk`` to avoid conflicts for LEDs, buttons and other peripherals where possible.
+   * The board RAM memory layout for all boards with one node for SoftDevice RAM, combining the static and dynamic nodes to simplify the representation.
 
 * Disabled all Peripheral Resource Sharing (PRS) boxes for the ``bm_nrf54l15dk`` board variants.
 


### PR DESCRIPTION
The nodes for SoftDevice allocated RAM is thus far not referenced in code. When modifying the allocated RAM for SoftDevice, there is no real need to distinguish between static and dynamic RAM. When getting numbers on the needed or required RAM
from the SoftDevice on initialization there is no distinction between static and dynamic.
The static RAM size is equal to the minimum size of the combined node.

Also update the board layout images in documentation after numerous changes to dts files.