### PR TITLE
[alternative to #741] applications: firmware_loader: wait for write to complete

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -169,6 +169,9 @@ static uint32_t ble_change_address(void)
 	return sd_ble_gap_addr_set(&device_address);
 }
 
+/* Forward declaration of extern function. */
+bool img_mgmt_write_in_progress(void);
+
 int main(void)
 {
 	int err;
@@ -329,6 +332,11 @@ int main(void)
 			__SEV();
 			__WFE();
 		}
+	}
+
+	/* Wait for the new firmware image to be written. */
+	while (img_mgmt_write_in_progress()) {
+		k_sleep(K_MSEC(10));
 	}
 
 	sys_reboot(SYS_REBOOT_WARM);

--- a/applications/firmware_loader/uart_mcumgr/src/main.c
+++ b/applications/firmware_loader/uart_mcumgr/src/main.c
@@ -44,6 +44,9 @@ static enum mgmt_cb_return os_mgmt_reboot_hook(uint32_t event, enum mgmt_cb_retu
 	return MGMT_CB_OK;
 }
 
+/* Forward declaration of extern function. */
+bool img_mgmt_write_in_progress(void);
+
 int main(void)
 {
 	LOG_INF("UART MCUmgr sample started");
@@ -54,6 +57,11 @@ int main(void)
 		k_cpu_idle();
 
 		smp_uart_process_rx_queue();
+	}
+
+	/* Wait for the new firmware image to be written. */
+	while (img_mgmt_write_in_progress()) {
+		k_sleep(K_MSEC(10));
 	}
 
 	sys_reboot(SYS_REBOOT_WARM);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/bm_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/bm_img_mgmt.c
@@ -167,3 +167,8 @@ int img_mgmt_write_image_data(unsigned int offset, const void *data, unsigned in
 out:
 	return rc;
 }
+
+bool img_mgmt_write_in_progress(void)
+{
+	return bm_storage_is_busy(&s0_storage);
+}


### PR DESCRIPTION
Light alternative to #741.
Wait for writing the firmware image to complete before rebooting the application.