### PR TITLE
doc: nrf-bm: app_dev: dfu: bootloader_keys: Embeeded key record

### DIFF
--- a/doc/nrf-bm/app_dev/dfu/bootloader_keys.rst
+++ b/doc/nrf-bm/app_dev/dfu/bootloader_keys.rst
@@ -13,6 +13,7 @@ Signature type
 
 MCUboot in |BMshort| allow a few signatures types.
 The ED25519 signature type is recommended as supported for nRF54L Series devices with cryptographic hardware support (CRACEN and KMU).
+The ED25519 signature type is available for nRF54LS05B devices as well, but it is supported by software only (``nrf_oberon``).
 It is recommended to use the pure version of the ED25519 signature (:kconfig:option:`SB_CONFIG_BM_BOOT_IMG_HASH_ALG_PURE`).
 The rest of the signature types are for evaluation purpose only and are inherited from the MCUboot project.
 
@@ -50,6 +51,11 @@ You can also provide the sysbuild Kconfig option during compilation.
 
 KMU (Key Management Unit)
 *************************
+
+.. note::
+   KMU support is available for nRF54L15, nRF54L10, nRF54L05, nRF54LM20 and nRF54LV10 devices.
+   For nRF54LS05B devices, the bootloader will use one embedded key.
+   For more information, see :ref:`ug_bootloader_keys_embedded`.
 
 Most nRF54L Series devices include the Key Management Unit (KMU) hardware peripheral.
 This on-die module is designed to work with the CRACEN hardware accelerator, enabling secure storage and usage of cryptographic keys.
@@ -99,3 +105,12 @@ The last remaining key cannot be invalidated.
 To enable the Kconfig options for the MCUboot image, edit the :file:`sysbuild/mcuboot.conf` file in your application directory.
 For most of the samples, you must create the :file:`sysbuild` folder and the :file:`sysbuild/mcuboot.conf` file.
 This file applies to the MCUboot image only and is edited the same way as the :file:`prj.conf` file is used for your application image.
+
+.. _ug_bootloader_keys_embedded:
+
+Bootloader built-in Key
+***********************
+
+For nRF54LS05B devices, the bootloader will use one embedded key.
+This key is part of the bootloader image and it is unchangeable unless the bootloader is reprogrammed.
+For this method, no additional configuration or other actions are required for the bootloader to use the key.


### PR DESCRIPTION
Added info on embeeded key usage by MCUboot for
nRF54LS05 SoC