### PR TITLE
storage: bm_storage: send events async when possible

### DIFF
--- a/doc/nrf-bm/libraries/bm_storage.rst
+++ b/doc/nrf-bm/libraries/bm_storage.rst
@@ -120,6 +120,18 @@ The following events may be reported to the user callback:
 
 Each event includes the result code, information about the address range of the associated operation, and whether the operation is synchronous or asynchronous.
 
+Event deferral
+--------------
+
+Backends that do not have an internal operation queue (for example, the RRAM backend) deliver events synchronously from the same call context as the caller.
+If the application queues another storage operation from within its event handler, unbounded recursion can occur.
+
+Backends with an internal operation queue (for example, the SoftDevice backend) are not affected, because re-entrant calls are enqueued and processed iteratively.
+
+To prevent recursion in backends without a queue, enable the :kconfig:option:`CONFIG_BM_SCHEDULER` Kconfig option.
+When the scheduler is available, synchronous events are automatically deferred and delivered from the main thread context on the next call to :c:func:`bm_scheduler_process`.
+Deferred events have their :c:member:`bm_storage_evt.is_async` field set to ``true``.
+
 Sample
 ******
 
@@ -141,6 +153,11 @@ Dependencies
   * :kconfig:option:`CONFIG_SOFTDEVICE`
   * :kconfig:option:`CONFIG_NRF_SDH`
   * :kconfig:option:`CONFIG_RING_BUFFER`
+
+Optional dependencies:
+
+* :kconfig:option:`CONFIG_BM_SCHEDULER` – Enables deferral of synchronous events to the main thread context.
+  See :ref:`Event deferral <lib_storage>`.
 
 API documentation
 *****************

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -117,6 +117,7 @@ Storage
      * The :c:func:`bm_storage_nvm_info_get` function to retrieve NVM information, such as the size of the program unit and other.
      * The :c:member:`bm_storage_config.is_wear_aligned` configuration flag to enforce wear unit alignment on operations.
      * The :c:member:`bm_storage_config.is_write_padded` configuration flag to automatically pad write operations to the alignment unit.
+     * The :c:func:`bm_storage_evt_dispatch` function for event delivery.
 
    Updated:
      * The :c:func:`bm_storage_is_busy` function to return ``false`` instead of ``true`` when called with a ``NULL`` pointer or an uninitialized instance.
@@ -127,10 +128,15 @@ Storage
      * The SoftDevice backend to support chunking of write operations.
      * The ``no_explicit_erase`` field in :c:struct:`bm_storage_info` has been renamed to ``is_erase_before_write`` to explicitly convey that the memory must be erased before it can be written to.
      * The SoftDevice backend's :c:member:`bm_storage_info.program_unit` from 16 to 4 bytes, reflecting the true minimum programmable unit.
-     * The ``start_addr`` and ``end_addr`` fields in :c:struct:`bm_storage_config` and :c:struct:`bm_storage` have been replaced by ``addr`` and ``size``. The API now uses relative addressing (0-based offsets within the partition).
+     * The ``start_addr`` and ``end_addr`` fields in :c:struct:`bm_storage_config` and :c:struct:`bm_storage` have been replaced by ``addr`` and ``size``.
+       The API now uses relative addressing (0-based offsets within the partition).
      * The :c:func:`bm_storage_write` and :c:func:`bm_storage_erase` functions to return ``-ENOMEM`` when out of memory, instead of ``-EIO``.
      * The :c:func:`bm_storage_read`, :c:func:`bm_storage_write`, and :c:func:`bm_storage_erase` functions to return ``-EINVAL`` on alignment errors, instead of ``-EFAULT``.
      * The :c:enum:`bm_storage_evt_dispatch_type` enum and the :c:member:`bm_storage_evt.dispatch_type` field have been replaced by a boolean :c:member:`bm_storage_evt.is_async`.
