### PR TITLE
tests: add sdh_evt_dispatch helper file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -106,6 +106,7 @@
 /tests/lib/                                 @nrfconnect/ncs-bm
 /tests/subsys/fs/bm_zms/                    @nrfconnect/ncs-bm @rghaddab
 /tests/subsys/kmu/                          @nrfconnect/ncs-eris @nrfconnect/ncs-eris-test
+/tests/unit/util/                           @nrfconnect/ncs-bm
 /tests/unit/lib/                            @nrfconnect/ncs-bm
 /tests/unit/lib/bluetooth/ble_adv/          @nrfconnect/ncs-bm-test
 /tests/unit/lib/bluetooth/ble_conn_params/  @nrfconnect/ncs-bm

--- a/cmake/unity/unity_softdevice_setup.cmake
+++ b/cmake/unity/unity_softdevice_setup.cmake
@@ -23,3 +23,18 @@ function(unity_softdevice_header_setup)
   zephyr_include_directories(${SOFTDEVICE_INCLUDE_DIR})
   zephyr_compile_definitions(SVCALL_AS_NORMAL_FUNCTION)
 endfunction()
+
+# Add the sdh_evt_dispatch test helper to the current unit test.
+#
+# The helper exposes sdh_evt_dispatch_{ble,soc,state}() which let tests
+# fire SoftDevice events at all observers registered via
+# NRF_SDH_BLE_OBSERVER, NRF_SDH_SOC_OBSERVER, and NRF_SDH_STATE_EVT_OBSERVER.
+#
+
+function(unity_softdevice_event_setup)
+  set(dir ${ZEPHYR_NRF_BM_MODULE_DIR}/tests/unit/util/sdh_evt_dispatch)
+
+  target_sources(app PRIVATE ${dir}/sdh_evt_dispatch.c)
+  target_include_directories(app PRIVATE ${dir}/include)
+  zephyr_linker_sources(SECTIONS ${dir}/sdh_evt_dispatch.ld)
+endfunction()

--- a/cmake/unity/unity_softdevice_setup.cmake
+++ b/cmake/unity/unity_softdevice_setup.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+function(unity_softdevice_header_setup)
+  cmake_parse_arguments(ARG "" "VARIANT;SOC" "" ${ARGN})
+
+  if(NOT DEFINED ARG_VARIANT)
+    set(ARG_VARIANT "s115")
+  endif()
+  if(NOT DEFINED ARG_SOC)
+    set(ARG_SOC "nrf54l")
+  endif()
+
+  set(SOFTDEVICE_INCLUDE_DIR
+    "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/${ARG_SOC}/${ARG_VARIANT}/${ARG_VARIANT}_API/include"
+  )
+
+  set(SOFTDEVICE_INCLUDE_DIR "${SOFTDEVICE_INCLUDE_DIR}" PARENT_SCOPE)
+
+  zephyr_include_directories(${SOFTDEVICE_INCLUDE_DIR})
+  zephyr_compile_definitions(SVCALL_AS_NORMAL_FUNCTION)
+endfunction()

--- a/include/bm/bluetooth/ble_adv.h
+++ b/include/bm/bluetooth/ble_adv.h
@@ -238,10 +238,17 @@ struct ble_adv_config {
 };
 
 /**
- * @brief Library's Bluetooth LE event handler.
+ * @brief Bluetooth LE event handler for the advertising library.
+ *
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          advertising library.
+ *
+ * @note This handler is registered automatically by @ref BLE_ADV_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
  *
  * @param[in] ble_evt Bluetooth LE stack event.
- * @param[in] ble_adv Advertising Module instance.
+ * @param[in] ble_adv Pointer to the @ref ble_adv instance.
  */
 void ble_adv_on_ble_evt(const ble_evt_t *ble_evt, void *ble_adv);
 

--- a/include/bm/bluetooth/ble_db_discovery.h
+++ b/include/bm/bluetooth/ble_db_discovery.h
@@ -241,12 +241,19 @@ uint32_t ble_db_discovery_service_register(struct ble_db_discovery *db_discovery
 					   const ble_uuid_t *uuid);
 
 /**
- * @brief Application's Bluetooth LE Stack event handler.
+ * @brief Bluetooth LE event handler for the Database Discovery library.
  *
- * @param[in] ble_evt Event received.
- * @param[in,out] context DB discovery instance.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Database Discovery library.
+ *
+ * @note This handler is registered automatically by @ref BLE_DB_DISCOVERY_DEF and
+ *       is called by the SoftDevice handler. The application does not need to
+ *       call it directly.
+ *
+ * @param[in] ble_evt          Bluetooth LE stack event.
+ * @param[in] ble_db_discovery Pointer to the @ref ble_db_discovery instance.
  */
-void ble_db_discovery_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_db_discovery_on_ble_evt(const ble_evt_t *ble_evt, void *ble_db_discovery);
 
 #endif /* BLE_DB_DISCOVERY_H__ */
 

--- a/include/bm/bluetooth/ble_gq.h
+++ b/include/bm/bluetooth/ble_gq.h
@@ -300,16 +300,19 @@ uint32_t ble_gq_item_add(const struct ble_gq *gatt_queue, struct ble_gq_req *req
 uint32_t ble_gq_conn_handle_register(const struct ble_gq *gatt_queue, uint16_t conn_handle);
 
 /**
- * @brief Handle Bluetooth LE events from the SoftDevice.
+ * @brief Bluetooth LE event handler for the GATT Queue library.
  *
- * @details This function handles the Bluetooth LE events received from the SoftDevice. If an
- *          event is relevant to the BGQ module, it is used to update internal variables,
- *          process queued GATT requests and, if necessary, send errors to the application.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          GATT Queue library.
  *
- * @param[in] ble_evt     Pointer to the event.
- * @param[in] gatt_queue  Pointer to the @ref ble_gq instance.
+ * @note This handler is registered automatically by @ref BLE_GQ_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_gq  Pointer to the @ref ble_gq instance.
  */
-void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *gatt_queue);
+void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *ble_gq);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/ble_qwr.h
+++ b/include/bm/bluetooth/ble_qwr.h
@@ -13,9 +13,6 @@
  *
  * @details This module handles prepare write, execute write, and cancel write
  * commands. It also manages memory requests related to these operations.
- *
- * @note The application must propagate Bluetooth LE stack events to this module by calling
- *       @ref ble_qwr_on_ble_evt().
  */
 
 #ifndef BLE_QWR_H__
@@ -180,15 +177,19 @@ uint32_t ble_qwr_init(struct ble_qwr *qwr, const struct ble_qwr_config *qwr_conf
 uint32_t ble_qwr_conn_handle_assign(struct ble_qwr *qwr, uint16_t conn_handle);
 
 /**
- * @brief Function for handling Bluetooth LE stack events.
+ * @brief Bluetooth LE event handler for the Queued Writes module.
  *
- * @details Handles all events from the Bluetooth LE stack that are of interest to the
+ * @details Handles all Bluetooth LE stack events that are of interest to the
  *          Queued Writes module.
  *
- * @param[in] ble_evt Event received.
- * @param[in] context Queued Writes structure.
+ * @note This handler is registered automatically by @ref BLE_QWR_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_qwr Pointer to the @ref ble_qwr instance.
  */
-void ble_qwr_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_qwr_on_ble_evt(const ble_evt_t *ble_evt, void *ble_qwr);
 
 #if (CONFIG_BLE_QWR_MAX_ATTR > 0)
 /**

--- a/include/bm/bluetooth/ble_scan.h
+++ b/include/bm/bluetooth/ble_scan.h
@@ -42,7 +42,6 @@ extern "C" {
  */
 #define BLE_SCAN_DEF(_name)                                                                        \
 	static struct ble_scan _name;                                                              \
-	extern void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);                      \
 	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_scan_on_ble_evt, &_name, HIGH)
 
 /**
@@ -565,12 +564,19 @@ uint32_t ble_scan_all_filter_remove(struct ble_scan *scan);
 uint32_t ble_scan_params_set(struct ble_scan *scan, const ble_gap_scan_params_t *scan_params);
 
 /**
- * @brief Handler for Bluetooth LE stack events.
+ * @brief Bluetooth LE event handler for the Scanning library.
  *
- * @param[in] ble_evt Bluetooth LE event.
- * @param[in,out] scan Scan library instance.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Scanning library.
+ *
+ * @note This handler is registered automatically by @ref BLE_SCAN_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt  Bluetooth LE stack event.
+ * @param[in] ble_scan Pointer to the @ref ble_scan instance.
  */
-void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *scan);
+void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *ble_scan);
 
 /**
  * @brief Convert the raw address to the SoftDevice GAP address.

--- a/include/bm/bluetooth/services/ble_bas.h
+++ b/include/bm/bluetooth/services/ble_bas.h
@@ -29,7 +29,6 @@ extern "C" {
  */
 #define BLE_BAS_DEF(_name)                                                                         \
 	static struct ble_bas _name;                                                               \
-	extern void ble_bas_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);                       \
 	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_bas_on_ble_evt, &_name, HIGH)
 
 /** @brief Default security configuration. */
@@ -217,6 +216,21 @@ uint32_t ble_bas_init(struct ble_bas *bas, const struct ble_bas_config *bas_conf
  */
 uint32_t ble_bas_battery_level_update(struct ble_bas *bas, uint16_t conn_handle,
 				      uint8_t battery_level);
+
+/**
+ * @brief Bluetooth LE event handler for the Battery Service.
+ *
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Battery Service.
+ *
+ * @note This handler is registered automatically by @ref BLE_BAS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_bas Pointer to the @ref ble_bas instance.
+ */
+void ble_bas_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bas);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_bas_client.h
+++ b/include/bm/bluetooth/services/ble_bas_client.h
@@ -157,19 +157,19 @@ uint32_t ble_bas_client_init(struct ble_bas_client *bas_client,
 			     const struct ble_bas_client_config *bas_client_config);
 
 /**
- * @brief Handle Bluetooth LE events from the SoftDevice.
+ * @brief Bluetooth LE event handler for the Battery Service Client.
  *
- * @details This function handles the Bluetooth LE events received from the SoftDevice. If a
- *          Bluetooth LE event is relevant to the Battery Service Client module, the function uses
- *          the event's data to update interval variables and, if necessary, send events to the
- *          application.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Battery Service Client.
  *
- * @note This function must be called by the application.
+ * @note This handler is registered automatically by @ref BLE_BAS_CLIENT_DEF and
+ *       is called by the SoftDevice handler. The application does not need to
+ *       call it directly.
  *
- * @param[in] ble_evt Bluetooth LE event.
- * @param[in] context Battery Service client structure.
+ * @param[in] ble_evt        Bluetooth LE stack event.
+ * @param[in] ble_bas_client Pointer to the @ref ble_bas_client instance.
  */
-void ble_bas_client_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_bas_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bas_client);
 
 /**
  * @brief Enable notifications on the Battery Level characteristic.

--- a/include/bm/bluetooth/services/ble_bms.h
+++ b/include/bm/bluetooth/services/ble_bms.h
@@ -314,15 +314,19 @@ uint32_t ble_bms_auth_response(struct ble_bms *bms, bool authorize);
 uint32_t ble_bms_init(struct ble_bms *bms, struct ble_bms_config *bms_config);
 
 /**
- * @brief   Handle Bond Management Bluetooth LE stack events.
+ * @brief Bluetooth LE event handler for the Bond Management Service.
  *
- * @details This function handles all events from the Bluetooth LE stack that are of interest to the
+ * @details Handles all Bluetooth LE stack events that are of interest to the
  *          Bond Management Service.
  *
- * @param[in] ble_evt Event received.
- * @param[in] context BMS structure.
+ * @note This handler is registered automatically by @ref BLE_BMS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_bms Pointer to the @ref ble_bms instance.
  */
-void ble_bms_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_bms_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bms);
 
 /**
  * @brief Handle events from the @ref nrf_ble_qwr.

--- a/include/bm/bluetooth/services/ble_cgms.h
+++ b/include/bm/bluetooth/services/ble_cgms.h
@@ -590,14 +590,19 @@ struct ble_cgms {
 uint32_t ble_cgms_init(struct ble_cgms *cgms, const struct ble_cgms_config *cgms_init);
 
 /**
- * @brief Function for handling the application's Bluetooth LE stack events.
+ * @brief Bluetooth LE event handler for the Continuous Glucose Monitoring Service.
  *
- * @details Handles all events from the Bluetooth LE stack that are of interest to the CGM Service.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Continuous Glucose Monitoring Service.
  *
- * @param[in] ble_evt Event received.
- * @param[in] context Instance of the CGM Service.
+ * @note This handler is registered automatically by @ref BLE_CGMS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt  Bluetooth LE stack event.
+ * @param[in] ble_cgms Pointer to the @ref ble_cgms instance.
  */
