### PR TITLE
workflows: build_samples: Build all platform_allow devices on nightly

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [push, opened, reopened, synchronize]
 
+  schedule:
+    - cron: "0 4 * * 1-5"
+
   workflow_dispatch:
 
 jobs:
@@ -42,11 +45,33 @@ jobs:
           west init -l nrf-bm
           west update -o=--depth=1 -n
 
-      - name: Build samples
+      - name: Build samples on commit
+        if: github.event.pull_request
         working-directory: nrf-bm
         run: |
           west twister -T samples --build-only -vc --inline-logs --integration --subset 1/2
           west twister -T samples --build-only -vc --inline-logs --integration --subset 2/2
+
+      - name: Build samples nightly
+        if: ${{ github.event.schedule || github.event.workflow_dispatch }}
+        working-directory: nrf-bm
+        # Split the run into multiple calls as we have limited space for the workflow
+        run: |
+          west twister -T samples --build-only -vc --inline-logs --subset 1/15
+          west twister -T samples --build-only -vc --inline-logs --subset 2/15
+          west twister -T samples --build-only -vc --inline-logs --subset 3/15
+          west twister -T samples --build-only -vc --inline-logs --subset 4/15
+          west twister -T samples --build-only -vc --inline-logs --subset 5/15
+          west twister -T samples --build-only -vc --inline-logs --subset 6/15
+          west twister -T samples --build-only -vc --inline-logs --subset 7/15
+          west twister -T samples --build-only -vc --inline-logs --subset 8/15
+          west twister -T samples --build-only -vc --inline-logs --subset 9/15
+          west twister -T samples --build-only -vc --inline-logs --subset 10/15
+          west twister -T samples --build-only -vc --inline-logs --subset 11/15
+          west twister -T samples --build-only -vc --inline-logs --subset 12/15
+          west twister -T samples --build-only -vc --inline-logs --subset 13/15
+          west twister -T samples --build-only -vc --inline-logs --subset 14/15
+          west twister -T samples --build-only -vc --inline-logs --subset 15/15
 
       - name: upload-logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build samples nightly](https://github.com/nrfconnect/sdk-nrf-bm/actions/workflows/build_samples.yml/badge.svg?event=schedule)](https://github.com/nrfconnect/sdk-nrf-bm/actions/workflows/build_samples.yml)
+
 # sdk-nrf-bm
 
 Base repository for the nRF Connect SDK Bare Metal option.


### PR DESCRIPTION
Compile the samples for all devices in the allow list each night monday-friday at 4 AM.