+     * All backends to use the new :c:func:`bm_storage_evt_dispatch` function for event delivery.
+       For backends without an internal operation queue (such as RRAM), enabling :c:func:`bm_scheduler` defers synchronous events to the main thread context.
+     * The SoftDevice backend to process operations iteratively instead of recursively when the SoftDevice is disabled.
+       Re-entrant calls from event handlers are safely enqueued and processed by the loop.
 
 * ``bm_rmem`` library:
 

--- a/include/bm/storage/bm_storage.h
+++ b/include/bm/storage/bm_storage.h
@@ -334,6 +334,20 @@ bool bm_storage_is_busy(const struct bm_storage *storage);
  */
 const struct bm_storage_info *bm_storage_nvm_info_get(const struct bm_storage *storage);
 
+/**
+ * @brief Dispatch a storage event to the application's event handler.
+ *
+ * When the event scheduler (@c CONFIG_BM_SCHEDULER) is enabled and the event is
+ * synchronous, the event is deferred for delivery in the main thread context.
+ * Otherwise, the event handler is invoked directly.
+ *
+ * This function is intended for use by backend implementations.
+ *
+ * @param[in] storage The storage instance.
+ * @param[in] evt The event to dispatch.
+ */
+void bm_storage_evt_dispatch(const struct bm_storage *storage, struct bm_storage_evt *evt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/storage/bm_storage/bm_storage.c
+++ b/subsys/storage/bm_storage/bm_storage.c
@@ -10,6 +10,10 @@
 #include <sys/types.h>
 #include <bm/storage/bm_storage.h>
 
+#if defined(CONFIG_BM_SCHEDULER)
+#include <bm/bm_scheduler.h>
+#endif
+
 static bool is_within_bounds(uint32_t offset, uint32_t len, uint32_t size)
 {
 	return (offset + len <= size) && (offset + len > offset);
@@ -190,4 +194,46 @@ const struct bm_storage_info *bm_storage_nvm_info_get(const struct bm_storage *s
 	}
 
 	return storage->nvm_info;
+}
+
+#if defined(CONFIG_BM_SCHEDULER)
+struct bm_storage_deferred_evt {
+	bm_storage_evt_handler_t handler;
+	struct bm_storage_evt evt;
+};
+
+static void deferred_evt_handler(void *data, size_t len)
+{
+	struct bm_storage_deferred_evt *deferred = data;
+
+	deferred->handler(&deferred->evt);
+}
+#endif
+
+void bm_storage_evt_dispatch(const struct bm_storage *storage, struct bm_storage_evt *evt)
+{
+	if (!storage->evt_handler) {
+		return;
+	}
+
+#if defined(CONFIG_BM_SCHEDULER)
+	if (!evt->is_async) {
+		int err;
+		struct bm_storage_deferred_evt deferred = {
+			.handler = storage->evt_handler,
+			.evt = *evt,
+		};
+
+		deferred.evt.is_async = true;
+
+		err = bm_scheduler_defer(deferred_evt_handler, &deferred, sizeof(deferred));
+		__ASSERT_NO_MSG(!err);
+
+		if (!err) {
+			return;
+		}
+	}
+#endif
+
+	storage->evt_handler(evt);
 }

--- a/subsys/storage/bm_storage/native_sim/bm_storage_native_sim.c
+++ b/subsys/storage/bm_storage/native_sim/bm_storage_native_sim.c
@@ -23,11 +23,7 @@ static const struct bm_storage_info bm_storage_info = {
 
 static void event_send(const struct bm_storage *storage, struct bm_storage_evt *evt)
 {
-	if (!storage->evt_handler) {
-		return;
-	}
-
-	storage->evt_handler(evt);
+	bm_storage_evt_dispatch(storage, evt);
 }
 
 static void write_padded(const struct bm_storage *storage, uint32_t dest, const void *src,

--- a/subsys/storage/bm_storage/rram/bm_storage_rram.c
+++ b/subsys/storage/bm_storage/rram/bm_storage_rram.c
@@ -39,11 +39,7 @@ static uint8_t pad_buffer[RRAMC_WRITE_BLOCK_SIZE];
 
 static void event_send(const struct bm_storage *storage, struct bm_storage_evt *evt)
 {
-	if (!storage->evt_handler) {
-		return;
-	}
-
-	storage->evt_handler(evt);
+	bm_storage_evt_dispatch(storage, evt);
 }
 
 static int bm_storage_rramc_init(struct bm_storage *storage, const struct bm_storage_config *config)

--- a/subsys/storage/bm_storage/sd/bm_storage_sd.c
+++ b/subsys/storage/bm_storage/sd/bm_storage_sd.c
@@ -283,11 +283,23 @@ static void queue_process(void)
 			continue;
 
 		case NRF_ERROR_BUSY:
-			/* The SoftDevice is executing a non-volatile memory operation that was not
-			 * requested by the storage logic.
-			 * Stop processing the queue until a system event is received.
+			/* The SoftDevice is executing a non-volatile memory operation
+			 * that was not requested by this library.
 			 */
-			bm_storage_sd.queue_state = QUEUE_WAITING;
+			if (bm_storage_sd.softdevice_is_enabled) {
+				/* Stop processing the queue until the next SoC event is received.
+				 */
+				bm_storage_sd.queue_state = QUEUE_WAITING;
+				return;
+			}
+
+			/* Stop processing the queue until the user enqueues another
+			 * operation. Otherwise, there is a chance we might drain the
+			 * queue and fail all the operations.
+			 */
+			bm_storage_sd.queue_state = QUEUE_IDLE;
+			bm_storage_sd.operation_state = OP_NONE;
+			event_send(&bm_storage_sd.current_operation, -EBUSY);
 			return;
 
 		default:

--- a/subsys/storage/bm_storage/sd/bm_storage_sd.c
+++ b/subsys/storage/bm_storage/sd/bm_storage_sd.c
@@ -102,6 +102,8 @@ static
 #endif
 void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx);
 
+static bool on_operation_success(struct bm_storage_sd_op *op);
+
 RING_BUF_DECLARE(sd_fifo, CONFIG_BM_STORAGE_BACKEND_SD_QUEUE_SIZE *
 		 sizeof(struct bm_storage_sd_op));
 
@@ -138,7 +140,7 @@ static void event_send(const struct bm_storage_sd_op *op, uint32_t result)
 		break;
 	}
 
-	op->storage->evt_handler(&evt);
+	bm_storage_evt_dispatch(op->storage, &evt);
 }
 
 __aligned(sizeof(uint32_t)) /* SoftDevice requirement */