-void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *ble_cgms);
 
 /**
  * @brief Report a new glucose measurement to the CGM Service module.

--- a/include/bm/bluetooth/services/ble_hids.h
+++ b/include/bm/bluetooth/services/ble_hids.h
@@ -700,17 +700,19 @@ struct ble_hids {
 };
 
 /**
- * @brief Function for handling the Application's Bluetooth LE Stack events.
+ * @brief Bluetooth LE event handler for the HID Service.
  *
- * @details Handles all events from the Bluetooth LE stack of interest to the HID Service.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          HID Service.
  *
- * @note This function is registered with a NRF_SDH_BLE_OBSERVER and is called automatically
- *       by the SoftDevice Handler.
+ * @note This handler is registered automatically by @ref BLE_HIDS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
  *
- * @param[in] ble_evt Event received.
- * @param[in] context HID Service structure.
+ * @param[in] ble_evt  Bluetooth LE stack event.
+ * @param[in] ble_hids Pointer to the @ref ble_hids instance.
  */
-void ble_hids_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_hids_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hids);
 
 /**
  * @brief Function for initializing the HID Service.

--- a/include/bm/bluetooth/services/ble_hrs.h
+++ b/include/bm/bluetooth/services/ble_hrs.h
@@ -29,7 +29,6 @@ extern "C" {
  */
 #define BLE_HRS_DEF(_name)                                                                         \
 	static struct ble_hrs _name;                                                               \
-	extern void ble_hrs_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);                       \
 	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_hrs_on_ble_evt, &_name, HIGH)
 
 /** @brief Default security configuration. */
@@ -309,6 +308,21 @@ uint32_t ble_hrs_sensor_contact_detected_update(struct ble_hrs *hrs,
  *         - @ref sd_ble_gatts_value_set()
  */
 uint32_t ble_hrs_body_sensor_location_set(struct ble_hrs *hrs, uint8_t body_sensor_location);
+
+/**
+ * @brief Bluetooth LE event handler for the Heart Rate Service.
+ *
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Heart Rate Service.
+ *
+ * @note This handler is registered automatically by @ref BLE_HRS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_hrs Pointer to the @ref ble_hrs instance.
+ */
+void ble_hrs_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hrs);
 
 #ifdef __cplusplus
 }

--- a/include/bm/bluetooth/services/ble_hrs_client.h
+++ b/include/bm/bluetooth/services/ble_hrs_client.h
@@ -169,17 +169,19 @@ uint32_t ble_hrs_client_init(struct ble_hrs_client *hrs_client,
 			     const struct ble_hrs_client_config *hrs_client_config);
 
 /**
- * @brief Handle Bluetooth LE events from the SoftDevice.
+ * @brief Bluetooth LE event handler for the Heart Rate Service Client.
  *
- * @details This function handles the Bluetooth LE events received from the SoftDevice.
- *          If an event is relevant to the Heart Rate Client module, the function uses
- *          the event's data to update interval variables and, if necessary, send events to the
- *          application.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Heart Rate Service Client.
  *
- * @param[in, out] ble_evt Bluetooth LE event.
- * @param[in] ctx Heart Rate Client structure.
+ * @note This handler is registered automatically by @ref BLE_HRS_CLIENT_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt        Bluetooth LE stack event.
+ * @param[in] ble_hrs_client Pointer to the @ref ble_hrs_client instance.
  */
-void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ctx);
+void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hrs_client);
 
 /**
  * @brief Request the peer to start sending notification of Heart Rate Measurement.

--- a/include/bm/bluetooth/services/ble_lbs.h
+++ b/include/bm/bluetooth/services/ble_lbs.h
@@ -37,7 +37,6 @@ struct ble_lbs;
  */
 #define BLE_LBS_DEF(_name)                                                                         \
 	static struct ble_lbs _name;                                                               \
-	extern void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs_instance);              \
 	NRF_SDH_BLE_OBSERVER(_name##_obs, ble_lbs_on_ble_evt, &_name, HIGH)
 
 /** @brief Default security configuration. */
@@ -147,15 +146,19 @@ struct ble_lbs {
 uint32_t ble_lbs_init(struct ble_lbs *lbs, const struct ble_lbs_config *cfg);
 
 /**
- * @brief Function for handling the application's Bluetooth LE stack events.
+ * @brief Bluetooth LE event handler for the LED Button Service.
  *
- * @details This function handles all events from the Bluetooth LE stack that are of interest to the
+ * @details Handles all Bluetooth LE stack events that are of interest to the
  *          LED Button Service.
  *
- * @param[in] ble_evt      Event received.
- * @param[in] lbs_instance LED Button Service structure.
+ * @note This handler is registered automatically by @ref BLE_LBS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_lbs Pointer to the @ref ble_lbs instance.
  */
-void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs_instance);
+void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *ble_lbs);
 
 /**
  * @brief Function for sending a button state notification.

--- a/include/bm/bluetooth/services/ble_nus.h
+++ b/include/bm/bluetooth/services/ble_nus.h
@@ -35,9 +35,6 @@ extern "C" {
 /** Byte 12 and 13 of the NUS TX Characteristic UUID. */
 #define BLE_UUID_NUS_TX_CHARACTERISTIC 0x0003
 
-/* Forward declaration */
-void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *context);
-
 /**
  * @brief Macro for defining a ble_nus instance.
  *
@@ -194,15 +191,19 @@ struct ble_nus {
 uint32_t ble_nus_init(struct ble_nus *nus, const struct ble_nus_config *nus_config);
 
 /**
- * @brief Function for handling the Nordic UART Service's Bluetooth LE events.
+ * @brief Bluetooth LE event handler for the Nordic UART Service.
  *
- * @note This function is registered automatically by @ref BLE_NUS_DEF
- *       and should not be called directly by the application.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Nordic UART Service.
  *
- * @param[in] ble_evt Event received from the SoftDevice.
- * @param[in] context Nordic UART Service structure.
+ * @note This handler is registered automatically by @ref BLE_NUS_DEF and is
+ *       called by the SoftDevice handler. The application does not need to call
+ *       it directly.
+ *
+ * @param[in] ble_evt Bluetooth LE stack event.
+ * @param[in] ble_nus Pointer to the @ref ble_nus instance.
  */
-void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *ble_nus);
 
 /**
  * @brief Send data on the NUS TX characteristic as a notification.

--- a/include/bm/bluetooth/services/ble_nus_client.h
+++ b/include/bm/bluetooth/services/ble_nus_client.h
@@ -198,16 +198,19 @@ void ble_nus_client_on_db_disc_evt(struct ble_nus_client *nus_client,
 				   const struct ble_db_discovery_evt *evt);
 
 /**
- * @brief Handle Bluetooth LE events from the SoftDevice.
+ * @brief Bluetooth LE event handler for the Nordic UART Service Client.
  *
- * @details This function handles the Bluetooth LE events received from the SoftDevice. If an
- *          event is relevant to the NUS library, the function uses the event's data to update
- *          internal variables and, if necessary, send events to the application.
+ * @details Handles all Bluetooth LE stack events that are of interest to the
+ *          Nordic UART Service Client.
  *
- * @param[in] ble_evt Bluetooth LE event.
- * @param[in] context NUS client structure.
+ * @note This handler is registered automatically by @ref BLE_NUS_CLIENT_DEF and
+ *       is called by the SoftDevice handler. The application does not need to
+ *       call it directly.
+ *
+ * @param[in] ble_evt        Bluetooth LE stack event.
+ * @param[in] ble_nus_client Pointer to the @ref ble_nus_client instance.
  */
-void ble_nus_client_on_ble_evt(const ble_evt_t *ble_evt, void *context);
+void ble_nus_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_nus_client);
 
 /**
  * @brief Request the peer to start sending notification of TX characteristic.

--- a/lib/bluetooth/ble_adv/ble_adv.c
+++ b/lib/bluetooth/ble_adv/ble_adv.c
@@ -8,6 +8,7 @@
 #include <bm/bluetooth/ble_adv_data.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(ble_adv, CONFIG_BLE_ADV_LOG_LEVEL);
@@ -478,21 +479,24 @@ uint32_t ble_adv_stop(struct ble_adv *ble_adv)
 	return NRF_SUCCESS;
 }
 
-void ble_adv_on_ble_evt(const ble_evt_t *ble_evt, void *instance)
+void ble_adv_on_ble_evt(const ble_evt_t *ble_evt, void *ble_adv)
 {
-	struct ble_adv *ble_adv = (struct ble_adv *)instance;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_adv, "ble_adv is NULL");
+
+	struct ble_adv *adv = ble_adv;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:
-		on_connected(ble_adv, ble_evt);
+		on_connected(adv, ble_evt);
 		break;
 	case BLE_GAP_EVT_DISCONNECTED:
 		/* Upon disconnection, activate allow list and start directed advertising */
-		on_disconnected(ble_adv, ble_evt);
+		on_disconnected(adv, ble_evt);
 		break;
 	case BLE_GAP_EVT_ADV_SET_TERMINATED:
 		/* Upon advertising time-out, move onto next advertising mode */
-		on_terminated(ble_adv, ble_evt);
+		on_terminated(adv, ble_evt);
 		break;
 	default:
 		/* Do nothing */

--- a/lib/bluetooth/ble_conn_state/ble_conn_state.c
+++ b/lib/bluetooth/ble_conn_state/ble_conn_state.c
@@ -372,11 +372,7 @@ uint32_t ble_conn_state_for_each_set_user_flag(uint16_t flag_index,
 	return for_each_set_flag(bcs.flags.user_flags[flag_index], user_function, ctx);
 }
 
-#ifdef CONFIG_UNITY
-void ble_evt_handler(const ble_evt_t *ble_evt, void *ctx)
-#else
 static void ble_evt_handler(const ble_evt_t *ble_evt, void *ctx)
-#endif
 {
 	int idx = nrf_sdh_ble_idx_get(ble_evt->evt.gap_evt.conn_handle);
 

--- a/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
+++ b/lib/bluetooth/ble_db_discovery/ble_db_discovery.c
@@ -654,11 +654,14 @@ static void on_disconnected(struct ble_db_discovery *db_discovery, const ble_gap
 	}
 }
 
-void ble_db_discovery_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_db_discovery_on_ble_evt(const ble_evt_t *ble_evt, void *ble_db_discovery)
 {
-	struct ble_db_discovery *const db_discovery = (struct ble_db_discovery *)context;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_db_discovery, "ble_db_discovery is NULL");
 
-	if (!ble_evt || !db_discovery || !db_discovery->gatt_queue) {
+	struct ble_db_discovery *const db_discovery = ble_db_discovery;
+
+	if (!db_discovery->gatt_queue) {
 		return;
 	}
 

--- a/lib/bluetooth/ble_gq/gatt_queue.c
+++ b/lib/bluetooth/ble_gq/gatt_queue.c
@@ -407,15 +407,14 @@ uint32_t ble_gq_conn_handle_register(const struct ble_gq *gq, uint16_t conn_hand
 	return NRF_SUCCESS;
 }
 
-void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *gatt_queue)
+void ble_gq_on_ble_evt(const ble_evt_t *ble_evt, void *ble_gq)
 {
-	const struct ble_gq *const gq = (struct ble_gq *)gatt_queue;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_gq, "ble_gq is NULL");
+
+	const struct ble_gq *const gq = ble_gq;
 	uint16_t conn_handle;
 	uint16_t conn_id;
