### PR TITLE
ble_nus: simplify service by removing per-connection context

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -247,6 +247,11 @@ Bluetooth LE Services
 
    * Fixed a potential buffer over-read when parsing malformed Heart Rate Measurement notifications.
 
+* :ref:`lib_ble_service_nus`:
+
+   * Removed the ``ble_nus_client_context`` structure and the ``link_ctx`` field from :c:struct:`ble_nus_evt` structure.
+     The service now reads the CCCD directly from the SoftDevice instead of caching notification state internally.
+
 * :ref:`lib_ble_service_nus_client` service:
 
    * Added the Nordic UART Service (NUS) client.

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -98,16 +98,6 @@ enum ble_nus_evt_type {
 };
 
 /**
- * @brief Nordic UART Service client context structure.
- *
- * @details This structure contains state context related to hosts.
- */
-struct ble_nus_client_context {
-	/** Indicate if the peer has enabled notification of the RX characteristic. */
-	bool is_notification_enabled;
-};
-
-/**
  * @brief Nordic UART Service event structure.
  *
  * @details This structure is passed to an event coming from service.
@@ -117,8 +107,6 @@ struct ble_nus_evt {
 	enum ble_nus_evt_type evt_type;
 	/** Connection handle. */
 	uint16_t conn_handle;