@@ -240,50 +242,62 @@ static void queue_process(void)
 {
 	uint32_t ret;
 
-	if (bm_storage_sd.operation_state == OP_NONE) {
-		if (!queue_load_next()) {
-			bm_storage_sd.queue_state = QUEUE_IDLE;
+	for (;;) {
+		if (bm_storage_sd.operation_state == OP_NONE) {
+			if (!queue_load_next()) {
+				bm_storage_sd.queue_state = QUEUE_IDLE;
+				return;
+			}
+		}
+
+		ret = 0;
+		bm_storage_sd.queue_state = QUEUE_RUNNING;
+		bm_storage_sd.operation_state = OP_EXECUTING;
+
+		switch (bm_storage_sd.current_operation.id) {
+		case WRITE:
+			ret = write_execute(&bm_storage_sd.current_operation);
+			break;
+		case ERASE:
+			ret = erase_execute(&bm_storage_sd.current_operation);
+			break;
+		}
+
+		switch (ret) {
+		case NRF_SUCCESS:
+			if (bm_storage_sd.softdevice_is_enabled) {
+				/* Wait for the real SoC event from the SoftDevice. */
+				return;
+			}
+
+			/* The SoftDevice won't send an SoC event, process the result
+			 * of the operation immediately, and clear the current
+			 * operation if it has finished, so we'll load a new one
+			 * in the next loop iteration.
+			 */
+			if (on_operation_success(&bm_storage_sd.current_operation)) {
+				bm_storage_sd.operation_state = OP_NONE;
+				event_send(&bm_storage_sd.current_operation, 0);
+			}
+			/* Continue processing the operation queue */
+			continue;
+
+		case NRF_ERROR_BUSY:
+			/* The SoftDevice is executing a non-volatile memory operation that was not
+			 * requested by the storage logic.
+			 * Stop processing the queue until a system event is received.
+			 */
+			bm_storage_sd.queue_state = QUEUE_WAITING;
 			return;
+
+		default:
+			/* The SoftDevice API returned an error synchronously.
+			 * This is not recoverable, process the next operation immediately.
+			 */
+			bm_storage_sd.operation_state = OP_NONE;
+			event_send(&bm_storage_sd.current_operation, -EIO);
+			continue;
 		}
-	}
-
-	ret = 0;
-	bm_storage_sd.queue_state = QUEUE_RUNNING;
-	bm_storage_sd.operation_state = OP_EXECUTING;
-
-	switch (bm_storage_sd.current_operation.id) {
-	case WRITE:
-		ret = write_execute(&bm_storage_sd.current_operation);
-		break;
-	case ERASE:
-		ret = erase_execute(&bm_storage_sd.current_operation);
-		break;
-	}
-
-	switch (ret) {
-	case NRF_SUCCESS:
-		/* The operation was accepted by the SoftDevice.
-		 * If the SoftDevice is enabled, wait for a SoC event, otherwise simulate it.
-		 */
-		if (!bm_storage_sd.softdevice_is_enabled) {
-			bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
-		}
-		break;
-	case NRF_ERROR_BUSY:
-		/* The SoftDevice is executing a non-volatile memory operation that was not
-		 * requested by the storage logic.
-		 * Stop processing the queue until a system event is received.
-		 */
-		bm_storage_sd.queue_state = QUEUE_WAITING;
-		break;
-	default:
-		/* An error has occurred and we cannot proceed further with this operation.
-		 * Process the next operation in the queue.
-		 */
-		event_send(&bm_storage_sd.current_operation, -EIO);
-		bm_storage_sd.operation_state = OP_NONE;
-		queue_process();
-		break;
 	}
 }
 

--- a/tests/unit/subsys/storage/bm_storage/src/unity_test.c
+++ b/tests/unit/subsys/storage/bm_storage/src/unity_test.c
@@ -5,8 +5,13 @@
  */
 #include <unity.h>
 #include <errno.h>
+#include <string.h>
 
 #include <bm/storage/bm_storage.h>
+
+#if defined(CONFIG_BM_SCHEDULER)
+#include <bm/bm_scheduler.h>
+#endif
 
 /* Arbitrary block size. */
 #define BLOCK_SIZE 16
@@ -92,6 +97,9 @@ static struct bm_storage_api bm_storage_test_api_rram_like = {
 	.is_busy = bm_storage_test_api_is_busy,
 };
 
+static struct bm_storage_evt dispatch_evt;
+static bool dispatch_evt_received;
+
 static void bm_storage_evt_handler(struct bm_storage_evt *evt)
 {
 	switch (evt->id) {
@@ -102,6 +110,12 @@ static void bm_storage_evt_handler(struct bm_storage_evt *evt)
 	default:
 		break;
 	}
+}
+
+static void dispatch_evt_handler(struct bm_storage_evt *evt)
+{
+	dispatch_evt_received = true;
+	dispatch_evt = *evt;
 }
 
 void test_bm_storage_init_efault(void)
@@ -679,9 +693,108 @@ void test_bm_storage_init_wear_aligned_einval(void)
 	TEST_ASSERT_EQUAL(-EINVAL, err);
 }
 
+void test_bm_storage_evt_dispatch_null_handler(void)
+{
+	int err;
+	struct bm_storage storage = {0};
+	struct bm_storage_config config = {
+		.api = &bm_storage_test_api,
+		.addr = PARTITION_START,
+		.size = PARTITION_SIZE,
+	};
+	struct bm_storage_evt evt = {
+		.id = BM_STORAGE_EVT_WRITE_RESULT,
+		.is_async = false,
+	};
+
+	err = bm_storage_init(&storage, &config);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* Must not crash when the event handler is NULL. */
+	bm_storage_evt_dispatch(&storage, &evt);
+}
+
+void test_bm_storage_evt_dispatch_async(void)
+{
+	int err;
+	struct bm_storage storage = {0};
+	struct bm_storage_config config = {
+		.api = &bm_storage_test_api,
+		.evt_handler = dispatch_evt_handler,
+		.addr = PARTITION_START,
+		.size = PARTITION_SIZE,
+	};
+	struct bm_storage_evt evt = {
+		.id = BM_STORAGE_EVT_WRITE_RESULT,
+		.is_async = true,
+		.result = 0,
+		.addr = 0x100,
+		.len = 32,
+	};
+
+	err = bm_storage_init(&storage, &config);
+	TEST_ASSERT_EQUAL(0, err);
+
+	bm_storage_evt_dispatch(&storage, &evt);
+
+	/* Async events are always dispatched directly, regardless of scheduler. */
+	TEST_ASSERT_TRUE(dispatch_evt_received);
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, dispatch_evt.id);
+	TEST_ASSERT_EQUAL(true, dispatch_evt.is_async);
+	TEST_ASSERT_EQUAL(0, dispatch_evt.result);
+	TEST_ASSERT_EQUAL(0x100, dispatch_evt.addr);
+	TEST_ASSERT_EQUAL(32, dispatch_evt.len);
+}
+
+void test_bm_storage_evt_dispatch_sync(void)
+{
+	int err;
+	struct bm_storage storage = {0};
+	struct bm_storage_config config = {
+		.api = &bm_storage_test_api,
+		.evt_handler = dispatch_evt_handler,
+		.addr = PARTITION_START,
+		.size = PARTITION_SIZE,
+	};
+	struct bm_storage_evt evt = {
+		.id = BM_STORAGE_EVT_ERASE_RESULT,
+		.is_async = false,
+		.result = 0,
+		.addr = 0x200,
+		.len = 64,
+	};
+
+	err = bm_storage_init(&storage, &config);
+	TEST_ASSERT_EQUAL(0, err);
+
+	bm_storage_evt_dispatch(&storage, &evt);
+
+#if defined(CONFIG_BM_SCHEDULER)
+	/* With scheduler: sync events are deferred, not delivered yet. */
+	TEST_ASSERT_FALSE(dispatch_evt_received);
+
+	bm_scheduler_process();
+
+	TEST_ASSERT_TRUE(dispatch_evt_received);
+	/* The event is marked async since it was deferred. */
+	TEST_ASSERT_EQUAL(true, dispatch_evt.is_async);
+#else
+	/* Without scheduler: sync events are dispatched directly. */
+	TEST_ASSERT_TRUE(dispatch_evt_received);
+	TEST_ASSERT_EQUAL(false, dispatch_evt.is_async);
+#endif
+
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_ERASE_RESULT, dispatch_evt.id);
+	TEST_ASSERT_EQUAL(0, dispatch_evt.result);
+	TEST_ASSERT_EQUAL(0x200, dispatch_evt.addr);
+	TEST_ASSERT_EQUAL(64, dispatch_evt.len);
+}
+
 void setUp(void)
 {
 	backend_uninit_retval = 0;
+	dispatch_evt_received = false;
+	memset(&dispatch_evt, 0, sizeof(dispatch_evt));
 }
 
 void tearDown(void)