-
-	if (ble_evt == NULL || gq == NULL) {
-		return;
-	}
 
 	/* Obtain connection handle and filter out events that do not trigger queue processing. */
 	if (ble_evt->header.evt_id == BLE_GAP_EVT_DISCONNECTED) {

--- a/lib/bluetooth/ble_qwr/ble_qwr.c
+++ b/lib/bluetooth/ble_qwr/ble_qwr.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <ble.h>
 #include <bm/bluetooth/ble_qwr.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 
 /* Non-zero value used to make sure the given structure has been initialized by the module. */
@@ -401,15 +402,12 @@ static void on_rw_authorize_request(struct ble_qwr *qwr, const ble_gatts_evt_t *
 #endif
 }
 
-void ble_qwr_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_qwr_on_ble_evt(const ble_evt_t *ble_evt, void *ble_qwr)
 {
-	struct ble_qwr *qwr;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_qwr, "ble_qwr is NULL");
 
-	if (!context || !ble_evt) {
-		return;
-	}
-
-	qwr = (struct ble_qwr *)context;
+	struct ble_qwr *qwr = ble_qwr;
 
 	if (qwr->initialized != BLE_QWR_INITIALIZED) {
 		return;

--- a/lib/bluetooth/ble_scan/ble_scan.c
+++ b/lib/bluetooth/ble_scan/ble_scan.c
@@ -836,9 +836,12 @@ static void ble_scan_on_connected_evt(const struct ble_scan *scan,
 	}
 }
 
-void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_scan_on_ble_evt(const ble_evt_t *ble_evt, void *ble_scan)
 {
-	struct ble_scan *scan = (struct ble_scan *)context;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_scan, "ble_scan is NULL");
+
+	struct ble_scan *scan = ble_scan;
 	const ble_gap_evt_adv_report_t *adv_report = &ble_evt->evt.gap_evt.params.adv_report;
 	const ble_gap_evt_t *gap_evt = &ble_evt->evt.gap_evt;
 

--- a/lib/bluetooth/peer_manager/modules/nrf_ble_lesc.c
+++ b/lib/bluetooth/peer_manager/modules/nrf_ble_lesc.c
@@ -342,6 +342,8 @@ static uint32_t lesc_oob_data_set(uint16_t conn_handle)
 
 void nrf_ble_lesc_on_ble_evt(const ble_evt_t *ble_evt)
 {
+	__ASSERT(ble_evt, "ble_evt is NULL");
+
 	uint32_t nrf_err = NRF_SUCCESS;
 	const uint16_t conn_handle = ble_evt->evt.gap_evt.conn_handle;
 	const int idx = nrf_sdh_ble_idx_get(conn_handle);

--- a/subsys/bluetooth/services/ble_bas/bas.c
+++ b/subsys/bluetooth/services/ble_bas/bas.c
@@ -108,10 +108,12 @@ static void on_write(struct ble_bas *bas, const ble_gatts_evt_t *gatts_evt)
 	bas->evt_handler(bas, &bas_evt);
 }
 
-void ble_bas_on_ble_evt(const ble_evt_t *ble_evt, void *bas)
+void ble_bas_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bas)
 {
-	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(bas, "BAS instance is NULL");
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_bas, "ble_bas is NULL");
+
+	struct ble_bas *bas = ble_bas;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTS_EVT_WRITE:

--- a/subsys/bluetooth/services/ble_bas_client/bas_client.c
+++ b/subsys/bluetooth/services/ble_bas_client/bas_client.c
@@ -11,6 +11,7 @@
 #include <bm/bluetooth/services/uuid.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(bas_client, CONFIG_BLE_BAS_CLIENT_LOG_LEVEL);
 
@@ -172,13 +173,12 @@ static void on_disconnected(struct ble_bas_client *bas_client, const ble_evt_t *
 	}
 }
 
-void ble_bas_client_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_bas_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bas_client)
 {
-	if ((ble_evt == NULL) || (context == NULL)) {
-		return;
-	}
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_bas_client, "ble_bas_client is NULL");
 
-	struct ble_bas_client *bas_client = (struct ble_bas_client *)context;
+	struct ble_bas_client *bas_client = ble_bas_client;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTC_EVT_HVX:

--- a/subsys/bluetooth/services/ble_bms/bms.c
+++ b/subsys/bluetooth/services/ble_bms/bms.c
@@ -416,15 +416,12 @@ uint16_t ble_bms_on_qwr_evt(struct ble_bms *bms, struct ble_qwr *qwr,
 	return BLE_GATT_STATUS_SUCCESS;
 }
 
-void ble_bms_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_bms_on_ble_evt(const ble_evt_t *ble_evt, void *ble_bms)
 {
-	struct ble_bms *bms;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_bms, "ble_bms is NULL");
 
-	if (!context || !ble_evt) {
-		return;
-	}
-
-	bms = (struct ble_bms *)context;
+	struct ble_bms *bms = ble_bms;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTS_EVT_RW_AUTHORIZE_REQUEST:

--- a/subsys/bluetooth/services/ble_cgms/cgms.c
+++ b/subsys/bluetooth/services/ble_cgms/cgms.c
@@ -18,6 +18,7 @@
 #include "cgms_socp.h"
 #include "cgms_sst.h"
 
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 
@@ -302,9 +303,12 @@ static void on_rw_authorize_request(struct ble_cgms *cgms, const ble_gatts_evt_t
 	}
 }
 
-void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_cgms_on_ble_evt(const ble_evt_t *ble_evt, void *ble_cgms)
 {
-	struct ble_cgms *cgms = (struct ble_cgms *)context;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_cgms, "ble_cgms is NULL");
+
+	struct ble_cgms *cgms = ble_cgms;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:

--- a/subsys/bluetooth/services/ble_hids/hids.c
+++ b/subsys/bluetooth/services/ble_hids/hids.c
@@ -597,13 +597,12 @@ static void on_rw_authorize_request(struct ble_hids *hids, const ble_evt_t *ble_
 	}
 }
 
-void ble_hids_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_hids_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hids)
 {
-	struct ble_hids *hids = (struct ble_hids *)context;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_hids, "ble_hids is NULL");
 
-	if (!hids) {
-		return;
-	}
+	struct ble_hids *hids = ble_hids;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:

--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -188,22 +188,24 @@ static void on_write(struct ble_hrs *hrs, const ble_gatts_evt_t *gatts_evt)
 	hrs->evt_handler(hrs, &hrs_evt);
 }
 
-void ble_hrs_on_ble_evt(const ble_evt_t *ble_evt, void *hrs_instance)
+void ble_hrs_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hrs)
 {
-	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(hrs_instance, "BLE instance is NULL");
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_hrs, "ble_hrs is NULL");
+
+	struct ble_hrs *hrs = ble_hrs;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:
-		on_connect(hrs_instance, &ble_evt->evt.gap_evt);
+		on_connect(hrs, &ble_evt->evt.gap_evt);
 		break;
 
 	case BLE_GAP_EVT_DISCONNECTED:
-		on_disconnect(hrs_instance, &ble_evt->evt.gap_evt);
+		on_disconnect(hrs, &ble_evt->evt.gap_evt);
 		break;
 
 	case BLE_GATTS_EVT_WRITE:
-		on_write(hrs_instance, &ble_evt->evt.gatts_evt);
+		on_write(hrs, &ble_evt->evt.gatts_evt);
 		break;
 
 	default:

--- a/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
+++ b/subsys/bluetooth/services/ble_hrs_client/ble_hrs_client.c
@@ -194,10 +194,12 @@ uint32_t ble_hrs_client_init(struct ble_hrs_client *hrs_client,
 	return ble_db_discovery_service_register(hrs_client_config->db_discovery, &hrs_uuid);
 }
 
-void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *hrs_client)
+void ble_hrs_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_hrs_client)
 {
-	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(hrs_client, "HRS central instance is NULL");
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_hrs_client, "ble_hrs_client is NULL");
+
+	struct ble_hrs_client *hrs_client = ble_hrs_client;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTC_EVT_HVX:

--- a/subsys/bluetooth/services/ble_lbs/lbs.c
+++ b/subsys/bluetooth/services/ble_lbs/lbs.c
@@ -35,10 +35,12 @@ static void on_write(struct ble_lbs *lbs, const ble_evt_t *ble_evt)
 	lbs->evt_handler(lbs, &lbs_evt);
 }
 
-void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *lbs)
+void ble_lbs_on_ble_evt(const ble_evt_t *ble_evt, void *ble_lbs)
 {
-	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(lbs, "LBS instance is NULL");
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_lbs, "ble_lbs is NULL");
+
+	struct ble_lbs *lbs = ble_lbs;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GATTS_EVT_WRITE:

--- a/subsys/bluetooth/services/ble_nus/nus.c
+++ b/subsys/bluetooth/services/ble_nus/nus.c
@@ -173,10 +173,12 @@ static void on_hvx_tx_complete(struct ble_nus *nus, const ble_evt_t *ble_evt)
 	}
 }
 
-void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *nus)
+void ble_nus_on_ble_evt(const ble_evt_t *ble_evt, void *ble_nus)
 {
-	__ASSERT(ble_evt, "BLE event is NULL");
-	__ASSERT(nus, "context is NULL");
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_nus, "ble_nus is NULL");
+
+	struct ble_nus *nus = ble_nus;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:

--- a/subsys/bluetooth/services/ble_nus_client/nus_client.c
+++ b/subsys/bluetooth/services/ble_nus_client/nus_client.c
@@ -7,6 +7,7 @@
 #include <bm/bluetooth/services/ble_nus_client.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(ble_nus_client, CONFIG_BLE_NUS_CLIENT_LOG_LEVEL);
 
@@ -111,13 +112,12 @@ uint32_t ble_nus_client_init(struct ble_nus_client *nus_client,
 	return ble_db_discovery_service_register(nus_client_config->db_discovery, &uart_uuid);
 }
 
-void ble_nus_client_on_ble_evt(const ble_evt_t *ble_evt, void *context)
+void ble_nus_client_on_ble_evt(const ble_evt_t *ble_evt, void *ble_nus_client)
 {
-	struct ble_nus_client *nus_client = (struct ble_nus_client *)context;
+	__ASSERT(ble_evt, "ble_evt is NULL");
+	__ASSERT(ble_nus_client, "ble_nus_client is NULL");
 
-	if (!nus_client || !ble_evt) {
-		return;
-	}
+	struct ble_nus_client *nus_client = ble_nus_client;
 
 	if (nus_client->conn_handle == BLE_CONN_HANDLE_INVALID) {
 		return;

--- a/subsys/storage/bm_storage/sd/bm_storage_sd.c
+++ b/subsys/storage/bm_storage/sd/bm_storage_sd.c
@@ -97,10 +97,7 @@ static const struct bm_storage_info bm_storage_info = {
 	.is_erase_before_write = false,
 };
 
-#ifndef CONFIG_UNITY
-static
-#endif
-void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx);
+static void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx);
 
 static bool on_operation_success(struct bm_storage_sd_op *op);
 
@@ -462,10 +459,7 @@ static bool bm_storage_sd_is_busy(const struct bm_storage *storage)
 	return (bm_storage_sd.queue_state != QUEUE_IDLE);
 }
 
-#ifndef CONFIG_UNITY
-static
-#endif
-int bm_storage_sd_on_state_evt(enum nrf_sdh_state_evt evt, void *ctx)
+static int bm_storage_sd_on_state_evt(enum nrf_sdh_state_evt evt, void *ctx)
 {
 	/* Are we ready to change state? */
 	bool is_busy = false;
@@ -498,10 +492,7 @@ int bm_storage_sd_on_state_evt(enum nrf_sdh_state_evt evt, void *ctx)
 }
 NRF_SDH_STATE_EVT_OBSERVER(sdh_state_evt, bm_storage_sd_on_state_evt, NULL, HIGH);
 
-#ifndef CONFIG_UNITY
-static
-#endif
-void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx)
+static void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx)
 {
 	bool operation_finished;
 

--- a/tests/subsys/fs/bm_zms/CMakeLists.txt
+++ b/tests/subsys/fs/bm_zms/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bm_zms)
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
   ${ZEPHYR_NRF_BM_MODULE_DIR}/subsys/fs/bm_zms
 )
 

--- a/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
@@ -25,7 +25,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
@@ -16,11 +16,6 @@ unity_softdevice_header_setup()
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv/CMakeLists.txt
@@ -10,21 +10,15 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_adv)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
@@ -25,7 +25,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
@@ -16,11 +16,6 @@ unity_softdevice_header_setup()
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_adv_data/CMakeLists.txt
@@ -10,21 +10,15 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_adv_data)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
@@ -27,7 +27,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)

--- a/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
@@ -19,11 +19,6 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_ble.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
@@ -12,6 +12,7 @@ project(unit_test_ble_conn_params)
 
 include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
 unity_softdevice_header_setup()
+unity_softdevice_event_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
@@ -22,8 +23,6 @@ zephyr_compile_definitions(
   NRF54L15_XXAA
   SUPPRESS_INLINE_IMPLEMENTATION
 )
-
-zephyr_linker_sources(SECTIONS evt_obs.ld)
 
 # Generate and add test file
 test_runner_generate(src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_params/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_conn_params)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
@@ -21,12 +20,7 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_b
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)

--- a/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
@@ -10,13 +10,13 @@
 #include <string.h>
 #include <stddef.h>
 #include <bm/bluetooth/ble_conn_params.h>
-#include <bm/softdevice_handler/nrf_sdh.h>
-#include <zephyr/sys/iterable_sections.h>
 
 #include "cmock_ble_gap.h"
 #include "cmock_ble_gattc.h"
 #include "cmock_ble_gatts.h"
 #include "cmock_nrf_sdh_ble.h"
+
+#include <sdh_evt_dispatch.h>
 
 #define BLE_GAP_DATA_LENGTH_DEFAULT 27
 
@@ -25,22 +25,6 @@
 #define ATT_MTU_INVALID (BLE_GATT_ATT_MTU_DEFAULT - 1)
 
 struct ble_conn_params_evt app_evt;
