### PR TITLE
ble_hrs: return raw sd errors and improve test coverage

### DIFF
--- a/include/bm/bluetooth/services/ble_hrs.h
+++ b/include/bm/bluetooth/services/ble_hrs.h
@@ -222,17 +222,19 @@ uint32_t ble_hrs_init(struct ble_hrs *hrs, const struct ble_hrs_config *hrs_conf
 void ble_hrs_conn_params_evt(struct ble_hrs *hrs, const struct ble_conn_params_evt *conn_param_evt);
 
 /**
- * @brief Function for sending heart rate measurement if notification has been enabled.
+ * @brief Send a heart rate measurement notification.
  *
- * @details The application calls this function after having performed a heart rate measurement.
- *          If notification has been enabled, the heart rate measurement data is encoded and sent to
- *          the client.
+ * @details Reads the CCCD to check whether the peer has enabled notifications.
+ *          If enabled, encodes the heart rate measurement and sends it as a BLE notification.
+ *          If notifications are not enabled or the CCCD state is unknown,
+ *          no data is sent and the function returns an error.
  *
  * @param hrs Heart rate service.
- * @param heart_rate heart rate Measurement.
+ * @param heart_rate Heart rate measurement in beats per minute.
  *
  * @retval NRF_SUCCESS On success.
  * @retval NRF_ERROR_NULL If @p hrs is @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE CCCD Notification bit is not set by the peer.
  * @return In addition, this function may return any error
  *         returned by the following SoftDevice functions:
  *         - @ref sd_ble_gatts_value_get()

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -95,9 +95,10 @@ static void heart_rate_meas_timeout_handler(void *context)
 
 	nrf_err = ble_hrs_heart_rate_measurement_send(&ble_hrs, (uint16_t)heart_rate);
 	if (nrf_err) {
-		/* Ignore if not in a connection or notifications disabled in CCCD. */
+		/* Ignore if not connected, or CCCD not written/configured by peer. */
 		if (nrf_err != BLE_ERROR_INVALID_CONN_HANDLE &&
-		    nrf_err != NRF_ERROR_INVALID_STATE) {
+		    nrf_err != NRF_ERROR_INVALID_STATE &&
+		    nrf_err != BLE_ERROR_GATTS_SYS_ATTR_MISSING) {
 			LOG_ERR("Failed to send heart rate measurement, nrf_error %#x", nrf_err);
 		}
 	}

--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -275,12 +275,7 @@ uint32_t ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart
 	/* Get heart rate measurement CCCD value. */
 	nrf_err = sd_ble_gatts_value_get(hrs->conn_handle, hrs->hrm_handles.cccd_handle, &cccd_val);
 	if (nrf_err) {
-		if (nrf_err == BLE_ERROR_GATTS_SYS_ATTR_MISSING) {
-			/* CCCD value is unknown. Do not notify. */
-			return NRF_ERROR_INVALID_STATE;
-		} else {
-			return nrf_err;
-		}
+		return nrf_err;
 	}
 
 	/* CCCD read success. Check if peer has enabled notifications. */
@@ -299,7 +294,7 @@ uint32_t ble_hrs_heart_rate_measurement_send(struct ble_hrs *hrs, uint16_t heart
 
 	nrf_err = sd_ble_gatts_hvx(hrs->conn_handle, &hvx);
 	if (nrf_err) {
-		LOG_ERR("Failed to notify heart rate measurement, nrf_error %#x", nrf_err);
+		LOG_DBG("Failed to notify heart rate measurement, nrf_error %#x", nrf_err);
 		return nrf_err;
 	}
 

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -676,6 +676,43 @@ void test_ble_hrs_init_invalid_param(void)
 	TEST_ASSERT_EQUAL(ERROR, nrf_err);
 }
 
