### PR TITLE
ble_bas: return raw SoftDevice error from service API

### DIFF
--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -70,9 +70,10 @@ void battery_level_meas_timeout_handler(void *context)
 
 	nrf_err = ble_bas_battery_level_update(&ble_bas, conn_handle, battery_level);
 	if (nrf_err) {
-		/* Ignore if not in a connection or notifications disabled in CCCD. */
+		/* Ignore if not connected, or CCCD not written/configured by peer. */
 		if (nrf_err != BLE_ERROR_INVALID_CONN_HANDLE &&
-		    nrf_err != NRF_ERROR_INVALID_STATE) {
+		    nrf_err != NRF_ERROR_INVALID_STATE &&
+		    nrf_err != BLE_ERROR_GATTS_SYS_ATTR_MISSING) {
 			LOG_ERR("Failed to update battery level, nrf_error %#x", nrf_err);
 		}
 	}

--- a/subsys/bluetooth/services/ble_bas/bas.c
+++ b/subsys/bluetooth/services/ble_bas/bas.c
@@ -222,12 +222,6 @@ uint32_t ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle,
 	nrf_err = sd_ble_gatts_hvx(conn_handle, &hvx);
 	if (nrf_err) {
 		LOG_DBG("Failed to notify battery level, nrf_error %#x", nrf_err);
-
-		if (nrf_err == BLE_ERROR_GATTS_SYS_ATTR_MISSING) {
-			/* CCCD value is unknown. Treat as if notifications are not enabled. */
-			nrf_err = NRF_ERROR_INVALID_STATE;
-		}
-
 		return nrf_err;
 	}
 


### PR DESCRIPTION
Stop converting BLE_ERROR_GATTS_SYS_ATTR_MISSING to NRF_ERROR_INVALID_STATE inside ble_bas_battery_level_update. Return the SoftDevice error directly and let the application decide how to handle it.

Update the HRS sample to also ignore BLE_ERROR_GATTS_SYS_ATTR_MISSING alongside NRF_ERROR_INVALID_STATE and BLE_ERROR_INVALID_CONN_HANDLE when updating the battery level.