-
-/* Invoke the BLE event handlers in ble_conn_params, passing BLE event 'evt'. */
-void ble_evt_send(const ble_evt_t *evt)
-{
-	TYPE_SECTION_FOREACH(struct nrf_sdh_ble_evt_observer, nrf_sdh_ble_evt_observers, obs) {
-		obs->handler(evt, obs->context);
-	}
-}
-
-/* Invoke the state event handlers in ble_conn_params, passing state event. */
-void state_evt_send(enum nrf_sdh_state_evt state)
-{
-	TYPE_SECTION_FOREACH(struct nrf_sdh_state_evt_observer, nrf_sdh_state_evt_observers, obs) {
-		obs->handler(state, obs->context);
-	}
-}
 
 /* Event handler for conn params */
 void conn_params_evt_handler(const struct ble_conn_params_evt *evt)
@@ -73,7 +57,7 @@ void test_ble_evt_no_handler(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_conn_params_evt_handler_set(void)
@@ -206,7 +190,7 @@ void test_ble_conn_params_att_mtu_set_retry_after_busy(void)
 	__cmock_sd_ble_gattc_exchange_mtu_request_ExpectAndReturn(CONN_HANDLE, ATT_MTU_VALID,
 								  NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	/* Event is processed, not called again */
 
@@ -216,7 +200,7 @@ void test_ble_conn_params_att_mtu_set_retry_after_busy(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_conn_params_att_mtu_get_error_null(void)
@@ -351,7 +335,7 @@ void test_ble_conn_params_data_length_set_busy(void)
 	__cmock_sd_ble_gap_data_length_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &dlp_expected, 1, &dll_expected, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	/* Event is processed, not called again */
 
@@ -361,7 +345,7 @@ void test_ble_conn_params_data_length_set_busy(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_conn_params_data_length_set_resources(void)
@@ -646,7 +630,7 @@ void test_ble_conn_params_phy_radio_mode_set_busy(void)
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &phy_1mbps, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	/* Event is processed, not called again */
 
@@ -656,7 +640,7 @@ void test_ble_conn_params_phy_radio_mode_set_busy(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_conn_params_phy_radio_mode_get_error_null(void)
@@ -739,7 +723,7 @@ void test_ble_evt_connected(void)
 	__cmock_sd_ble_gap_conn_param_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &conn_params_expected, 1, NRF_ERROR_BUSY);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_connected_conn_params(void)
@@ -786,7 +770,7 @@ void test_ble_evt_connected_conn_params(void)
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &phy_supported, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_disconnected(void)
@@ -802,7 +786,7 @@ void test_ble_evt_disconnected(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_exchange_mtu_rsp(void)
@@ -822,7 +806,7 @@ void test_ble_evt_exchange_mtu_rsp(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -850,7 +834,7 @@ void test_ble_evt_exchange_mtu_request(void)
 	__cmock_sd_ble_gatts_exchange_mtu_reply_ExpectAndReturn(
 		CONN_HANDLE, ATT_MTU_VALID, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -878,7 +862,7 @@ void test_ble_evt_exchange_mtu_request_error(void)
 	__cmock_sd_ble_gatts_exchange_mtu_reply_ExpectAndReturn(
 		CONN_HANDLE, ATT_MTU_VALID, NRF_ERROR_BUSY);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_conn_param_update_accepted(void)
@@ -902,7 +886,7 @@ void test_ble_evt_conn_param_update_accepted(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_UPDATED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -946,7 +930,7 @@ void test_ble_evt_conn_param_update_negotiate(void)
 	__cmock_sd_ble_gap_conn_param_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &conn_params_expected, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_conn_param_update_busy(void)
@@ -979,7 +963,7 @@ void test_ble_evt_conn_param_update_busy(void)
 	__cmock_sd_ble_gap_conn_param_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &conn_params_expected, 1, NRF_ERROR_BUSY);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	/* Calls from BLE observers. */
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
@@ -990,7 +974,7 @@ void test_ble_evt_conn_param_update_busy(void)
 	__cmock_sd_ble_gap_disconnect_ExpectAndReturn(
 		CONN_HANDLE, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_REJECTED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -1018,7 +1002,7 @@ void test_ble_evt_data_length_update(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_DATA_LENGTH_UPDATED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -1059,7 +1043,7 @@ void test_ble_evt_data_length_update_request(void)
 	__cmock_sd_ble_gap_data_length_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &dlp_expected, 1, &dll_expected, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_ble_evt_phy_update(void)
@@ -1083,7 +1067,7 @@ void test_ble_evt_phy_update(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 
 	TEST_ASSERT_EQUAL(BLE_CONN_PARAMS_EVT_RADIO_PHY_MODE_UPDATED, app_evt.evt_type);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, app_evt.conn_handle);
@@ -1119,7 +1103,7 @@ void test_ble_evt_phy_update_request(void)
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &phy_auto, 1, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	sdh_evt_dispatch_ble(&ble_evt);
 }
 
 void test_sdh_state_evt(void)
@@ -1131,15 +1115,15 @@ void test_sdh_state_evt(void)
 		.conn_sup_timeout = CONFIG_BLE_CONN_PARAMS_SUP_TIMEOUT,
 	};
 
-	state_evt_send(NRF_SDH_STATE_EVT_DISABLED);
+	sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_DISABLED);
 
 	__cmock_sd_ble_gap_ppcp_set_ExpectWithArrayAndReturn(&ppcp, 1, NRF_ERROR_BUSY);
 
-	state_evt_send(NRF_SDH_STATE_EVT_BLE_ENABLED);
+	sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_BLE_ENABLED);
 
 	__cmock_sd_ble_gap_ppcp_set_ExpectWithArrayAndReturn(&ppcp, 1, NRF_SUCCESS);
 
-	state_evt_send(NRF_SDH_STATE_EVT_BLE_ENABLED);
+	sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_BLE_ENABLED);
 }
 
 void setUp(void)

--- a/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
@@ -22,7 +22,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
@@ -12,6 +12,7 @@ project(unit_test_ble_conn_state)
 
 include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
 unity_softdevice_header_setup()
+unity_softdevice_event_setup()
 
 zephyr_compile_definitions(
   NRF54L15_XXAA

--- a/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
@@ -10,18 +10,12 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_conn_state)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_conn_state/CMakeLists.txt
@@ -14,11 +14,6 @@ include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
 unity_softdevice_header_setup()
 unity_softdevice_event_setup()
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_conn_state/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_state/src/unity_test.c
@@ -11,6 +11,8 @@
 #include <bm/bluetooth/ble_conn_state.h>
 #include <zephyr/sys/util.h>
 
+#include <sdh_evt_dispatch.h>
+
 static uint16_t conn_handle1;
 static uint16_t conn_handle2 = 1;
 static uint16_t conn_handle3 = 2;
@@ -59,8 +61,6 @@ uint16_t nrf_sdh_ble_conn_handle_get(int idx)
 {
 	return conn_handles_registered[idx];
 }
-
-extern void ble_evt_handler(const ble_evt_t *ble_evt, void *ctx);
 
 static uint32_t arbitrary_context;
 /* Conn handle that will cause flag operations to overflow into next flag if not checked. */
@@ -158,14 +158,14 @@ void test_ble_conn_state_init(void)
 	conn_handle_register(conn_handle7);
 	conn_handle_register(conn_handle8);
 
-	ble_evt_handler(connected_evt(conn_handle1, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle2, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle4, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle5, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle6, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle7, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle8, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle4, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle5, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle6, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle7, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle8, dummy_role));
 
 	valid_conn_handles = ble_conn_state_conn_count();
 	TEST_ASSERT(valid_conn_handles > 0);
@@ -210,14 +210,14 @@ void test_ble_conn_state_valid(void)
 	conn_handle_register(conn_handle8);
 
 	/* Activate some conn. handles and check that those are reported as valid. */
-	ble_evt_handler(connected_evt(conn_handle1, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle2, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle4, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle5, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle6, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle7, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle8, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle4, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle5, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle6, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle7, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle8, dummy_role));
 
 	for (uint16_t conn_handle = 0; conn_handle < (65535); conn_handle++) {
 		valid = ble_conn_state_valid(conn_handle);
@@ -234,9 +234,9 @@ void test_ble_conn_state_valid(void)
 	/* Deactivate some conn handles and check that they are still valid
 	 * Handles which are disconnected should still be valid until a connect event occurs
 	 */
-	ble_evt_handler(disconnected_evt(conn_handle2), NULL);
-	ble_evt_handler(disconnected_evt(conn_handle3), NULL);
-	ble_evt_handler(disconnected_evt(conn_handle7), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle2));
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle3));
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle7));
 
 	for (uint16_t conn_handle = 0; conn_handle < (65535); conn_handle++) {
 		valid = ble_conn_state_valid(conn_handle);
@@ -257,7 +257,7 @@ void test_ble_conn_state_valid(void)
 	 * invalid
 	 */
 	conn_handle_register(conn_handle3);
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
 
 	for (uint16_t conn_handle = 0; conn_handle < (65535); conn_handle++) {
 		sprintf(msg, "conn_handle = %d", conn_handle);
@@ -293,7 +293,7 @@ void test_ble_conn_state_role(void)
 #if defined(BLE_GAP_ROLE_CENTRAL)
 	/* Activating a connection with CENTRAL role. */
 	conn_handle_register(conn_handle1);
-	ble_evt_handler(connected_evt(conn_handle1, BLE_GAP_ROLE_CENTRAL), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, BLE_GAP_ROLE_CENTRAL));
 
 	/* Test that the role is properly returned. */
 	role = ble_conn_state_role(conn_handle1);
@@ -306,26 +306,26 @@ void test_ble_conn_state_role(void)
 	/* Disconnect a handle and test that it still has a valid role,
 	 * until a new connection occurs.
 	 */
-	ble_evt_handler(disconnected_evt(conn_handle1), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle1));
 	role = ble_conn_state_role(conn_handle1);
 	TEST_ASSERT_EQUAL_UINT(BLE_GAP_ROLE_CENTRAL, role);
 
 	/* Test that a disconnected handle is invalidated after a connection has occurred. */
 	conn_handle_register(conn_handle2);
-	ble_evt_handler(connected_evt(conn_handle2, BLE_GAP_ROLE_CENTRAL), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, BLE_GAP_ROLE_CENTRAL));
 	role = ble_conn_state_role(conn_handle1);
 	TEST_ASSERT_EQUAL_UINT(BLE_GAP_ROLE_INVALID, role);
 #endif
 	/* (Re)activate both connections */
-	ble_evt_handler(disconnected_evt(conn_handle1), NULL);
-	ble_evt_handler(disconnected_evt(conn_handle2), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle1));
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle2));
 #if defined(BLE_GAP_ROLE_CENTRAL)
 	conn_handle_register(conn_handle1);
-	ble_evt_handler(connected_evt(conn_handle1, BLE_GAP_ROLE_CENTRAL), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, BLE_GAP_ROLE_CENTRAL));
 #endif
 
 	conn_handle_register(conn_handle2);
-	ble_evt_handler(connected_evt(conn_handle2, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, BLE_GAP_ROLE_PERIPH));
 
 #if defined(BLE_GAP_ROLE_CENTRAL)
 	role = ble_conn_state_role(conn_handle1);
@@ -370,7 +370,7 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(lesc);
 
 	/* Testing that an active, unencrypted handle returns unencrypted. */
-	ble_evt_handler(connected_evt(conn_handle1, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, BLE_GAP_ROLE_PERIPH));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -379,7 +379,7 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(lesc);
 
 	/* Testing that a security level of 2 or greater returns encrypted */
-	ble_evt_handler(conn_sec_update_evt(conn_handle1, 2), NULL);
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle1, 2));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -388,18 +388,18 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(lesc);
 
 	/* Testing that a successful auth_status with LESC returns LESC. */
-	ble_evt_handler(auth_status_evt(conn_handle1, false, BLE_GAP_SEC_STATUS_SUCCESS), NULL);
+	sdh_evt_dispatch_ble(auth_status_evt(conn_handle1, false, BLE_GAP_SEC_STATUS_SUCCESS));
 	lesc           = ble_conn_state_lesc(conn_handle1);
 	TEST_ASSERT_FALSE(lesc);
-	ble_evt_handler(auth_status_evt(conn_handle1, true, BLE_GAP_SEC_STATUS_UNSPECIFIED), NULL);
+	sdh_evt_dispatch_ble(auth_status_evt(conn_handle1, true, BLE_GAP_SEC_STATUS_UNSPECIFIED));
 	lesc           = ble_conn_state_lesc(conn_handle1);
 	TEST_ASSERT_FALSE(lesc);