+void test_ble_hrs_init_hrm_char_add_error(void)
+{
+	/* Service add succeeds but HRM characteristic add fails. */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {0};
+	struct ble_hrs_config cfg = {
+		.is_sensor_contact_supported = true,
+		.body_sensor_location = (uint8_t[]){ BLE_HRS_BODY_SENSOR_LOCATION_FINGER }
+	};
+
+	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
+	/* HRM is the first characteristic_add call — make it fail. */
+	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(ERROR);
+
+	nrf_err = ble_hrs_init(&hrs, &cfg);
+	TEST_ASSERT_EQUAL(ERROR, nrf_err);
+}
+
+void test_ble_hrs_init_bsl_char_add_error(void)
+{
+	/* Service and HRM characteristic add succeed, but BSL characteristic add fails. */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {0};
+	struct ble_hrs_config cfg = {
+		.is_sensor_contact_supported = true,
+		.body_sensor_location = (uint8_t[]){ BLE_HRS_BODY_SENSOR_LOCATION_FINGER }
+	};
+
+	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
+	/* First call (HRM) succeeds, second call (BSL) fails. */
+	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_SUCCESS);
+	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(ERROR);
+
+	nrf_err = ble_hrs_init(&hrs, &cfg);
+	TEST_ASSERT_EQUAL(ERROR, nrf_err);
+}
+
 extern int unity_main(void);
 
 int main(void)

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -13,8 +13,18 @@
 
 #include "cmock_ble_gatts.h"
 
+/* Simulated connection handle for test events. */
+#define TEST_CONN_HANDLE 0x0001
+
+/* Simulated CCCD handle for write event tests. */
+#define TEST_CCCD_HANDLE 0x0010
+
 /* An arbitrary error, to test forwarding of errors from SoftDevice calls */
 #define ERROR 0xbaadf00d
+
+/* State captured by stub_hrs_evt_handler() for post-call verification. */
+static bool evt_handler_called;
+static struct ble_hrs_evt received_evt;
 
 /* Captured HVX payload from stub_sd_ble_gatts_hvx_capture() for post-call verification. */
 static uint8_t captured_hvx_data[20];
@@ -51,6 +61,13 @@ static uint32_t stub_sd_ble_gatts_characteristic_add(uint16_t service_handle,
 	return NRF_SUCCESS;
 }
 
+static void stub_hrs_evt_handler(struct ble_hrs *hrs, const struct ble_hrs_evt *evt)
+{
+	/* Stub event handler that captures the event for post-call verification. */
+	evt_handler_called = true;
+	received_evt = *evt;
+}
+
 static uint32_t stub_sd_ble_gatts_hvx_capture(uint16_t conn_handle,
 					      const ble_gatts_hvx_params_t *p_hvx_params,
 					      int calls)