-	/** Pointer to the link context. */
-	struct ble_nus_client_context *link_ctx;
 	union {
 		/** @ref BLE_NUS_EVT_RX_DATA event data. */
 		struct {
@@ -140,7 +128,7 @@ struct ble_nus;
 /** @brief Nordic UART Service event handler type. */
 typedef void (*ble_nus_evt_handler_t)(struct ble_nus *nus, const struct ble_nus_evt *evt);
 
-/*
+/**
  * @brief Nordic UART Service initialization structure.
  *
  * @details This structure contains the initialization information for the service. The application
@@ -183,8 +171,6 @@ struct ble_nus {
 	ble_gatts_char_handles_t tx_handles;
 	/** Handles related to the RX characteristic (as provided by the SoftDevice). */
 	ble_gatts_char_handles_t rx_handles;
-	/** Link context with handles of all current connections and its context. */
-	struct ble_nus_client_context contexts[CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT];
 	/** Event handler to be called for handling received data. */
 	ble_nus_evt_handler_t evt_handler;
 };
@@ -210,10 +196,8 @@ uint32_t ble_nus_init(struct ble_nus *nus, const struct ble_nus_config *nus_conf
 /**
  * @brief Function for handling the Nordic UART Service's Bluetooth LE events.
  *
- * @details The Nordic UART Service expects the application to call this function each time an
- *          event is received from the SoftDevice. This function processes the event if it
- *          is relevant and calls the Nordic UART Service event handler of the
- *          application if necessary.
+ * @note This function is registered automatically by @ref BLE_NUS_DEF
+ *       and should not be called directly by the application.
  *
  * @param[in] ble_evt Event received from the SoftDevice.
  * @param[in] context Nordic UART Service structure.
@@ -221,20 +205,22 @@ uint32_t ble_nus_init(struct ble_nus *nus, const struct ble_nus_config *nus_conf
 void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *context);
 
 /**
- * @brief Function for sending data to the peer.
+ * @brief Send data on the NUS TX characteristic as a notification.
  *
- * @details This function sends the input string as an RX characteristic notification to the
- *          peer.
+ * @details Sends data if the notification bit in the CCCD is set for @p conn_handle.
  *
  * @param[in] nus Pointer to the Nordic UART Service structure.
- * @param[in] data String to be sent.
- * @param[in,out] length In: Length of the @p data string. Out: Number of bytes sent.
+ * @param[in] data Data to be sent.
+ * @param[in,out] length In: Length of the @p data. Out: Number of bytes sent.
  * @param[in] conn_handle Connection handle of the destination client.
  *
  * @retval NRF_SUCCESS On success.
- * @retval NRF_ERROR_NULL If @p nus, @p data or @p length are @c NULL.
+ * @retval NRF_ERROR_NULL If @p nus, @p data, or @p length are @c NULL.
+ * @retval NRF_ERROR_INVALID_STATE If the peer has not enabled TX notifications
+ *         (CCCD not set for notifications).
  * @return In addition, this function may return any error
  *         returned by the following SoftDevice functions:
+ *         - @ref sd_ble_gatts_value_get()
  *         - @ref sd_ble_gatts_hvx()
  */
 uint32_t ble_nus_data_send(struct ble_nus *nus, uint8_t *data, uint16_t *length,

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -79,12 +79,13 @@ static void lpuarte_rx_handler(char *data, size_t data_len)
 
 	LOG_INF("Sending data over BLE NUS, len %d", len);
 
+	/* Retry when the SoftDevice notification queue is full.
+	 * sd_ble_gatts_hvx() returns NRF_ERROR_RESOURCES when UART data arrives faster than the
+	 * radio can transmit notifications.
+	 */
 	do {
 		nrf_err = ble_nus_data_send(&ble_nus, data, &len, conn_handle);
-		if ((nrf_err) &&
-		    (nrf_err != NRF_ERROR_INVALID_STATE) &&
-		    (nrf_err != NRF_ERROR_RESOURCES) &&
-		    (nrf_err != NRF_ERROR_NOT_FOUND)) {
+		if ((nrf_err) && (nrf_err != NRF_ERROR_RESOURCES)) {
 			LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
 			return;
 		}
@@ -95,7 +96,7 @@ static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
 	uint8_t c;
-	/* receive buffer used in UART ISR callback */
+	/* receive buffer used in UART ISR callback. */
 	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
 	static uint16_t rx_buf_idx;
 	uint16_t len;
@@ -116,12 +117,13 @@ static void uarte_rx_handler(char *data, size_t data_len)
 			len = rx_buf_idx;
 			LOG_INF("Sending data over BLE NUS, len %d", len);
 
+			/* Retry when the SoftDevice notification queue is full.
+			 * sd_ble_gatts_hvx() returns NRF_ERROR_RESOURCES when UART data arrives
+			 * faster than the radio can transmit notifications.
+			 */
 			do {
 				nrf_err = ble_nus_data_send(&ble_nus, rx_buf, &len, conn_handle);
-				if ((nrf_err) &&
-				    (nrf_err != NRF_ERROR_INVALID_STATE) &&
-				    (nrf_err != NRF_ERROR_RESOURCES) &&
-				    (nrf_err != NRF_ERROR_NOT_FOUND)) {
+				if ((nrf_err) && (nrf_err != NRF_ERROR_RESOURCES)) {
 					LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
 					return;
 				}

--- a/subsys/bluetooth/services/ble_nus/nus.c
+++ b/subsys/bluetooth/services/ble_nus/nus.c
@@ -15,14 +15,6 @@
 
 LOG_MODULE_REGISTER(ble_nus, CONFIG_BLE_NUS_LOG_LEVEL);
 
-static struct ble_nus_client_context *ble_nus_client_context_get(struct ble_nus *nus,
-								 uint16_t conn_handle)
-{
-	const int idx = nrf_sdh_ble_idx_get(conn_handle);
-
-	return ((idx >= 0) ? &nus->contexts[idx] : NULL);
-}
-
 static uint32_t nus_rx_char_add(struct ble_nus *nus, const struct ble_nus_config *cfg)
 {
 	ble_uuid_t char_uuid = {
@@ -84,7 +76,7 @@ static uint32_t nus_tx_char_add(struct ble_nus *nus, const struct ble_nus_config
 		.max_len = BLE_NUS_MAX_DATA_LEN,
 	};
 
-	/* Add Nordic UART TX declaration, value and CCCD attributes */
+	/* Add Nordic UART TX declaration, value and CCCD attributes. */
 	return sd_ble_gatts_characteristic_add(nus->service_handle, &char_md, &attr_char_value,
 					       &nus->tx_handles);
 }
@@ -103,35 +95,15 @@ static void on_connect(struct ble_nus *nus, const ble_evt_t *ble_evt)
 		.evt_type = BLE_NUS_EVT_COMM_STARTED,
 		.conn_handle = conn_handle,
 	};
-	uint8_t cccd_value[2];
 	ble_gatts_value_t gatts_val = {
-		.p_value = cccd_value,
-		.len = sizeof(cccd_value),
-		.offset = 0,
+		.p_value = (uint8_t *)&(uint16_t){0},
+		.len = sizeof(uint16_t),
 	};
-	struct ble_nus_client_context *ctx;
 
-	ctx = ble_nus_client_context_get(nus, conn_handle);
-	if (ctx == NULL) {
-		LOG_ERR("Could not fetch nus context for connection handle %#x", conn_handle);
-		evt.evt_type = BLE_NUS_EVT_ERROR;
-		evt.error.reason = NRF_ERROR_NOT_FOUND;
-		if (nus->evt_handler != NULL) {
-			nus->evt_handler(nus, &evt);
-		}
-	}
-
-	/* Check the hosts CCCD value to inform of readiness to send data using the
-	 * RX characteristic
-	 */
+	/* Check the host's CCCD value to inform of readiness to send data. */
 	nrf_err = sd_ble_gatts_value_get(conn_handle, nus->tx_handles.cccd_handle, &gatts_val);
 	if ((nrf_err == NRF_SUCCESS) && (nus->evt_handler != NULL) &&
 	    is_notification_enabled(gatts_val.p_value)) {
-		if (ctx != NULL) {
-			ctx->is_notification_enabled = true;
-		}
-
-		evt.link_ctx = ctx;
 		nus->evt_handler(nus, &evt);
 	}
 }
@@ -149,34 +121,16 @@ static void on_write(struct ble_nus *nus, const ble_evt_t *ble_evt)
 	struct ble_nus_evt evt = {
 		.conn_handle = conn_handle,
 	};
-	struct ble_nus_client_context *ctx;
-
-	ctx = ble_nus_client_context_get(nus, conn_handle);
-	if (ctx == NULL) {
-		LOG_ERR("Could not fetch nus context for connection handle %#x", conn_handle);
-		evt.evt_type = BLE_NUS_EVT_ERROR;
-		evt.error.reason = NRF_ERROR_NOT_FOUND;
-		if (nus->evt_handler != NULL) {
-			nus->evt_handler(nus, &evt);
-		}
-	}
-
-	LOG_DBG("Link ctx %p", ctx);
-	evt.link_ctx = ctx;
 
 	if ((evt_write->handle == nus->tx_handles.cccd_handle) && (evt_write->len == 2)) {
-		if (ctx != NULL) {
-			if (is_notification_enabled(evt_write->data)) {
-				ctx->is_notification_enabled = true;
-				evt.evt_type = BLE_NUS_EVT_COMM_STARTED;
-			} else {
-				ctx->is_notification_enabled = false;
-				evt.evt_type = BLE_NUS_EVT_COMM_STOPPED;
-			}
+		if (is_notification_enabled(evt_write->data)) {
+			evt.evt_type = BLE_NUS_EVT_COMM_STARTED;
+		} else {
+			evt.evt_type = BLE_NUS_EVT_COMM_STOPPED;
+		}
 
-			if (nus->evt_handler != NULL) {
-				nus->evt_handler(nus, &evt);
-			}
+		if (nus->evt_handler != NULL) {
+			nus->evt_handler(nus, &evt);
 		}
 	} else if ((evt_write->handle == nus->rx_handles.value_handle) &&
 		   (nus->evt_handler != NULL)) {
@@ -198,21 +152,23 @@ static void on_write(struct ble_nus *nus, const ble_evt_t *ble_evt)
  */
 static void on_hvx_tx_complete(struct ble_nus *nus, const ble_evt_t *ble_evt)
 {
+	uint32_t nrf_err;
 	const uint16_t conn_handle = ble_evt->evt.gatts_evt.conn_handle;
 	struct ble_nus_evt evt = {
 		.evt_type = BLE_NUS_EVT_TX_RDY,
 		.conn_handle = conn_handle,
 	};
-	struct ble_nus_client_context *ctx;
+	ble_gatts_value_t val = {
+		.p_value = (uint8_t *)&(uint16_t){0},
+		.len = sizeof(uint16_t),
+	};
 
-	ctx = ble_nus_client_context_get(nus, conn_handle);
-	if (ctx == NULL) {
-		LOG_ERR("Could not fetch nus context for connection handle %#x", conn_handle);
-		return;
-	}
+	/* Check if peer still has notifications enabled. */
+	nrf_err = sd_ble_gatts_value_get(conn_handle, nus->tx_handles.cccd_handle, &val);
 
-	if ((ctx->is_notification_enabled) && (nus->evt_handler != NULL)) {
-		evt.link_ctx = ctx;
+	if ((nrf_err == NRF_SUCCESS) &&
+	    is_notification_enabled(val.p_value) &&
+	    (nus->evt_handler != NULL)) {
 		nus->evt_handler(nus, &evt);
 	}
 }
@@ -287,22 +243,31 @@ uint32_t ble_nus_init(struct ble_nus *nus, const struct ble_nus_config *cfg)
 		return nrf_err;
 	}
 
-	return 0;
+	return NRF_SUCCESS;
 }
 
 uint32_t ble_nus_data_send(struct ble_nus *nus, uint8_t *data,
 			   uint16_t *len, uint16_t conn_handle)
 {
-	ble_gatts_hvx_params_t hvx = { 0 };
+	uint32_t nrf_err;
+	ble_gatts_hvx_params_t hvx = {
+		.type = BLE_GATT_HVX_NOTIFICATION,
+		.p_len = len,
+		.p_data = data,
+	};
 
 	if (!nus || !data || !len) {
 		return NRF_ERROR_NULL;
 	}
 
-	hvx.type = BLE_GATT_HVX_NOTIFICATION;
 	hvx.handle = nus->tx_handles.value_handle;
-	hvx.p_data = data;
-	hvx.p_len = len;
 
-	return sd_ble_gatts_hvx(conn_handle, &hvx);
+	/* Send TX data as a notification. */
+	nrf_err = sd_ble_gatts_hvx(conn_handle, &hvx);
+	if (nrf_err) {
+		LOG_DBG("Failed to notify NUS TX data, nrf_error %#x", nrf_err);
+		return nrf_err;
+	}
+
+	return NRF_SUCCESS;
 }

--- a/tests/unit/subsys/bluetooth/services/ble_nus/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_nus/src/unity_test.c
@@ -14,13 +14,11 @@
 
 #include "cmock_ble_gatts.h"
 #include "cmock_ble.h"
-#include "cmock_nrf_sdh_ble.h"
 
 /* An arbitrary error, to test forwarding of errors from SoftDevice calls */
 #define ERROR 0xbaadf00d
 
 static struct ble_nus ble_nus;
-static struct ble_nus_client_context *last_link_ctx;
 static uint16_t test_case_conn_handle = 0x1000;
 static bool evt_handler_called;
 
@@ -88,31 +86,19 @@ static uint32_t stub_sd_ble_gatts_value_get_err(uint16_t conn_handle, uint16_t h
 
 static void ble_nus_evt_handler_on_connect(struct ble_nus *nus, const struct ble_nus_evt *evt)
 {
-	last_link_ctx = evt->link_ctx;
 	TEST_ASSERT_EQUAL(BLE_NUS_EVT_COMM_STARTED, evt->evt_type);
-	TEST_ASSERT_TRUE(evt->link_ctx->is_notification_enabled);
-	evt_handler_called = true;
-}
-
-static void ble_nus_evt_handler_on_connect_null_ctx(struct ble_nus *nus,
-						    const struct ble_nus_evt *evt)
-{
-	TEST_ASSERT_EQUAL(BLE_NUS_EVT_ERROR, evt->evt_type);
-	TEST_ASSERT_NULL(evt->link_ctx);
 	evt_handler_called = true;
 }
 
 static void ble_nus_evt_handler_on_write_notif(struct ble_nus *nus, const struct ble_nus_evt *evt)
 {
 	TEST_ASSERT_EQUAL(BLE_NUS_EVT_COMM_STARTED, evt->evt_type);
-	TEST_ASSERT_TRUE(evt->link_ctx->is_notification_enabled);
 	evt_handler_called = true;
 }
 
 static void ble_nus_evt_handler_on_write_indica(struct ble_nus *nus, const struct ble_nus_evt *evt)
 {
 	TEST_ASSERT_EQUAL(BLE_NUS_EVT_COMM_STOPPED, evt->evt_type);
-	TEST_ASSERT_FALSE(evt->link_ctx->is_notification_enabled);
 	evt_handler_called = true;
 }
 
@@ -129,7 +115,6 @@ static void ble_nus_evt_handler_on_hvx_tx_complete(struct ble_nus *nus,
 						   const struct ble_nus_evt *evt)
 {
 	TEST_ASSERT_EQUAL(BLE_NUS_EVT_TX_RDY, evt->evt_type);
-	TEST_ASSERT_EQUAL_PTR(last_link_ctx, evt->link_ctx);
 	evt_handler_called = true;
 }
 
@@ -146,21 +131,6 @@ static void nus_init(struct ble_nus_config *nus_cfg)
 	nrf_err = ble_nus_init(&ble_nus, nus_cfg);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 	TEST_ASSERT_EQUAL_PTR(nus_cfg->evt_handler, ble_nus.evt_handler);
-}
-
-static void setup_with_notif_enabled(uint16_t conn_handle)
-{
-	const ble_evt_t ble_evt = {
-		.evt.gap_evt.conn_handle = conn_handle,
-		.header.evt_id = BLE_GAP_EVT_CONNECTED
-	};
-
-	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(conn_handle, 0);
-	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
-	__cmock_sd_ble_gatts_value_get_Stub(NULL);
-
-	TEST_ASSERT_TRUE(evt_handler_called);
 }
 
 void test_ble_nus_init_error_null(void)
@@ -230,21 +200,18 @@ void test_ble_nus_on_ble_evt_gap_evt_on_connect_readiness(void)
 	nus_init(&nus_cfg);
 
 	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 
 	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get_err);
 	ble_nus.evt_handler = ble_nus_evt_handler_on_connect;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 
 	TEST_ASSERT_FALSE(evt_handler_called);
 
 	ble_nus.evt_handler = ble_nus_evt_handler_on_connect;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 
@@ -262,24 +229,6 @@ void test_ble_nus_on_ble_evt_gap_evt_on_connect(void)
 	nus_init(&nus_cfg);
 
 	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
-	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
-
-	TEST_ASSERT_TRUE(evt_handler_called);
-}
-
-void test_ble_nus_on_ble_evt_gap_evt_on_connect_null_ctx(void)
-{
-	const ble_evt_t ble_evt = {
-		.evt.gap_evt.conn_handle = test_case_conn_handle,
-		.header.evt_id = BLE_GAP_EVT_CONNECTED
-	};
-	struct ble_nus_config nus_cfg = {.evt_handler = ble_nus_evt_handler_on_connect_null_ctx};
-
-	nus_init(&nus_cfg);
-
-	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, -1);
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 
 	TEST_ASSERT_TRUE(evt_handler_called);
@@ -303,7 +252,6 @@ void test_ble_nus_on_ble_evt_gap_evt_on_write(void)
 	nus_init(&nus_cfg);
 
 	*data_notif_enable = BLE_GATT_HVX_NOTIFICATION;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 	TEST_ASSERT_TRUE(evt_handler_called);
@@ -311,17 +259,15 @@ void test_ble_nus_on_ble_evt_gap_evt_on_write(void)
 	evt_handler_called = false;
 	*data_notif_enable = BLE_GATT_HVX_INDICATION;
 	ble_nus.evt_handler = ble_nus_evt_handler_on_write_indica;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 	TEST_ASSERT_TRUE(evt_handler_called);
 
 	evt_handler_called = false;
-	ble_nus.evt_handler = ble_nus_evt_handler_on_connect_null_ctx;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, -1);
+	ble_nus.evt_handler = NULL;
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
-	TEST_ASSERT_TRUE(evt_handler_called);
+	TEST_ASSERT_FALSE(evt_handler_called);
 
 	uint8_t *const data_ptr = ble_evt.evt.gatts_evt.params.write.data;
 
@@ -330,7 +276,6 @@ void test_ble_nus_on_ble_evt_gap_evt_on_write(void)
 	ble_nus.evt_handler = ble_nus_evt_handler_on_write_value;
 	data_ptr[0] = 0xAB;
 	data_ptr[1] = 0xCD;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 	TEST_ASSERT_TRUE(evt_handler_called);
@@ -339,31 +284,22 @@ void test_ble_nus_on_ble_evt_gap_evt_on_write(void)
 void test_ble_nus_on_hvx_tx_complete(void)
 {
 	ble_evt_t ble_evt = {
-		.evt.gap_evt.conn_handle = test_case_conn_handle,
-		.header.evt_id = BLE_GAP_EVT_CONNECTED
+		.evt.gatts_evt.conn_handle = test_case_conn_handle,
+		.header.evt_id = BLE_GATTS_EVT_HVN_TX_COMPLETE
 	};
 	struct ble_nus_config nus_cfg = {.evt_handler = ble_nus_evt_handler_on_connect};
 
 	nus_init(&nus_cfg);
 
-	/* Setup context */
-	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
-	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
-
-	TEST_ASSERT_TRUE(evt_handler_called);
-
-	/* Test a non relevant event */
+	/* No handler set, should not call back. */
 	evt_handler_called = false;
-	ble_evt.header.evt_id = BLE_GATTS_EVT_HVN_TX_COMPLETE;
 	ble_nus.evt_handler = NULL;
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
+	__cmock_sd_ble_gatts_value_get_Stub(stub_sd_ble_gatts_value_get);
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
 	TEST_ASSERT_FALSE(evt_handler_called);
 
-	/* Test a relevant event */
-	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(test_case_conn_handle, 0);
+	/* Handler set, notifications enabled, should call back. */
 	ble_nus.evt_handler = ble_nus_evt_handler_on_hvx_tx_complete;
 
 	ble_nus_on_ble_evt(&ble_evt, &ble_nus);
@@ -397,7 +333,6 @@ void test_ble_nus_data_send_hvx_error(void)
 	struct ble_nus_config nus_cfg = {.evt_handler = ble_nus_evt_handler_on_connect};
 
 	nus_init(&nus_cfg);
-	setup_with_notif_enabled(test_case_conn_handle);
 
 	__cmock_sd_ble_gatts_hvx_ExpectAnyArgsAndReturn(ERROR);
 
@@ -418,7 +353,6 @@ void test_ble_nus_data_send_success(void)
 	struct ble_nus_config nus_cfg = {.evt_handler = ble_nus_evt_handler_on_connect};
 
 	nus_init(&nus_cfg);
-	setup_with_notif_enabled(test_case_conn_handle);
 	expected_hvx_params.handle = ble_nus.tx_handles.value_handle;
 
 	__cmock_sd_ble_gatts_hvx_ExpectAndReturn(test_case_conn_handle, &expected_hvx_params,


### PR DESCRIPTION
Remove per-connection client context from NUS service. Instead of caching notification state internally, read the CCCD directly from the SoftDevice when needed.

This removes ble_nus_client_context, the contexts array, link_ctx from ble_nus_evt, and the nrf_sdh_ble_idx_get
dependency. Simplifies on_connect, on_write, on_hvx_tx_complete, and ble_nus_data_send.

Update NUS sample error handling and unit tests to match.