-	ble_evt_handler(auth_status_evt(conn_handle1, true, BLE_GAP_SEC_STATUS_SUCCESS), NULL);
+	sdh_evt_dispatch_ble(auth_status_evt(conn_handle1, true, BLE_GAP_SEC_STATUS_SUCCESS));
 	lesc           = ble_conn_state_lesc(conn_handle1);
 	TEST_ASSERT(lesc);
 
 	/* level 3 returns MITM protected. */
-	ble_evt_handler(conn_sec_update_evt(conn_handle1, 3), NULL);
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle1, 3));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -408,7 +408,7 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(lesc);
 
 	/* level 4 returns LESC. */
-	ble_evt_handler(conn_sec_update_evt(conn_handle1, 4), NULL);
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle1, 4));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -417,7 +417,7 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT(lesc);
 
 	/* Testing that a security level of less than 2 returns unencrypted. */
-	ble_evt_handler(conn_sec_update_evt(conn_handle1, 0), NULL);
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle1, 0));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -425,7 +425,7 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(mitm_protected);
 	TEST_ASSERT_FALSE(lesc);
 
-	ble_evt_handler(conn_sec_update_evt(conn_handle1, 1), NULL);
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle1, 1));
 	encrypted      = ble_conn_state_encrypted(conn_handle1);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle1);
 	lesc           = ble_conn_state_lesc(conn_handle1);
@@ -434,8 +434,8 @@ void test_ble_conn_state_encrypted(void)
 	TEST_ASSERT_FALSE(lesc);
 
 	/* Adding a second connection. */
-	ble_evt_handler(connected_evt(conn_handle2, BLE_GAP_ROLE_PERIPH), NULL);
-	ble_evt_handler(conn_sec_update_evt(conn_handle2, 4), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, BLE_GAP_ROLE_PERIPH));
+	sdh_evt_dispatch_ble(conn_sec_update_evt(conn_handle2, 4));
 	encrypted      = ble_conn_state_encrypted(conn_handle2);
 	mitm_protected = ble_conn_state_mitm_protected(conn_handle2);
 	lesc           = ble_conn_state_lesc(conn_handle2);
@@ -486,9 +486,9 @@ void test_ble_conn_state_status(void)
 			       BLE_CONN_STATUS_INVALID);
 
 	/* Activating some conn handles. */
-	ble_evt_handler(connected_evt(conn_handle1, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle2, dummy_role), NULL);
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle2, dummy_role));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
 
 	/* Let's test they are connected */
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_CONNECTED);
@@ -496,14 +496,14 @@ void test_ble_conn_state_status(void)
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle3), BLE_CONN_STATUS_CONNECTED);
 
 	/* Disconnect one handle */
-	ble_evt_handler(disconnected_evt(conn_handle2), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle2));
 	/* Its status should be DISCONNECTED now */
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_CONNECTED);
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle2), BLE_CONN_STATUS_DISCONNECTED);
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle3), BLE_CONN_STATUS_CONNECTED);
 
 	/* Disconnect another handle */
-	ble_evt_handler(disconnected_evt(conn_handle3), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle3));
 	/* There should be two connections whose status is DISCONNECTED */
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_CONNECTED);
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle2), BLE_CONN_STATUS_DISCONNECTED);
@@ -517,7 +517,7 @@ void test_ble_conn_state_status(void)
 	TEST_ASSERT(valid);
 
 	/* Reactivate a connection handle */
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
 
 	/* After a connection event is received, disconnected connections are purged */
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_CONNECTED);
@@ -528,7 +528,7 @@ void test_ble_conn_state_status(void)
 	TEST_ASSERT_FALSE(valid);
 
 	/* Let's disconnect another handle */
-	ble_evt_handler(disconnected_evt(conn_handle1), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle1));
 
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_DISCONNECTED);
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle2), BLE_CONN_STATUS_INVALID);
@@ -539,18 +539,18 @@ void test_ble_conn_state_status(void)
 	valid = ble_conn_state_status(conn_handle2);
 	TEST_ASSERT_FALSE(valid);
 
-	ble_evt_handler(disconnected_evt(conn_handle3), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle3));
 #endif
 
 	dummy_role = BLE_GAP_ROLE_PERIPH;
 
-	ble_evt_handler(connected_evt(conn_handle1, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle1, dummy_role));
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_CONNECTED);
 
-	ble_evt_handler(disconnected_evt(conn_handle1), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handle1));
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_DISCONNECTED);
 
-	ble_evt_handler(connected_evt(conn_handle3, dummy_role), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handle3, dummy_role));
 	TEST_ASSERT_EQUAL_UINT(ble_conn_state_status(conn_handle1), BLE_CONN_STATUS_INVALID);
 
 	/* Testing overflow of conn_handle. */
@@ -576,7 +576,7 @@ void test_ble_conn_state_connections_and_list(void)
 	/* Activating all connections. Testing that n is updated. */
 	for (int i = 0; i < 8; i++) {
 		conn_handle_register(conn_handles[i]);
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH));
 	}
 
 	connections = ble_conn_state_conn_count();
@@ -588,7 +588,7 @@ void test_ble_conn_state_connections_and_list(void)
 
 	/* Deactivating all but one connection. Testing that n is updated */
 	for (int i = 1; i < 8; i++) {
-		ble_evt_handler(disconnected_evt(conn_handles[i]), NULL);
+		sdh_evt_dispatch_ble(disconnected_evt(conn_handles[i]));
 	}
 
 	connections = ble_conn_state_conn_count();
@@ -603,7 +603,7 @@ void test_ble_conn_state_connections_and_list(void)
 				       conn_handle_list.len);
 
 	/* Activate one connection. Testing that n is updated (should now be one). */
-	ble_evt_handler(connected_evt(conn_handles[0], BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handles[0], BLE_GAP_ROLE_PERIPH));
 
 	connections = ble_conn_state_conn_count();
 	TEST_ASSERT_EQUAL_UINT(1, connections);
@@ -613,7 +613,7 @@ void test_ble_conn_state_connections_and_list(void)
 
 	/* Activating all connections. Testing that n is updated (should now be 8). */
 	for (int i = 0; i < 8; i++) {
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH));
 	}
 
 	connections = ble_conn_state_conn_count();
@@ -646,7 +646,7 @@ void test_ble_conn_state_centrals_and_list(void)
 
 	/* Activating all connections. Testing that n is updated. */
 	for (int i = 0; i < 8; i++) {
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_CENTRAL), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_CENTRAL));
 	}
 
 	n_centrals = ble_conn_state_central_conn_count();
@@ -659,7 +659,7 @@ void test_ble_conn_state_centrals_and_list(void)
 
 	/* Deactivating all but one connection. Testing that n is unchanged */
 	for (int i = 1; i < 8; i++) {
-		ble_evt_handler(disconnected_evt(conn_handles[i]), NULL);
+		sdh_evt_dispatch_ble(disconnected_evt(conn_handles[i]));
 		/* Should still be valid */
 		valid = ble_conn_state_valid(conn_handles[i]);
 		TEST_ASSERT(valid);
@@ -677,7 +677,7 @@ void test_ble_conn_state_centrals_and_list(void)
 				       conn_handle_list.len);
 
 	/* Activate one connection. Testing that n is updated. */
-	ble_evt_handler(connected_evt(conn_handles[0], BLE_GAP_ROLE_CENTRAL), NULL);
+	sdh_evt_dispatch_ble(connected_evt(conn_handles[0], BLE_GAP_ROLE_CENTRAL));
 
 	n_centrals = ble_conn_state_central_conn_count();
 	TEST_ASSERT_EQUAL_UINT(1, n_centrals);
@@ -687,7 +687,7 @@ void test_ble_conn_state_centrals_and_list(void)
 
 	/* Activating all connections. Testing that n is updated. */
 	for (int i = 0; i < 8; i++) {
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_CENTRAL), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_CENTRAL));
 	}
 
 	n_centrals = ble_conn_state_central_conn_count();
@@ -711,11 +711,11 @@ void test_ble_conn_status_n_peripherals_and_handle(void)
 	 * correctly updated
 	 */
 	conn_handle_register(BLE_CONN_STATE_MAX_CONNECTIONS-1);
-	ble_evt_handler(connected_evt(BLE_CONN_STATE_MAX_CONNECTIONS-1, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(BLE_CONN_STATE_MAX_CONNECTIONS-1, BLE_GAP_ROLE_PERIPH));
 	TEST_ASSERT_EQUAL(1, ble_conn_state_peripheral_conn_count());
 
 	/* Disconnect the peripheral and check that the number is updated */
-	ble_evt_handler(disconnected_evt(BLE_CONN_STATE_MAX_CONNECTIONS-1), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(BLE_CONN_STATE_MAX_CONNECTIONS-1));
 	TEST_ASSERT_EQUAL(0, ble_conn_state_peripheral_conn_count());
 
 	/* The handle should not be in the list,
@@ -726,16 +726,16 @@ void test_ble_conn_status_n_peripherals_and_handle(void)
 	TEST_ASSERT(valid);
 
 	/* app_error_handler_bare_Expect(NRF_ERROR_NO_MEM); */
-	ble_evt_handler(connected_evt(BLE_CONN_STATE_MAX_CONNECTIONS, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(BLE_CONN_STATE_MAX_CONNECTIONS, BLE_GAP_ROLE_PERIPH));
 
 	/* app_error_handler_bare_Expect(NRF_ERROR_NO_MEM); */
 	conn_handle_register(1000);
-	ble_evt_handler(connected_evt(1000, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(1000, BLE_GAP_ROLE_PERIPH));
 
 	/* Connect some handles */
 	for (int i = 0; i < BLE_CONN_STATE_MAX_CONNECTIONS-1; i++) {
 		conn_handle_register(i);
-		ble_evt_handler(connected_evt(i, BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(connected_evt(i, BLE_GAP_ROLE_PERIPH));
 	}
 	/* Should report all peripherals */
 	TEST_ASSERT_EQUAL(BLE_CONN_STATE_MAX_CONNECTIONS-1, ble_conn_state_peripheral_conn_count());
@@ -787,7 +787,7 @@ void test_ble_conn_state_user_flag_set_get(void)
 
 	for (int i = 0; i < BLE_CONN_STATE_MAX_CONNECTIONS; i++) {
 		conn_handle_register(conn_handles[i]);
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH));
 	}
 
 	for (int i = 0; i < CONFIG_BLE_CONN_STATE_USER_FLAG_COUNT; i++) {
@@ -873,10 +873,10 @@ void test_ble_conn_state_user_flag_set_get(void)
 	}
 
 	/* Invalidate the connection handles by disconnecting them and reconnecting. */
-	ble_evt_handler(disconnected_evt(conn_handles[arbitrary_index1]), NULL);
-	ble_evt_handler(disconnected_evt(conn_handles[arbitrary_index2]), NULL);
-	ble_evt_handler(connected_evt(conn_handles[arbitrary_index1], BLE_GAP_ROLE_PERIPH), NULL);
-	ble_evt_handler(connected_evt(conn_handles[arbitrary_index2], BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handles[arbitrary_index1]));
+	sdh_evt_dispatch_ble(disconnected_evt(conn_handles[arbitrary_index2]));
+	sdh_evt_dispatch_ble(connected_evt(conn_handles[arbitrary_index1], BLE_GAP_ROLE_PERIPH));
+	sdh_evt_dispatch_ble(connected_evt(conn_handles[arbitrary_index2], BLE_GAP_ROLE_PERIPH));
 
 	for (int i = 0; i < CONFIG_BLE_CONN_STATE_USER_FLAG_COUNT; i++) {
 		/* Test that the flags are now 0 because of being invalidated. */
@@ -896,10 +896,10 @@ void test_ble_conn_state_conn_idx(void)
 	uint16_t conn_handle_err = BLE_CONN_STATE_MAX_CONNECTIONS+1;
 	uint16_t conn_handle_last = BLE_CONN_STATE_MAX_CONNECTIONS-1;
 
-	ble_evt_handler(connected_evt(0, BLE_GAP_ROLE_CENTRAL), NULL);
-	ble_evt_handler(connected_evt(1, BLE_GAP_ROLE_PERIPH), NULL);
-	ble_evt_handler(connected_evt(5, BLE_GAP_ROLE_CENTRAL), NULL);
-	ble_evt_handler(connected_evt(conn_handle_last, BLE_GAP_ROLE_CENTRAL), NULL);
+	sdh_evt_dispatch_ble(connected_evt(0, BLE_GAP_ROLE_CENTRAL));
+	sdh_evt_dispatch_ble(connected_evt(1, BLE_GAP_ROLE_PERIPH));
+	sdh_evt_dispatch_ble(connected_evt(5, BLE_GAP_ROLE_CENTRAL));
+	sdh_evt_dispatch_ble(connected_evt(conn_handle_last, BLE_GAP_ROLE_CENTRAL));
 
 	TEST_ASSERT_EQUAL(0, ble_conn_state_conn_idx(0));
 	TEST_ASSERT_EQUAL(1, ble_conn_state_conn_idx(1));
@@ -951,7 +951,7 @@ void test_ble_conn_state_for_each_set_user_flag(void)
 
 	for (int i = 0; i < 10; i++) {
 		conn_handle_register(conn_handles[i]);
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH));
 	}
 
 	/* No set flags. */
@@ -1011,8 +1011,8 @@ void test_ble_conn_state_for_each_set_user_flag(void)
 
 	/* No set flags. */
 	for (int i = 0; i < 10; i++) {
-		ble_evt_handler(disconnected_evt(conn_handles[i]), NULL);
-		ble_evt_handler(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH), NULL);
+		sdh_evt_dispatch_ble(disconnected_evt(conn_handles[i]));
+		sdh_evt_dispatch_ble(connected_evt(conn_handles[i], BLE_GAP_ROLE_PERIPH));
 	}
 	ble_conn_state_user_flag_set(conn_handles[3], flag_id2, 0);
 	calls_ret = ble_conn_state_for_each_set_user_flag(flag_id1, user_flag_function, NULL);
@@ -1028,9 +1028,9 @@ void test_ble_conn_state_for_each_connected(void)
 	calls_ret = ble_conn_state_for_each_connected(user_flag_function, NULL);
 	TEST_ASSERT_EQUAL(0, calls_ret);
 
-	ble_evt_handler(connected_evt(1, BLE_GAP_ROLE_CENTRAL), NULL);
-	ble_evt_handler(connected_evt(2, BLE_GAP_ROLE_CENTRAL), NULL);
-	ble_evt_handler(connected_evt(8, BLE_GAP_ROLE_PERIPH), NULL);
+	sdh_evt_dispatch_ble(connected_evt(1, BLE_GAP_ROLE_CENTRAL));
+	sdh_evt_dispatch_ble(connected_evt(2, BLE_GAP_ROLE_CENTRAL));
+	sdh_evt_dispatch_ble(connected_evt(8, BLE_GAP_ROLE_PERIPH));
 
 	expect_user_function_connected(1, NULL, 0);
 	expect_user_function_connected(2, NULL, 1);
@@ -1041,9 +1041,9 @@ void test_ble_conn_state_for_each_connected(void)
 	TEST_ASSERT_EQUAL(3, calls);
 	calls = 0;
 
-	ble_evt_handler(disconnected_evt(1), NULL);
-	ble_evt_handler(connected_evt(5, BLE_GAP_ROLE_PERIPH), NULL);
-	ble_evt_handler(disconnected_evt(8), NULL);
+	sdh_evt_dispatch_ble(disconnected_evt(1));
+	sdh_evt_dispatch_ble(connected_evt(5, BLE_GAP_ROLE_PERIPH));
+	sdh_evt_dispatch_ble(disconnected_evt(8));
 
 	expect_user_function_connected(2, NULL, 0);
 	expect_user_function_connected(5, NULL, 1);

--- a/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
@@ -24,7 +24,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
@@ -10,20 +10,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_db_discovery)
 