@@ -59,6 +76,159 @@ static uint32_t stub_sd_ble_gatts_hvx_capture(uint16_t conn_handle,
 	captured_hvx_len = *p_hvx_params->p_len;
 	memcpy(captured_hvx_data, p_hvx_params->p_data, captured_hvx_len);
 	return NRF_SUCCESS;
+}
+
+void test_ble_hrs_on_ble_evt_disconnect(void)
+{
+	/* Simulate connect then disconnect, verify conn_handle resets to invalid. */
+	struct ble_hrs hrs = {0};
+	const ble_evt_t connect_evt = {
+		.header.evt_id = BLE_GAP_EVT_CONNECTED,
+		.evt.gap_evt.conn_handle = TEST_CONN_HANDLE,
+	};
+	const ble_evt_t disconnect_evt = {
+		.header.evt_id = BLE_GAP_EVT_DISCONNECTED,
+		.evt.gap_evt.conn_handle = TEST_CONN_HANDLE,
+	};
+
+	/* First connect so conn_handle is valid. */
+	ble_hrs_on_ble_evt(&connect_evt, &hrs);
+	TEST_ASSERT_EQUAL(TEST_CONN_HANDLE, hrs.conn_handle);
+
+	/* Now disconnect. */
+	ble_hrs_on_ble_evt(&disconnect_evt, &hrs);
+	TEST_ASSERT_EQUAL(BLE_CONN_HANDLE_INVALID, hrs.conn_handle);
+}
+
+void test_ble_hrs_on_ble_evt_disconnect_when_already_disconnected(void)
+{
+	/* Receiving a disconnect event when not connected should be safely ignored. */
+	struct ble_hrs hrs = {
+		.conn_handle = BLE_CONN_HANDLE_INVALID,
+	};
+	const ble_evt_t disconnect_evt = {
+		.header.evt_id = BLE_GAP_EVT_DISCONNECTED,
+		.evt.gap_evt.conn_handle = TEST_CONN_HANDLE,
+	};
+
+	ble_hrs_on_ble_evt(&disconnect_evt, &hrs);
+	TEST_ASSERT_EQUAL(BLE_CONN_HANDLE_INVALID, hrs.conn_handle);
+}
+
+void test_ble_hrs_on_ble_evt_write_notification_enabled(void)
+{
+	/* Peer writes to CCCD enabling notifications. */
+	struct ble_hrs hrs = {
+		.evt_handler = stub_hrs_evt_handler,
+		.hrm_handles.cccd_handle = TEST_CCCD_HANDLE,
+	};
+
+	/* Allocate extra space for the CCCD write data (flexible array member). */
+	uint8_t evt_buf[sizeof(ble_evt_t) + 2] = {0};
+	ble_evt_t *evt = (ble_evt_t *)evt_buf;
+
+	/* Build a CCCD write event with notifications enabled.
+	 * CCCD value is 16-bit little-endian: 0x0001 = [0x01, 0x00].
+	 */
+	evt->header.evt_id = BLE_GATTS_EVT_WRITE;
+	evt->evt.gatts_evt.conn_handle = TEST_CONN_HANDLE;
+	evt->evt.gatts_evt.params.write.handle = TEST_CCCD_HANDLE;
+	evt->evt.gatts_evt.params.write.len = 2;
+	evt->evt.gatts_evt.params.write.data[0] = BLE_GATT_HVX_NOTIFICATION;
+	evt->evt.gatts_evt.params.write.data[1] = 0x00;
+
+	evt_handler_called = false;
+	ble_hrs_on_ble_evt(evt, &hrs);
+
+	TEST_ASSERT_TRUE(evt_handler_called);
+	TEST_ASSERT_EQUAL(BLE_HRS_EVT_NOTIFICATION_ENABLED, received_evt.evt_type);
+	TEST_ASSERT_EQUAL(TEST_CONN_HANDLE, received_evt.conn_handle);
+}
+
+void test_ble_hrs_on_ble_evt_write_notification_disabled(void)
+{
+	/* Peer writes to CCCD disabling notifications. */
+	struct ble_hrs hrs = {
+		.evt_handler = stub_hrs_evt_handler,
+		.hrm_handles.cccd_handle = TEST_CCCD_HANDLE,
+	};
+
+	/* Allocate extra space for the CCCD write data (flexible array member). */
+	uint8_t evt_buf[sizeof(ble_evt_t) + 2] = {0};
+	ble_evt_t *evt = (ble_evt_t *)evt_buf;
+
+	/* Build a CCCD write event with notifications disabled.
+	 * CCCD value is 16-bit little-endian: 0x0000 = [0x00, 0x00].
+	 */
+	evt->header.evt_id = BLE_GATTS_EVT_WRITE;
+	evt->evt.gatts_evt.conn_handle = TEST_CONN_HANDLE;
+	evt->evt.gatts_evt.params.write.handle = TEST_CCCD_HANDLE;
+	evt->evt.gatts_evt.params.write.len = 2;
+	evt->evt.gatts_evt.params.write.data[0] = BLE_GATT_HVX_INVALID;
+	evt->evt.gatts_evt.params.write.data[1] = 0x00;
+
+	evt_handler_called = false;
+	ble_hrs_on_ble_evt(evt, &hrs);
+
+	TEST_ASSERT_TRUE(evt_handler_called);
+	TEST_ASSERT_EQUAL(BLE_HRS_EVT_NOTIFICATION_DISABLED, received_evt.evt_type);
+	TEST_ASSERT_EQUAL(TEST_CONN_HANDLE, received_evt.conn_handle);
+}
+
+void test_ble_hrs_on_ble_evt_write_no_handler(void)
+{
+	/* No event handler registered, should return early without crash. */
+	struct ble_hrs hrs = {
+		.evt_handler = NULL,
+	};
+	ble_evt_t evt = {0};
+
+	evt.header.evt_id = BLE_GATTS_EVT_WRITE;
+	evt.evt.gatts_evt.conn_handle = TEST_CONN_HANDLE;
+
+	ble_hrs_on_ble_evt(&evt, &hrs);
+}
+
+void test_ble_hrs_on_ble_evt_write_wrong_handle(void)
+{
+	/* Write to a handle that is not the CCCD should be ignored. */
+	struct ble_hrs hrs = {
+		.evt_handler = stub_hrs_evt_handler,
+		.hrm_handles.cccd_handle = TEST_CCCD_HANDLE,
+	};
+	ble_evt_t evt = {0};
+
+	/* Build a write event targeting a different handle than the CCCD. */
+	evt.header.evt_id = BLE_GATTS_EVT_WRITE;
+	evt.evt.gatts_evt.conn_handle = TEST_CONN_HANDLE;
+	evt.evt.gatts_evt.params.write.handle = TEST_CCCD_HANDLE + 1;
+	evt.evt.gatts_evt.params.write.len = 2;
+
+	evt_handler_called = false;
+	ble_hrs_on_ble_evt(&evt, &hrs);
+
+	TEST_ASSERT_FALSE(evt_handler_called);
+}
+
+void test_ble_hrs_on_ble_evt_write_wrong_len(void)
+{
+	/* CCCD write with wrong length should be ignored. */
+	struct ble_hrs hrs = {
+		.evt_handler = stub_hrs_evt_handler,
+		.hrm_handles.cccd_handle = TEST_CCCD_HANDLE,
+	};
+	ble_evt_t evt = {0};
+
+	/* Build a CCCD write event with invalid length (expected 2 bytes). */
+	evt.header.evt_id = BLE_GATTS_EVT_WRITE;
+	evt.evt.gatts_evt.conn_handle = TEST_CONN_HANDLE;
+	evt.evt.gatts_evt.params.write.handle = TEST_CCCD_HANDLE;
+	evt.evt.gatts_evt.params.write.len = 1;
+
+	evt_handler_called = false;
+	ble_hrs_on_ble_evt(&evt, &hrs);
+
+	TEST_ASSERT_FALSE(evt_handler_called);
 }
 
 void test_ble_hrs_rr_interval_add_success(void)

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -616,6 +616,20 @@ void test_ble_hrs_heart_rate_measurement_send_with_rr_intervals_encoded(void)
 	TEST_ASSERT_EQUAL(6, captured_hvx_len);
 }
 