--- a/tests/unit/subsys/storage/bm_storage/testcase.yaml
+++ b/tests/unit/subsys/storage/bm_storage/testcase.yaml
@@ -2,3 +2,8 @@ tests:
   subsys.bm_storage:
     platform_allow: native_sim
     tags: unittest
+  subsys.bm_storage.scheduler:
+    platform_allow: native_sim
+    tags: unittest
+    extra_configs:
+      - CONFIG_BM_SCHEDULER=y

--- a/tests/unit/subsys/storage/bm_storage_sd/src/unity_test.c
+++ b/tests/unit/subsys/storage/bm_storage_sd/src/unity_test.c
@@ -495,8 +495,8 @@ void test_bm_storage_sd_write_retry_queued(void)
 	TEST_ASSERT_EQUAL(sizeof(buf), storage_event.len);
 }
 
-/* Test that when one operation in the queue fails to be scheduled,
- * we continue to process other operations.
+/* Test that when one operation in the queue fails to be scheduled with an error
+ * other than NRF_ERROR_BUSY, we continue to process other operations.
  */
 void test_bm_storage_sd_write_queued_eio(void)
 {
@@ -570,6 +570,65 @@ void test_bm_storage_sd_write_queued_eio(void)
 	TEST_ASSERT_EQUAL(0, storage_event.addr);
 	TEST_ASSERT_EQUAL_PTR(buf, storage_event.src);
 	TEST_ASSERT_EQUAL(sizeof(buf), storage_event.len);
+}
+
+/* Test that when the SoftDevice is disabled and an operation fails with
+ * a non-BUSY error (default case), the failed operation is not retried and
+ * the queue processes the next operation immediately.
+ */
+void test_bm_storage_sd_write_queued_disabled_eio(void)
+{
+	int err;
+	bool is_busy;
+	uint8_t buf[BLOCK_SIZE];
+	struct bm_storage storage = {0};
+	struct bm_storage_config config = {
+		.evt_handler = bm_storage_evt_handler,
+		.api = &bm_storage_sd_api,
+		.addr = PARTITION_START,
+		.size = PARTITION_SIZE,
+	};
+
+	__cmock_sd_softdevice_is_enabled_ExpectAndReturn(PTR_IGNORE, 0);
+	__cmock_sd_softdevice_is_enabled_IgnoreArg_p_softdevice_enabled();
+	__cmock_sd_softdevice_is_enabled_ReturnThruPtr_p_softdevice_enabled(&(uint8_t){false});
+
+	err = bm_storage_init(&storage, &config);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* First write fails with a non-BUSY error */
+	__cmock_sd_flash_write_ExpectAndReturn(
+		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)),
+		NRF_ERROR_INTERNAL);
+
+	err = bm_storage_write(&storage, 0, buf, sizeof(buf), (void *)0xBBBB0001);
+	TEST_ASSERT_EQUAL(0, err);
+
+	TEST_ASSERT_EQUAL(1, storage_event_count);
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
+	TEST_ASSERT_EQUAL(-EIO, storage_event.result);
+	TEST_ASSERT_EQUAL_PTR(0xBBBB0001, storage_event.ctx);
+
+	is_busy = bm_storage_is_busy(&storage);
+	TEST_ASSERT_FALSE(is_busy);
+
+	/* A second write starts a fresh operation (no retry of the first).
+	 * Only one sd_flash_write mock is needed: for the new operation.
+	 */
+	__cmock_sd_flash_write_ExpectAndReturn(
+		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)), 0);
+
+	err = bm_storage_write(&storage, 0, buf, sizeof(buf), (void *)0xBBBB0002);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* The second operation succeeded — ctx confirms it's the new operation, not a retry */
+	TEST_ASSERT_EQUAL(2, storage_event_count);
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
+	TEST_ASSERT_EQUAL(0, storage_event.result);
+	TEST_ASSERT_EQUAL_PTR(0xBBBB0002, storage_event.ctx);
+
+	err = bm_storage_uninit(&storage);
+	TEST_ASSERT_EQUAL(0, err);
 }
 
 void test_bm_storage_sd_write_enomem(void)