-set(SOFTDEVICE_VARIANT "s145")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/CMakeLists.txt
@@ -15,11 +15,6 @@ unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_db_discovery/src/unity_test.c
@@ -276,21 +276,6 @@ void test_ble_db_discovery_start_success(void)
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
-void test_ble_db_discovery_on_ble_evt_check_arg_null(void)
-{
-	uint32_t nrf_err;
-	ble_evt_t evt = {0};
-
-	ble_db_discovery_on_ble_evt(&evt, NULL);
-
-	ble_db_discovery_on_ble_evt(&evt, &db_discovery);
-
-	nrf_err = ble_db_discovery_init(&db_discovery, &db_disc_config);
-	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
-
-	ble_db_discovery_on_ble_evt(NULL, &db_discovery);
-}
-
 static uint32_t stub_ble_gq_item_scenario_discover_two_services(
 	const struct ble_gq *gatt_queue, struct ble_gq_req *req, uint16_t conn_handle,
 	int cmock_num_calls)

--- a/tests/unit/lib/bluetooth/ble_gq/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_gq/CMakeLists.txt
@@ -16,11 +16,6 @@ unity_softdevice_header_setup()
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_gq/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_gq/CMakeLists.txt
@@ -10,21 +10,15 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_gq)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_gq/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_gq/src/unity_test.c
@@ -596,11 +596,6 @@ void test_ble_gq_item_add_req_gatts_hvx_error_invalid_param(void)
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, glob_error);
 }
 
-void test_ble_gq_on_ble_evt_null(void)
-{
-	ble_gq_on_ble_evt(NULL, NULL);
-}
-
 void test_ble_gq_on_ble_evt_disconnected_event_item_purge(void)
 {
 	uint32_t nrf_err;

--- a/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
@@ -26,7 +26,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_qwr)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
@@ -20,12 +19,7 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_qwr/CMakeLists.txt
@@ -17,11 +17,6 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_qwr/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_qwr/src/unity_test.c
@@ -318,9 +318,7 @@ void test_ble_qwr_on_ble_evt_do_nothing(void)
 	const ble_evt_t ble_evt = {0};
 	struct ble_qwr qwr = {0};
 
-	/* We expect these to return immediately */
-	ble_qwr_on_ble_evt(&ble_evt, NULL);
-	ble_qwr_on_ble_evt(NULL, &qwr);
+	/* Uninitialized qwr: handler should return immediately. */
 	ble_qwr_on_ble_evt(&ble_evt, &qwr);
 }
 

--- a/tests/unit/lib/bluetooth/ble_racp/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_racp/CMakeLists.txt
@@ -10,10 +10,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_racp)
 
-zephyr_include_directories(
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
@@ -27,7 +27,6 @@ zephyr_compile_definitions(
 zephyr_include_directories(
   mocks
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
@@ -10,23 +10,20 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_radio_notif)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(mocks/cmsis.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_soc.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
   SWI02_IRQn=30
 )
 
 zephyr_include_directories(
   mocks
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_radio_notif/CMakeLists.txt
@@ -16,6 +16,8 @@ unity_softdevice_header_setup()
 cmock_handle(mocks/cmsis.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_soc.h)
 
+# NRF54L15_XXAA and SUPPRESS_INLINE_IMPLEMENTATION are required by nrf_soc.h.
+# SWI02_IRQn is provided by the mocked cmsis.h.
 zephyr_compile_definitions(
   NRF54L15_XXAA
   SUPPRESS_INLINE_IMPLEMENTATION

--- a/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
@@ -28,7 +28,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)

--- a/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_scan)
 
-set(SOFTDEVICE_VARIANT "s145")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
@@ -22,12 +21,7 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_adv_data.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)

--- a/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
@@ -24,8 +24,6 @@ zephyr_compile_definitions(
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
-zephyr_linker_sources(SECTIONS evt_obs.ld)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
+++ b/tests/unit/lib/bluetooth/ble_scan/CMakeLists.txt
@@ -19,11 +19,6 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_ble.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_adv_data.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/lib/bluetooth/ble_scan/evt_obs.ld
+++ b/tests/unit/lib/bluetooth/ble_scan/evt_obs.ld
@@ -1,1 +1,0 @@
-ITERABLE_SECTION_ROM(nrf_sdh_ble_evt_observers, 4)

--- a/tests/unit/lib/bluetooth/ble_scan/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_scan/src/unity_test.c
@@ -9,8 +9,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <bm/bluetooth/ble_scan.h>
-#include <bm/softdevice_handler/nrf_sdh.h>
-#include <zephyr/sys/iterable_sections.h>
 
 #include "cmock_ble_gap.h"
 #include "cmock_ble_gatts.h"
@@ -27,14 +25,6 @@ BLE_SCAN_DEF(ble_scan);
 
 static struct ble_scan_evt scan_event;
 static struct ble_scan_evt scan_event_prev;
-
-/* Invoke the BLE event handlers in ble_conn_params, passing BLE event 'evt'. */
-void ble_evt_send(const ble_evt_t *evt)
-{
-	TYPE_SECTION_FOREACH(struct nrf_sdh_ble_evt_observer, nrf_sdh_ble_evt_observers, obs) {
-		obs->handler(evt, obs->context);
-	}
-}
 
 void scan_event_handler_func(const struct ble_scan_evt *scan_evt)
 {
@@ -660,7 +650,7 @@ void test_ble_scan_on_ble_evt_adv_report_empty(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 
 	test_ble_scan_init();
 }
@@ -687,7 +677,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_name_bad_data(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 
 }
@@ -711,7 +701,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_address_not_found(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 }
 
@@ -734,7 +724,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_address(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(1, scan_event.filter_match.filter_match.address_filter_match);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.name_filter_match);
@@ -769,7 +759,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_name_not_found(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 }
 
@@ -797,7 +787,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_name(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.address_filter_match);
 	TEST_ASSERT_EQUAL(1, scan_event.filter_match.filter_match.name_filter_match);
@@ -837,7 +827,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_short_name_not_found(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 }
 
@@ -870,7 +860,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_short_name(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.address_filter_match);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.name_filter_match);
@@ -909,7 +899,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_appearance_not_found(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 }
 
@@ -941,7 +931,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_appearance(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.address_filter_match);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.name_filter_match);
@@ -1009,7 +999,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_name_and_appearance(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt_name);
+	ble_scan_on_ble_evt(&ble_evt_name, &ble_scan);
 
 	__cmock_ble_adv_data_appearance_find_ExpectWithArrayAndReturn(
 		ble_evt_appearance.evt.gap_evt.params.adv_report.data.p_data, 1,
@@ -1019,7 +1009,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_name_and_appearance(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(
 		NULL, &ble_scan.scan_buffer, NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt_appearance);
+	ble_scan_on_ble_evt(&ble_evt_appearance, &ble_scan);
 
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.address_filter_match);
@@ -1061,7 +1051,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_uuid_not_found(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_NOT_FOUND, scan_event.evt_type);
 }
 
@@ -1097,7 +1087,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_uuid(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.address_filter_match);
 	TEST_ASSERT_EQUAL(0, scan_event.filter_match.filter_match.name_filter_match);
@@ -1186,7 +1176,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_uuid_connect(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 
 	__cmock_ble_adv_data_uuid_find_ExpectWithArrayAndReturn(
@@ -1206,7 +1196,7 @@ void test_ble_scan_on_ble_evt_adv_report_device_uuid_connect(void)
 	__cmock_sd_ble_gap_scan_start_ExpectAndReturn(NULL, &ble_scan.scan_buffer,
 						      NRF_SUCCESS);
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_CONNECTING_ERROR, scan_event_prev.evt_type);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_FILTER_MATCH, scan_event.evt_type);
 }
@@ -1225,7 +1215,7 @@ void test_ble_scan_on_ble_evt_timeout(void)
 
 	test_ble_scan_init();
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_SCAN_TIMEOUT, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(BLE_GAP_TIMEOUT_SRC_SCAN, scan_event.timeout.src);
 }
@@ -1244,7 +1234,7 @@ void test_ble_scan_on_ble_evt_connected(void)
 
 	test_ble_scan_init();
 
-	ble_evt_send(&ble_evt);
+	ble_scan_on_ble_evt(&ble_evt, &ble_scan);
 	TEST_ASSERT_EQUAL(BLE_SCAN_EVT_CONNECTED, scan_event.evt_type);
 	TEST_ASSERT_EQUAL(1, scan_event.connected.connected->role);
 	TEST_ASSERT_EQUAL(CONN_HANDLE, scan_event.connected.conn_handle);

--- a/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
@@ -24,7 +24,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
@@ -15,11 +15,6 @@ unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas/CMakeLists.txt
@@ -10,20 +10,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_bas)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
@@ -27,7 +27,6 @@ zephyr_linker_sources(SECTIONS evt_obs.ld)
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
@@ -10,24 +10,18 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_bas_client)
 
