### PR TITLE
samples: boot: mcuboot_recovery_entry: extend size_opt list

### DIFF
--- a/samples/boot/mcuboot_recovery_entry/sample.yaml
+++ b/samples/boot/mcuboot_recovery_entry/sample.yaml
@@ -48,6 +48,8 @@ tests:
       - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
@@ -55,6 +57,8 @@ tests:
       - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
     tags:
       - sysbuild
     extra_args:


### PR DESCRIPTION
Added bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot and bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot to tastcase of size-optimized assembly.

Both are below 14 kB of MCUboot and around 26 kB of firmware loader.