+void test_ble_hrs_heart_rate_measurement_send_cccd_read_error(void)
+{
+	/* sd_ble_gatts_value_get fails, error should be propagated. */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {
+		.conn_handle = BLE_CONN_HANDLE_INVALID,
+	};
+
+	__cmock_sd_ble_gatts_value_get_ExpectAnyArgsAndReturn(ERROR);
+
+	nrf_err = ble_hrs_heart_rate_measurement_send(&hrs, 72);
+	TEST_ASSERT_EQUAL(ERROR, nrf_err);
+}
+
 void test_ble_hrs_heart_rate_measurement_send(void)
 {
 	uint32_t nrf_err;

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -16,6 +16,10 @@
 /* An arbitrary error, to test forwarding of errors from SoftDevice calls */
 #define ERROR 0xbaadf00d
 
+/* Captured HVX payload from stub_sd_ble_gatts_hvx_capture() for post-call verification. */
+static uint8_t captured_hvx_data[20];
+static uint16_t captured_hvx_len;
+
 void ble_hrs_on_ble_evt(const ble_evt_t *evt, struct ble_hrs *hrs);
 
 static uint32_t stub_sd_ble_gatts_characteristic_add(uint16_t service_handle,
@@ -44,6 +48,16 @@ static uint32_t stub_sd_ble_gatts_characteristic_add(uint16_t service_handle,
 	TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
 	TEST_ASSERT_NOT_NULL(p_attr_char_value->p_value);
 
+	return NRF_SUCCESS;
+}
+
+static uint32_t stub_sd_ble_gatts_hvx_capture(uint16_t conn_handle,
+					      const ble_gatts_hvx_params_t *p_hvx_params,
+					      int calls)
+{
+	/* Captures the encoded HVX notification data for assertion in tests. */
+	captured_hvx_len = *p_hvx_params->p_len;
+	memcpy(captured_hvx_data, p_hvx_params->p_data, captured_hvx_len);
 	return NRF_SUCCESS;
 }
 
@@ -323,6 +337,113 @@ void test_ble_hrs_heart_rate_measurement_send_error_invalid_state(void)
 
 	nrf_err = ble_hrs_heart_rate_measurement_send(&hrs, heart_rate_measurement);
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_STATE, nrf_err);
+}
+
+void test_ble_hrs_heart_rate_measurement_send_sensor_contact_detected(void)
+{
+	/* Test that sensor contact detected flag is encoded in the HRM.
+	 * Flags byte layout: BIT(1) = contact detected, BIT(2) = contact supported.
+	 * With both set, flags should be 0x06.
+	 */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {
+		.service_handle = 0,
+		.conn_handle = BLE_CONN_HANDLE_INVALID,
+		.rr_interval_count = 0,
+		.max_hrm_len = 20,
+		.is_sensor_contact_supported = true,
+		.is_sensor_contact_detected = true
+	};
+
+	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get_notif_enabled);
+	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_capture);
+
+	nrf_err = ble_hrs_heart_rate_measurement_send(&hrs, 72);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Verify flags: BIT(2) sensor contact supported | BIT(1) sensor contact detected. */
+	TEST_ASSERT_EQUAL(0x06, captured_hvx_data[0]);
+}
+
+void test_ble_hrs_heart_rate_measurement_send_16bit_heart_rate(void)
+{
+	/* Test that heart rate > 255 triggers 16-bit encoding in hrm_encode.
+	 * 300 = 0x012C, encoded as two bytes: [0x2C, 0x01].
+	 * Flags byte: BIT(0) = 16-bit HR format.
+	 * Layout: [flags][hr_low][hr_high] -> len = 3.
+	 */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {
+		.service_handle = 0,
+		.conn_handle = BLE_CONN_HANDLE_INVALID,
+		.rr_interval_count = 0,
+		.max_hrm_len = 20,
+		.is_sensor_contact_supported = false,
+		.is_sensor_contact_detected = false
+	};
+
+	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get_notif_enabled);
+	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_capture);
+
+	nrf_err = ble_hrs_heart_rate_measurement_send(&hrs, 300);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Verify flags: BIT(0) = 16-bit heart rate format. */
+	TEST_ASSERT_EQUAL(0x01, captured_hvx_data[0]);
+	/* Verify 16-bit heart rate: 300 = 0x012C -> low byte, high byte. */
+	TEST_ASSERT_EQUAL(0x2C, captured_hvx_data[1]);
+	TEST_ASSERT_EQUAL(0x01, captured_hvx_data[2]);
+	/* flags(1) + hr(2) = 3 bytes total. */
+	TEST_ASSERT_EQUAL(3, captured_hvx_len);
+}
+
+void test_ble_hrs_heart_rate_measurement_send_with_rr_intervals_encoded(void)
+{
+	/* Test that RR intervals are actually encoded into the HRM payload when max_hrm_len
+	 * is large enough.
+	 *
+	 * Layout: [flags][hr][rr0_low][rr0_high][rr1_low][rr1_high] -> len = 6.
+	 * 800 = 0x0320, 850 = 0x0352.
+	 * Flags byte: BIT(4) = RR interval included.
+	 */
+	uint32_t nrf_err;
+	struct ble_hrs hrs = {
+		.service_handle = 0,
+		.conn_handle = BLE_CONN_HANDLE_INVALID,
+		.rr_interval_count = 0,
+		.max_hrm_len = 20,
+		.is_sensor_contact_supported = false,
+		.is_sensor_contact_detected = false
+	};
+
+	/* Pre-fill two RR intervals that will fit in the encoded buffer. */
+	nrf_err = ble_hrs_rr_interval_add(&hrs, 800);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	nrf_err = ble_hrs_rr_interval_add(&hrs, 850);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_EQUAL(2, hrs.rr_interval_count);
+
+	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get_notif_enabled);
+	__cmock_sd_ble_gatts_hvx_Stub(stub_sd_ble_gatts_hvx_capture);
+
+	nrf_err = ble_hrs_heart_rate_measurement_send(&hrs, 72);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+
+	/* Both RR intervals should have been consumed during encoding. */
+	TEST_ASSERT_EQUAL(0, hrs.rr_interval_count);
+
+	/* Verify flags: BIT(4) = RR interval included. */
+	TEST_ASSERT_EQUAL(0x10, captured_hvx_data[0]);
+	/* Verify heart rate. */
+	TEST_ASSERT_EQUAL(72, captured_hvx_data[1]);
+	/* Verify RR interval 800 = 0x0320: low byte, high byte. */
+	TEST_ASSERT_EQUAL(0x20, captured_hvx_data[2]);
+	TEST_ASSERT_EQUAL(0x03, captured_hvx_data[3]);
+	/* Verify RR interval 850 = 0x0352: low byte, high byte. */
+	TEST_ASSERT_EQUAL(0x52, captured_hvx_data[4]);
+	TEST_ASSERT_EQUAL(0x03, captured_hvx_data[5]);
+	/* flags(1) + hr(1) + 2*rr(2) = 6 bytes total. */
+	TEST_ASSERT_EQUAL(6, captured_hvx_len);
 }
 
 void test_ble_hrs_heart_rate_measurement_send(void)

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -727,6 +727,60 @@ void test_ble_hrs_init_bsl_char_add_error(void)
 	TEST_ASSERT_EQUAL(ERROR, nrf_err);
 }
 