-set(SOFTDEVICE_VARIANT "s145")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_db_discovery.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
-)
 
 # Generate and add test file
 test_runner_generate(src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
@@ -21,8 +21,6 @@ zephyr_compile_definitions(
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
-zephyr_linker_sources(SECTIONS evt_obs.ld)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/CMakeLists.txt
@@ -16,11 +16,6 @@ unity_softdevice_header_setup(VARIANT "s145")
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_db_discovery.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/evt_obs.ld
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/evt_obs.ld
@@ -1,1 +1,0 @@
-ITERABLE_SECTION_ROM(nrf_sdh_ble_evt_observers, 4)

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/prj.conf
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/prj.conf
@@ -1,7 +1,1 @@
-#
-# Copyright (c) 2026 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
 CONFIG_UNITY=y

--- a/tests/unit/subsys/bluetooth/services/ble_bas_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_bas_client/src/unity_test.c
@@ -29,14 +29,6 @@ BLE_DB_DISCOVERY_DEF(db_disc);
 
 static struct ble_bas_client_evt bas_client_evt;
 
-void ble_evt_send(const ble_evt_t *evt)
-{
-	TYPE_SECTION_FOREACH(struct nrf_sdh_ble_evt_observer, nrf_sdh_ble_evt_observers, obs)
-	{
-		obs->handler(evt, obs->context);
-	}
-}
-
 static void ble_bas_client_evt_handler(struct ble_bas_client *bas_client,
 				       const struct ble_bas_client_evt *evt)
 {

--- a/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
@@ -25,7 +25,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/mdk
 )
 

--- a/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
@@ -10,21 +10,18 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_bms)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_qwr.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
 zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/mdk
 )
 

--- a/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/CMakeLists.txt
@@ -16,11 +16,6 @@ unity_softdevice_header_setup()
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_qwr.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 zephyr_include_directories(
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/mdk
 )

--- a/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
@@ -500,10 +500,6 @@ void test_ble_bms_on_ble_evt_rw_authorize_req_uninitialized(void)
 	memcpy(evt.evt.gatts_evt.params.authorize_request.request.write.data,
 	       data, sizeof(data));
 
-	/* These should return immediately. */
-	ble_bms_on_ble_evt(&evt, NULL);
-	ble_bms_on_ble_evt(NULL, &ble_bms);
-
 	/* Unhandled as ctrlpt handle is not registered. */
 	ble_bms_on_ble_evt(&evt, &ble_bms);
 }
@@ -563,10 +559,6 @@ void test_ble_bms_on_ble_evt_rw_authorize_req(void)
 	};
 
 	test_ble_bms_init();
-
-	/* These should return immediately. */
-	ble_bms_on_ble_evt(&evt, NULL);
-	ble_bms_on_ble_evt(NULL, &ble_bms);
 
 	/* Empty data is rejected */
 	__cmock_sd_ble_gatts_rw_authorize_reply_Stub(stub_sd_ble_gatts_rw_authorize_reply_rejected);

--- a/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
@@ -24,7 +24,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
@@ -15,11 +15,6 @@ unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_dis/CMakeLists.txt
@@ -10,20 +10,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_dis)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
@@ -26,7 +26,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
@@ -17,11 +17,6 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_ble.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hids/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_hids)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
@@ -20,12 +19,7 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_b
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
@@ -24,7 +24,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
@@ -15,11 +15,6 @@ unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/CMakeLists.txt
@@ -10,20 +10,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_hrs)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs/src/unity_test.c
@@ -30,8 +30,6 @@ static struct ble_hrs_evt received_evt;
 static uint8_t captured_hvx_data[20];
 static uint16_t captured_hvx_len;
 
-void ble_hrs_on_ble_evt(const ble_evt_t *evt, struct ble_hrs *hrs);
-
 static uint32_t stub_sd_ble_gatts_characteristic_add(uint16_t service_handle,
 						     const ble_gatts_char_md_t *p_char_md,
 						     const ble_gatts_attr_t *p_attr_char_value,

--- a/tests/unit/subsys/bluetooth/services/ble_hrs_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs_client/CMakeLists.txt
@@ -26,7 +26,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_hrs_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_hrs_client/CMakeLists.txt
@@ -10,23 +10,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_hrs_client)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gattc.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gap.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_db_discovery.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
-
-zephyr_compile_definitions(
-  SVCALL_AS_NORMAL_FUNCTION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
-)
 
 # Generate and add test file
 test_runner_generate(src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
@@ -26,7 +26,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
@@ -17,11 +17,6 @@ cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_ble.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_nus)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble_gatts.h)
@@ -20,12 +19,7 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_b
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
-)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
 )
 
 # Generate and add test file

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
@@ -23,8 +23,6 @@ zephyr_compile_definitions(
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
-zephyr_linker_sources(SECTIONS evt_obs.ld)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
@@ -28,7 +28,6 @@ zephyr_compile_definitions(
 zephyr_linker_sources(SECTIONS evt_obs.ld)
 
 zephyr_include_directories(
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
   ${SOFTDEVICE_INCLUDE_DIR}
 )
 

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
@@ -18,11 +18,6 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh_ble.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_db_discovery.h)
 
-zephyr_compile_definitions(
-  NRF54L15_XXAA
-  SUPPRESS_INLINE_IMPLEMENTATION
-)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(unit_test_ble_nus_client)
 
-set(SOFTDEVICE_VARIANT "s145")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup(VARIANT "s145")
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/ble.h)
 cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_gq.h)
@@ -21,15 +20,10 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/bluetooth/ble_db_discovery.h
 
 zephyr_compile_definitions(
   NRF54L15_XXAA
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
 zephyr_linker_sources(SECTIONS evt_obs.ld)
-
-zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
-)
 
 # Generate and add test file
 test_runner_generate(src/unity_test.c)

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/evt_obs.ld
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/evt_obs.ld
@@ -1,1 +1,0 @@
-ITERABLE_SECTION_ROM(nrf_sdh_ble_evt_observers, 4)

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/prj.conf
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/prj.conf
@@ -1,6 +1,1 @@
-#
-# Copyright (c) 2026 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
 CONFIG_UNITY=y

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/src/unity_test.c
@@ -48,14 +48,6 @@ uint32_t stub_sd_ble_uuid_vs_add_success(ble_uuid128_t const *vs_uuid, uint8_t *
 	return NRF_SUCCESS;
 }
 
-void ble_evt_send(const ble_evt_t *evt)
-{
-	TYPE_SECTION_FOREACH(struct nrf_sdh_ble_evt_observer, nrf_sdh_ble_evt_observers, obs)
-	{
-		obs->handler(evt, obs->context);
-	}
-}
-
 static void ble_nus_client_evt_handler(struct ble_nus_client *ble_nus_client,
 				       const struct ble_nus_client_evt *ble_nus_evt)
 {
@@ -568,8 +560,6 @@ void test_ble_nus_client_on_ble_evt(void)
 
 	__cmock_ble_db_discovery_service_register_ExpectAnyArgsAndReturn(NRF_SUCCESS);
 	__cmock_ble_gq_conn_handle_register_ExpectAnyArgsAndReturn(NRF_SUCCESS);
-	__cmock_ble_db_discovery_on_ble_evt_ExpectAnyArgs();
-	__cmock_ble_gq_on_ble_evt_ExpectAnyArgs();
 	__cmock_sd_ble_uuid_vs_add_Stub(stub_sd_ble_uuid_vs_add_success);
 
 	nrf_err = ble_nus_client_init(&ble_nus_client, &nus_cfg);
@@ -580,9 +570,7 @@ void test_ble_nus_client_on_ble_evt(void)
 	ble_nus_client_handles_assign(&ble_nus_client, db_evt.conn_handle,
 				      &nus_client_evt.discovery_complete.handles);
 
-	__cmock_ble_db_discovery_on_ble_evt_ExpectAnyArgs();
-	__cmock_ble_gq_on_ble_evt_ExpectAnyArgs();
-	ble_evt_send(&ble_evt);
+	ble_nus_client_on_ble_evt(&ble_evt, &ble_nus_client);
 	TEST_ASSERT_EQUAL(BLE_NUS_CLIENT_EVT_TX_DATA, nus_client_evt.evt_type);
 	TEST_ASSERT_EQUAL(ble_evt.evt.gattc_evt.params.hvx.data[0],
 			  nus_client_evt.tx_data.data[0]);
@@ -591,7 +579,7 @@ void test_ble_nus_client_on_ble_evt(void)
 	ble_evt.header.evt_id = BLE_GAP_EVT_DISCONNECTED;
 	ble_evt.evt.gap_evt.conn_handle = test_case_conn_handle;
 	ble_evt.evt.gap_evt.params.disconnected.reason = BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION;
-	ble_evt_send(&ble_evt);
+	ble_nus_client_on_ble_evt(&ble_evt, &ble_nus_client);
 	TEST_ASSERT_EQUAL(BLE_NUS_CLIENT_EVT_DISCONNECTED, nus_client_evt.evt_type);
 	TEST_ASSERT_EQUAL(ble_evt.evt.gap_evt.params.disconnected.reason,
 			  nus_client_evt.disconnected.reason);

--- a/tests/unit/subsys/bluetooth/services/ble_nus_client/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_nus_client/src/unity_test.c
@@ -511,11 +511,6 @@ void test_ble_nus_client_handles_assign_error_null(void)
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_nus_client_on_ble_evt_null(void)
-{
-	ble_nus_client_on_ble_evt(NULL, NULL);
-}
-
 void test_ble_nus_client_on_ble_evt(void)
 {
 	uint32_t nrf_err;

--- a/tests/unit/subsys/storage/bm_storage/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage/CMakeLists.txt
@@ -10,8 +10,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(bm_storage)
 
-target_include_directories(app PRIVATE ${ZEPHYR_NRF_BM_MODULE_DIR}/include)
-
 # Generate and add test file
 test_runner_generate(src/unity_test.c)
 target_sources(app PRIVATE src/unity_test.c)

--- a/tests/unit/subsys/storage/bm_storage_rram/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage_rram/CMakeLists.txt
@@ -22,7 +22,6 @@ cmock_handle(${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/drivers/include/nrfx_rramc.h
 )
 
 zephyr_include_directories(
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/drivers/include
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/bsp/stable/templates

--- a/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
@@ -30,7 +30,6 @@ zephyr_compile_definitions(
 
 zephyr_include_directories(
   ${SOFTDEVICE_INCLUDE_DIR}
-  ${ZEPHYR_NRF_BM_MODULE_DIR}/include
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/bsp/stable
   ${ZEPHYR_BASE}/modules/hal_nordic/nrfx
 )

--- a/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
@@ -21,6 +21,7 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh.h
   FUNC_EXCLUDE "_handler" # Do not generate a mock for the prototype of the observer's handlers
 )
 
+# Required by nrf_soc.h.
 zephyr_compile_definitions(
   NRF54L15_XXAA
   NRF_APPLICATION

--- a/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
@@ -12,6 +12,7 @@ project(bm_storage_sd)
 
 include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
 unity_softdevice_header_setup()
+unity_softdevice_event_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_sdm.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_soc.h)

--- a/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
+++ b/tests/unit/subsys/storage/bm_storage_sd/CMakeLists.txt
@@ -10,9 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(bm_storage_sd)
 
-set(SOFTDEVICE_VARIANT "s115")
-set(SOFTDEVICE_INCLUDE_DIR "${ZEPHYR_NRF_BM_MODULE_DIR}/components/softdevice/nrf54l/\
-${SOFTDEVICE_VARIANT}/${SOFTDEVICE_VARIANT}_API/include")
+include(${ZEPHYR_NRF_BM_MODULE_DIR}/cmake/unity/unity_softdevice_setup.cmake)
+unity_softdevice_header_setup()
 
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_sdm.h)
 cmock_handle(${SOFTDEVICE_INCLUDE_DIR}/nrf_soc.h)
@@ -24,12 +23,10 @@ cmock_handle(${ZEPHYR_NRF_BM_MODULE_DIR}/include/bm/softdevice_handler/nrf_sdh.h
 zephyr_compile_definitions(
   NRF54L15_XXAA
   NRF_APPLICATION
-  SVCALL_AS_NORMAL_FUNCTION
   SUPPRESS_INLINE_IMPLEMENTATION
 )
 
 zephyr_include_directories(
-  ${SOFTDEVICE_INCLUDE_DIR}
   ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/bsp/stable
   ${ZEPHYR_BASE}/modules/hal_nordic/nrfx
 )

--- a/tests/unit/subsys/storage/bm_storage_sd/src/unity_test.c
+++ b/tests/unit/subsys/storage/bm_storage_sd/src/unity_test.c
@@ -10,8 +10,10 @@
 #include <zephyr/sys/util.h>
 
 #include <bm/storage/bm_storage.h>
+#include <bm/softdevice_handler/nrf_sdh.h>
 
-#include "bm/softdevice_handler/nrf_sdh.h"
+#include <sdh_evt_dispatch.h>
+
 #include "cmock_nrf_sdh.h"
 #include "cmock_nrf_sdm.h"
 #include "cmock_nrf_soc.h"
@@ -28,10 +30,7 @@
 #define WORD_SIZE(a) ((a) / sizeof(uint32_t))
 #define PTR_IGNORE NULL
 
-/* The backend's SoC event handler */
-extern void bm_storage_sd_on_soc_evt(uint32_t evt, void *ctx);
-/* The backend's SoftDevice state event handler */
-extern int bm_storage_sd_on_state_evt(enum nrf_sdh_state_evt evt, void *ctx);
+
 
 static struct bm_storage_evt storage_event;
 
@@ -192,7 +191,7 @@ void test_bm_storage_sd_uninit_outstanding(void)
 	err = bm_storage_uninit(&storage);
 	TEST_ASSERT_EQUAL(0, err);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	/* An event is generated regardless */
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
@@ -304,7 +303,7 @@ void test_bm_storage_sd_write(void)
 	is_busy = bm_storage_is_busy(&storage);
 	TEST_ASSERT_TRUE(is_busy);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -345,14 +344,14 @@ void test_bm_storage_sd_write_retry_etimedout(void)
 						       WORD_SIZE(sizeof(buf)), 0);
 
 		/* Operation times out and is retried */
-		bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_ERROR, NULL);
+		sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_ERROR);
 
 		/* No event is sent while we are retrying */
 		TEST_ASSERT_EQUAL(0, storage_event_received);
 	}
 
 	/* The last retry will send an error, and the operation is not retried */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_ERROR, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_ERROR);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -389,7 +388,7 @@ void test_bm_storage_sd_write_queued(void)
 	err = bm_storage_write(&storage, 0, buf, sizeof(buf), NULL);
 	TEST_ASSERT_EQUAL(0, err);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -401,7 +400,7 @@ void test_bm_storage_sd_write_queued(void)
 	/* Before the second operation is started, the SoftDevice changes state.
 	 * The backend is ready to change state since no operation is ongoing.
 	 */