@@ -818,6 +877,70 @@ void test_bm_storage_sd_write_softdevice_busy_retry(void)
 	TEST_ASSERT_EQUAL(0, storage_event.addr);
 	TEST_ASSERT_EQUAL_PTR(buf, storage_event.src);
 	TEST_ASSERT_EQUAL(sizeof(buf), storage_event.len);
+}
+
+/* Test that when the SoftDevice is disabled and an operation fails with NRF_ERROR_BUSY,
+ * the operation is discarded and the queue stops. The next write or erase call
+ * starts a fresh operation.
+ */
+void test_bm_storage_sd_write_softdevice_disabled_busy_stop(void)
+{
+	int err;
+	bool is_busy;
+	uint8_t buf[BLOCK_SIZE];
+	struct bm_storage storage = {0};
+	struct bm_storage_config config = {
+		.evt_handler = bm_storage_evt_handler,
+		.api = &bm_storage_sd_api,
+		.addr = PARTITION_START,
+		.size = PARTITION_SIZE,
+	};
+
+	__cmock_sd_softdevice_is_enabled_ExpectAndReturn(PTR_IGNORE, 0);
+	__cmock_sd_softdevice_is_enabled_IgnoreArg_p_softdevice_enabled();
+	__cmock_sd_softdevice_is_enabled_ReturnThruPtr_p_softdevice_enabled(&(uint8_t){false});
+
+	err = bm_storage_init(&storage, &config);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* First write gets BUSY */
+	__cmock_sd_flash_write_ExpectAndReturn(
+		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)),
+		NRF_ERROR_BUSY);
+
+	err = bm_storage_write(&storage, 0, buf, sizeof(buf), (void *)0xAAAA0001);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* BUSY is reported and the queue stops */
+	TEST_ASSERT_EQUAL(1, storage_event_count);
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
+	TEST_ASSERT_EQUAL(false, storage_event.is_async);
+	TEST_ASSERT_EQUAL(-EBUSY, storage_event.result);
+	TEST_ASSERT_EQUAL_PTR(0xAAAA0001, storage_event.ctx);
+
+	is_busy = bm_storage_is_busy(&storage);
+	TEST_ASSERT_FALSE(is_busy);
+
+	/* A second write starts a fresh operation (the BUSY one was discarded).
+	 * Only one sd_flash_write mock is needed: for the new operation.
+	 */
+	__cmock_sd_flash_write_ExpectAndReturn(
+		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)), 0);
+
+	err = bm_storage_write(&storage, 0, buf, sizeof(buf), (void *)0xAAAA0002);
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* The second operation succeeded — ctx confirms it's the new operation, not a retry */
+	TEST_ASSERT_EQUAL(2, storage_event_count);
+	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
+	TEST_ASSERT_EQUAL(0, storage_event.result);
+	TEST_ASSERT_EQUAL_PTR(0xAAAA0002, storage_event.ctx);
+
+	is_busy = bm_storage_is_busy(&storage);
+	TEST_ASSERT_FALSE(is_busy);
+
+	err = bm_storage_uninit(&storage);
+	TEST_ASSERT_EQUAL(0, err);
 }
 
 void test_bm_storage_sd_write_chunk(void)


### PR DESCRIPTION
When the event callback fires from the same call context as the caller,
an application that queues another storage operation from inside its event
handler creates unbounded recursion. The chain looks like:

`bm_storage_write()` -> backend write -> `event_send()` -> user handler ->
`bm_storage_write()` -> backend write -> `event_send()` -> user handler -> ...

This applies to all backends.

Rewrite the `queue_process()` function in SoftDevice backend to be
iterative instead of recursive, to avoid unbounded recursion when
the SoftDevice is disabled.

This patch introduces a common function for backends that can be used
to defer the dispatching of the events from backends to the application
using the scheduler, when it is available. Otherwise, it just dispatches
the event immediately.

The other patch changes the behavior when the SoftDevice is busy and disabled,
where instead of draining the queue and possibly failing all operations,
we just stop and re-attempt to process what's left in the queue once
the user enqueues another operation.