+void test_ble_hrs_conn_params_evt_mtu_updated(void)
+{
+	/* ATT MTU update for matching connection updates max_hrm_len. */
+	struct ble_hrs hrs = {
+		.conn_handle = TEST_CONN_HANDLE,
+		.max_hrm_len = 20,
+	};
+	const struct ble_conn_params_evt evt = {
+		.conn_handle = TEST_CONN_HANDLE,
+		.evt_type = BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED,
+		.att_mtu = 100,
+	};
+
+	ble_hrs_conn_params_evt(&hrs, &evt);
+
+	/* max_hrm_len = att_mtu(100) - ATT_OPCODE_LEN(1) - ATT_HANDLE_LEN(2) = 97 */
+	TEST_ASSERT_EQUAL(97, hrs.max_hrm_len);
+}
+
+void test_ble_hrs_conn_params_evt_wrong_conn_handle(void)
+{
+	/* ATT MTU update for a different connection should be ignored. */
+	struct ble_hrs hrs = {
+		.conn_handle = TEST_CONN_HANDLE,
+		.max_hrm_len = 20,
+	};
+	const struct ble_conn_params_evt evt = {
+		.conn_handle = TEST_CONN_HANDLE + 1,
+		.evt_type = BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED,
+		.att_mtu = 100,
+	};
+
+	ble_hrs_conn_params_evt(&hrs, &evt);
+
+	TEST_ASSERT_EQUAL(20, hrs.max_hrm_len);
+}
+
+void test_ble_hrs_conn_params_evt_wrong_type(void)
+{
+	/* Non MTU event for matching connection should be ignored. */
+	struct ble_hrs hrs = {
+		.conn_handle = TEST_CONN_HANDLE,
+		.max_hrm_len = 20,
+	};
+	const struct ble_conn_params_evt evt = {
+		.conn_handle = TEST_CONN_HANDLE,
+		.evt_type = BLE_CONN_PARAMS_EVT_REJECTED,
+	};
+
+	ble_hrs_conn_params_evt(&hrs, &evt);
+
+	TEST_ASSERT_EQUAL(20, hrs.max_hrm_len);
+}
+
 extern int unity_main(void);
 
 int main(void)


### PR DESCRIPTION
Return raw SoftDevice errors from ble_hrs notification path instead of converting them internally. Update the HRS sample to handle expected errors at the application level.

Improve ble_hrs unit test coverage for hrm_encode branches, ble_hrs_on_ble_evt (disconnect/write), init error paths, CCCD read failure, and conn_params_evt.