-	is_busy = bm_storage_sd_on_state_evt(NRF_SDH_STATE_EVT_DISABLE_PREPARE, NULL);
+	is_busy = sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_DISABLE_PREPARE);
 	TEST_ASSERT_FALSE(is_busy);
 
 	/* Second call won't trigger a call to the SoftDevice */
@@ -414,7 +413,7 @@ void test_bm_storage_sd_write_queued(void)
 	/* This will trigger the next sd_flash_write() call.
 	 * Because the SoftDevice is disabled, the event is sent out immediately.
 	 */
-	is_busy = bm_storage_sd_on_state_evt(NRF_SDH_STATE_EVT_DISABLED, NULL);
+	is_busy = sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_DISABLED);
 	TEST_ASSERT_FALSE(is_busy);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
@@ -462,7 +461,7 @@ void test_bm_storage_sd_write_retry_queued(void)
 						       WORD_SIZE(sizeof(buf)), 0);
 
 		/* Operation times out and is retried */
-		bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_ERROR, NULL);
+		sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_ERROR);
 
 		/* No event is sent while we are retrying */
 		TEST_ASSERT_EQUAL(0, storage_event_received);
@@ -474,7 +473,7 @@ void test_bm_storage_sd_write_retry_queued(void)
 	/* The last retry will send an error, and the operation is not retried,
 	 * but the next one is started.
 	 */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_ERROR, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_ERROR);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -484,7 +483,7 @@ void test_bm_storage_sd_write_retry_queued(void)
 	TEST_ASSERT_EQUAL_PTR(buf, storage_event.src);
 	TEST_ASSERT_EQUAL(sizeof(buf), storage_event.len);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -540,7 +539,7 @@ void test_bm_storage_sd_write_queued_eio(void)
 		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)), 0);
 
 	/* First operation has completed, second is rejected and third is scheduled*/
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	/* First is okay */
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_events[0].id);
@@ -561,7 +560,7 @@ void test_bm_storage_sd_write_queued_eio(void)
 	TEST_ASSERT_EQUAL(sizeof(buf), storage_events[1].len);
 
 	/* Last operation succeeds */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -668,7 +667,7 @@ void test_bm_storage_sd_write_enomem(void)
 
 	for (size_t i = 0; i < CONFIG_BM_STORAGE_BACKEND_SD_QUEUE_SIZE + 1; i++) {
 		/* Each system events triggers the next operation in the queue */
-		bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+		sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 	}
 }
 
@@ -712,7 +711,7 @@ void test_bm_storage_sd_write_two_instances(void)
 	/* Upon receiving the SoC event for the fist operation, one event is sent to
 	 * the instance that scheduled the operation. The second instance is unaffected.
 	 */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -735,7 +734,7 @@ void test_bm_storage_sd_write_two_instances(void)
 	err = bm_storage_uninit(&storage);
 	TEST_ASSERT_EQUAL(0, err);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -770,7 +769,7 @@ void test_bm_storage_sd_write_disable_prepare(void)
 	/* Before an operation is started, the SoftDevice changes state.
 	 * The backend is ready to change state since no operation is ongoing.
 	 */
-	is_busy = bm_storage_sd_on_state_evt(NRF_SDH_STATE_EVT_DISABLE_PREPARE, NULL);
+	is_busy = sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_DISABLE_PREPARE);
 	TEST_ASSERT_FALSE(is_busy);
 
 	/* This call won't trigger a call to the SoftDevice yet */
@@ -783,7 +782,7 @@ void test_bm_storage_sd_write_disable_prepare(void)
 	/* This will trigger the next sd_flash_write() call.
 	 * Because the SoftDevice is disabled, the event is sent out immediately.
 	 */
-	is_busy = bm_storage_sd_on_state_evt(NRF_SDH_STATE_EVT_DISABLED, NULL);
+	is_busy = sdh_evt_dispatch_state(NRF_SDH_STATE_EVT_DISABLED);
 	TEST_ASSERT_FALSE(is_busy);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
@@ -866,10 +865,10 @@ void test_bm_storage_sd_write_softdevice_busy_retry(void)
 	__cmock_sd_flash_write_ExpectAndReturn(
 		(uint32_t *)PARTITION_START, (uint32_t *)buf, WORD_SIZE(sizeof(buf)), 0);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	/* The operation completes */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(true, storage_event.is_async);
@@ -975,11 +974,11 @@ void test_bm_storage_sd_write_chunk(void)
 		(uint32_t *)(buf + BLOCK_SIZE),
 		WORD_SIZE(sizeof(buf) - BLOCK_SIZE), 0);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_FALSE(storage_event_received);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_WRITE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -1042,12 +1041,12 @@ void test_bm_storage_sd_write_padded(void)
 	TEST_ASSERT_EQUAL(0, err);
 
 	/* One event for all the data up to the last word */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_FALSE(storage_event_received);
 
 	/* Last word being written separately, due to internal buffering */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_TRUE(storage_event_received);
 
@@ -1186,7 +1185,7 @@ void test_bm_storage_sd_erase(void)
 	is_busy = bm_storage_is_busy(&storage);
 	TEST_ASSERT_TRUE(is_busy);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_ERASE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -1232,11 +1231,11 @@ void test_bm_storage_sd_erase_chunk(void)
 		WORD_SIZE(storage.nvm_info->wear_unit), 0);
 	__cmock_sd_flash_write_IgnoreArg_p_src();
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_FALSE(storage_event_received);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_ERASE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -1280,7 +1279,7 @@ void test_bm_storage_sd_erase_odd(void)
 	is_busy = bm_storage_is_busy(&storage);
 	TEST_ASSERT_TRUE(is_busy);
 
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 
 	TEST_ASSERT_EQUAL(BM_STORAGE_EVT_ERASE_RESULT, storage_event.id);
 	TEST_ASSERT_EQUAL(0, storage_event.result);
@@ -1332,7 +1331,7 @@ void test_bm_storage_sd_erase_enomem(void)
 
 	for (size_t i = 0; i < CONFIG_BM_STORAGE_BACKEND_SD_QUEUE_SIZE + 1; i++) {
 		/* Each system events triggers the next operation in the queue */
-		bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
+		sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
 	}
 }
 
@@ -1384,11 +1383,11 @@ void test_bm_storage_sd_soc_event_handler(void)
 	TEST_ASSERT_EQUAL(0, err);
 
 	/* Nothing happens */
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_SUCCESS, NULL);
-	bm_storage_sd_on_soc_evt(NRF_EVT_FLASH_OPERATION_ERROR, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_SUCCESS);
+	sdh_evt_dispatch_soc(NRF_EVT_FLASH_OPERATION_ERROR);
 	/* Non-FLASH event, nothing happens */
-	bm_storage_sd_on_soc_evt(NRF_EVT_HFCLKSTARTED, NULL);
-	bm_storage_sd_on_soc_evt(NRF_EVT_RADIO_SESSION_IDLE, NULL);
+	sdh_evt_dispatch_soc(NRF_EVT_HFCLKSTARTED);
+	sdh_evt_dispatch_soc(NRF_EVT_RADIO_SESSION_IDLE);
 }
 
 void setUp(void)

--- a/tests/unit/util/sdh_evt_dispatch/include/sdh_evt_dispatch.h
+++ b/tests/unit/util/sdh_evt_dispatch/include/sdh_evt_dispatch.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @brief Test utility for dispatching SoftDevice events to registered observers.
+ *
+ * Allows unit tests to send BLE, SoC, and state events to all observers
+ * registered via NRF_SDH_BLE_OBSERVER, NRF_SDH_SOC_OBSERVER, and
+ * NRF_SDH_STATE_EVT_OBSERVER without needing to make handler functions
+ * non-static or extern.
+ */
+
+#ifndef SDH_EVT_DISPATCH_H__
+#define SDH_EVT_DISPATCH_H__
+
+#include <ble.h>
+#include <bm/softdevice_handler/nrf_sdh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Dispatch a BLE event to all registered BLE observers.
+ *
+ * Iterates the nrf_sdh_ble_evt_observers iterable section and invokes
+ * each observer's handler in priority order.
+ *
+ * @param evt BLE event to dispatch.
+ */
+void sdh_evt_dispatch_ble(const ble_evt_t *evt);
+
+/**
+ * @brief Dispatch a SoC event to all registered SoC observers.
+ *
+ * Iterates the nrf_sdh_soc_evt_observers iterable section and invokes
+ * each observer's handler in priority order.
+ *
+ * @param evt_id SoC event ID to dispatch.
+ */
+void sdh_evt_dispatch_soc(uint32_t evt_id);
+
+/**
+ * @brief Dispatch a state event to all registered state observers.
+ *
+ * Iterates the nrf_sdh_state_evt_observers iterable section and invokes
+ * each observer's handler in priority order.
+ *
+ * @param state State event to dispatch.
+ * @returns Non-zero if any observers were busy, zero otherwise.
+ */
+int sdh_evt_dispatch_state(enum nrf_sdh_state_evt state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDH_EVT_DISPATCH_H__ */

--- a/tests/unit/util/sdh_evt_dispatch/sdh_evt_dispatch.c
+++ b/tests/unit/util/sdh_evt_dispatch/sdh_evt_dispatch.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <sdh_evt_dispatch.h>
+#include <bm/softdevice_handler/nrf_sdh_ble.h>
+#include <bm/softdevice_handler/nrf_sdh_soc.h>
+#include <zephyr/sys/iterable_sections.h>
+
+void sdh_evt_dispatch_ble(const ble_evt_t *evt)
+{
+	TYPE_SECTION_FOREACH(struct nrf_sdh_ble_evt_observer,
+			     nrf_sdh_ble_evt_observers, obs) {
+		obs->handler(evt, obs->context);
+	}
+}
+
+void sdh_evt_dispatch_soc(uint32_t evt_id)
+{
+	TYPE_SECTION_FOREACH(struct nrf_sdh_soc_evt_observer,
+			     nrf_sdh_soc_evt_observers, obs) {
+		obs->handler(evt_id, obs->context);
+	}
+}
+
+int sdh_evt_dispatch_state(enum nrf_sdh_state_evt state)
+{
+	int is_busy;
+
+	TYPE_SECTION_FOREACH(struct nrf_sdh_state_evt_observer,
+			     nrf_sdh_state_evt_observers, obs) {
+		is_busy = obs->handler(state, obs->context);
+
+		if (is_busy) {
+			return is_busy;
+		}
+	}
+
+	return 0;
+}

--- a/tests/unit/util/sdh_evt_dispatch/sdh_evt_dispatch.ld
+++ b/tests/unit/util/sdh_evt_dispatch/sdh_evt_dispatch.ld
@@ -1,2 +1,3 @@
 ITERABLE_SECTION_ROM(nrf_sdh_ble_evt_observers, 4)
+ITERABLE_SECTION_ROM(nrf_sdh_soc_evt_observers, 4)
 ITERABLE_SECTION_RAM(nrf_sdh_state_evt_observers, 4)


### PR DESCRIPTION
Add a small helper file to dispatch SoftDevice events to registered observers. This avoids boilerplate in tests, and clutter in the implementations under test to keep the observer's handlers global when compiling unit test.