### PR TITLE
peer_manager: Fixes to pm_peer_data_store() pds_peer_data_read() functions

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -158,6 +158,7 @@ Libraries
    * Removed the ``CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE`` Kconfig option.
      The PSA Crypto core can deduce the key slot buffer size based on the keys enabled in the build, so there is no need to define the size manually.
    * Fixed the :c:func:`pm_peer_data_store`, :c:func:`pm_peer_data_remote_db_store` and :c:func:`pm_peer_data_app_data_store` functions to allow data lengths that are not word aligned.
+   * Added a missing word alignment check of the ``data`` parameter to the :c:func:`pm_peer_data_store` function.
 
 * :ref:`lib_bm_buttons` library:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -157,6 +157,7 @@ Libraries
    * Updated the ``params`` union field of the :c:struct:`pm_evt` structure to an anonymous union.
    * Removed the ``CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE`` Kconfig option.
      The PSA Crypto core can deduce the key slot buffer size based on the keys enabled in the build, so there is no need to define the size manually.
+   * Fixed the :c:func:`pm_peer_data_store`, :c:func:`pm_peer_data_remote_db_store` and :c:func:`pm_peer_data_app_data_store` functions to allow data lengths that are not word aligned.
 
 * :ref:`lib_bm_buttons` library:
 

--- a/lib/bluetooth/peer_manager/include/modules/peer_data_storage.h
+++ b/lib/bluetooth/peer_manager/include/modules/peer_data_storage.h
@@ -58,7 +58,7 @@ uint32_t pds_init(void);
  *
  * @param[in]  peer_id   The peer the data belongs to.
  * @param[in]  data_id   The data to retrieve.
- * @param[out] data      The peer data. May not be @c NULL. data.length_words and data.data_id
+ * @param[out] data      The peer data. May not be @c NULL. data.length and data.data_id
  *                       are ignored. data.all_data is ignored if @p buf_len is @c NULL.
  * @param[in]  buf_len   Length of the provided buffer, in bytes. Pass @c NULL to only copy
  *                       a pointer to the data in flash.

--- a/lib/bluetooth/peer_manager/include/modules/peer_manager_internal.h
+++ b/lib/bluetooth/peer_manager/include/modules/peer_manager_internal.h
@@ -35,8 +35,8 @@ extern "C" {
  * @note This type is deprecated.
  */
 struct pm_peer_data {
-	/** @brief The length of the data in words. */
-	uint16_t length_words;
+	/** @brief Length of data in bytes. */
+	uint16_t length;
 	/**
 	 * @brief ID that specifies the type of data (defines which member of the union is
 	 *        used).
@@ -81,8 +81,8 @@ struct pm_peer_data {
  * @note This type is deprecated.
  */
 struct pm_peer_data_const {
-	/** @brief The length of the data in words. */
-	uint16_t length_words;
+	/** @brief Length of data in bytes. */
+	uint16_t length;
 	/**
 	 * @brief ID that specifies the type of data (defines which member of the union is
 	 *        used).

--- a/lib/bluetooth/peer_manager/modules/gatt_cache_manager.c
+++ b/lib/bluetooth/peer_manager/modules/gatt_cache_manager.c
@@ -597,7 +597,7 @@ void store_car_value(uint16_t conn_handle, bool car_value)
 
 	struct pm_peer_data_const peer_data = {
 		.data_id = PM_PEER_DATA_ID_CENTRAL_ADDR_RES,
-		.length_words = 1,
+		.length = sizeof(uint32_t),
 	};
 
 	pm_conn_state_user_flag_set(conn_handle, flag_car_update_pending, false);

--- a/lib/bluetooth/peer_manager/modules/gatts_cache_manager.c
+++ b/lib/bluetooth/peer_manager/modules/gatts_cache_manager.c
@@ -80,7 +80,7 @@ static void service_changed_pending_set(void)
 
 	struct pm_peer_data_const peer_data = {
 		.data_id = PM_PEER_DATA_ID_SERVICE_CHANGED_PENDING,
-		.length_words = PM_SC_STATE_N_WORDS(),
+		.length = sizeof(uint32_t),
 		.service_changed_pending = (bool *)&service_changed_pending,
 	};
 
@@ -379,7 +379,7 @@ void gscm_db_change_notification_done(uint16_t peer_id)
 
 	struct pm_peer_data_const peer_data = {
 		.data_id = PM_PEER_DATA_ID_SERVICE_CHANGED_PENDING,
-		.length_words = PM_SC_STATE_N_WORDS(),
+		.length = sizeof(uint32_t),
 		.service_changed_pending = (bool *)&service_changed_pending,
 	};
 

--- a/lib/bluetooth/peer_manager/modules/peer_data_storage.c
+++ b/lib/bluetooth/peer_manager/modules/peer_data_storage.c
@@ -417,8 +417,7 @@ uint32_t pds_peer_data_store(uint16_t peer_id, const struct pm_peer_data_const *
 
 	uint32_t entry_id = peer_id_peer_data_id_to_entry_id(peer_id, peer_data->data_id);
 
-	ret = bm_zms_write(&fs, entry_id, peer_data->all_data,
-			   peer_data->length_words * BYTES_PER_WORD);
+	ret = bm_zms_write(&fs, entry_id, peer_data->all_data, peer_data->length);
 	if (ret < 0) {
 		LOG_ERR("Could not write data to NVM. bm_zms_write() returned %d. "
 			"peer_id: %d",

--- a/lib/bluetooth/peer_manager/modules/peer_data_storage.c
+++ b/lib/bluetooth/peer_manager/modules/peer_data_storage.c
@@ -369,7 +369,6 @@ uint32_t pds_peer_data_read(uint16_t peer_id, enum pm_peer_data_id data_id,
 			    struct pm_peer_data *const data, const uint32_t *const buf_len)
 {
 	ssize_t ret;
-	uint8_t temp_buf[PM_PEER_DATA_MAX_SIZE] = { 0 };
 
 	__ASSERT_NO_MSG(module_initialized);
 	__ASSERT_NO_MSG(data != NULL);
@@ -381,7 +380,7 @@ uint32_t pds_peer_data_read(uint16_t peer_id, enum pm_peer_data_id data_id,
 
 	uint32_t entry_id = peer_id_peer_data_id_to_entry_id(peer_id, data_id);
 
-	ret = bm_zms_read(&fs, entry_id, temp_buf, sizeof(temp_buf));
+	ret = bm_zms_read(&fs, entry_id, data->all_data, *buf_len);
 	if (ret == -ENOENT) {
 		LOG_DBG("Could not read entry %d. bm_zms_read() returned %d. "
 			"peer_id: %d, data_id: %d", entry_id,
@@ -393,8 +392,6 @@ uint32_t pds_peer_data_read(uint16_t peer_id, enum pm_peer_data_id data_id,
 			ret, peer_id);
 		return NRF_ERROR_INTERNAL;
 	}
-
-	memcpy(data->all_data, temp_buf, MIN(*buf_len, ret));
 
 	if (*buf_len < ret) {
 		return NRF_ERROR_DATA_SIZE;

--- a/lib/bluetooth/peer_manager/modules/peer_database.c
+++ b/lib/bluetooth/peer_manager/modules/peer_database.c
@@ -260,7 +260,7 @@ static void peer_data_point_to_buffer(struct pm_peer_data *peer_data,
 	peer_data->data_id = data_id;
 
 	peer_data->all_data = (struct pm_peer_data_bonding *)buffer_memory;
-	peer_data->length_words = BYTES_TO_WORDS(n_bytes);
+	peer_data->length = n_bytes;
 }
 
 static void peer_data_const_point_to_buffer(struct pm_peer_data_const *peer_data,
@@ -271,20 +271,20 @@ static void peer_data_const_point_to_buffer(struct pm_peer_data_const *peer_data
 				  n_bufs);
 }
 
-static void write_buf_length_words_set(struct pm_peer_data_const *peer_data)
+static void write_buf_length_set(struct pm_peer_data_const *peer_data)
 {
 	switch (peer_data->data_id) {
 	case PM_PEER_DATA_ID_BONDING:
-		peer_data->length_words = PM_BONDING_DATA_N_WORDS();
+		peer_data->length = sizeof(struct pm_peer_data_bonding);
 		break;
 	case PM_PEER_DATA_ID_SERVICE_CHANGED_PENDING:
-		peer_data->length_words = PM_SC_STATE_N_WORDS();
+		peer_data->length = sizeof(uint32_t);
 		break;
 	case PM_PEER_DATA_ID_PEER_RANK:
-		peer_data->length_words = PM_USAGE_INDEX_N_WORDS();
+		peer_data->length = sizeof(uint32_t);
 		break;
 	case PM_PEER_DATA_ID_GATT_LOCAL:
-		peer_data->length_words = PM_LOCAL_DB_N_WORDS(peer_data->local_gatt_db->len);
+		peer_data->length = peer_data->local_gatt_db->len + PM_LOCAL_DB_LEN_OVERHEAD_BYTES;
 		break;
 	default:
 		/* No action needed. */
@@ -323,7 +323,7 @@ uint32_t write_buf_store(struct pdb_buffer_record *write_buffer_record)
 
 	peer_data_const_point_to_buffer(&peer_data, write_buffer_record->data_id, buffer_memory,
 					write_buffer_record->n_bufs);
-	write_buf_length_words_set(&peer_data);
+	write_buf_length_set(&peer_data);
 
 	nrf_err = pds_peer_data_store(write_buffer_record->peer_id, &peer_data,
 				      &write_buffer_record->store_token);
@@ -594,7 +594,7 @@ uint32_t pdb_write_buf_get(uint16_t peer_id, enum pm_peer_data_id data_id, uint3
 
 	peer_data_point_to_buffer(peer_data, data_id, buffer_memory, n_bufs);
 	if (new_record && (data_id == PM_PEER_DATA_ID_GATT_LOCAL)) {
-		peer_data->local_gatt_db->len = PM_LOCAL_DB_LEN(peer_data->length_words);
+		peer_data->local_gatt_db->len = peer_data->length - PM_LOCAL_DB_LEN_OVERHEAD_BYTES;
 	}
 
 	return NRF_SUCCESS;

--- a/lib/bluetooth/peer_manager/peer_manager.c
+++ b/lib/bluetooth/peer_manager/peer_manager.c
@@ -842,7 +842,7 @@ uint32_t pm_peer_data_store(uint16_t peer_id, enum pm_peer_data_id data_id, cons
 	struct pm_peer_data_const peer_data;
 
 	memset(&peer_data, 0, sizeof(peer_data));
-	peer_data.length_words = BYTES_TO_WORDS(length);
+	peer_data.length = length;
 	peer_data.data_id = data_id;
 	peer_data.all_data = data;
 
@@ -925,7 +925,7 @@ uint32_t pm_peer_new(uint16_t *new_peer_id, struct pm_peer_data_bonding *bonding
 
 	peer_data.data_id = PM_PEER_DATA_ID_BONDING;
 	peer_data.bonding_data = bonding_data;
-	peer_data.length_words = BYTES_TO_WORDS(sizeof(struct pm_peer_data_bonding));
+	peer_data.length = sizeof(struct pm_peer_data_bonding);
 
 	nrf_err = pds_peer_data_store(*new_peer_id, &peer_data, token);
 
@@ -1095,7 +1095,7 @@ uint32_t pm_peer_rank_highest(uint16_t peer_id)
 
 	uint32_t nrf_err;
 	struct pm_peer_data_const peer_data = {
-		.length_words = BYTES_TO_WORDS(sizeof(current_highest_peer_rank)),
+		.length = sizeof(current_highest_peer_rank),
 		.data_id = PM_PEER_DATA_ID_PEER_RANK,
 		.peer_rank = &current_highest_peer_rank};
 

--- a/lib/bluetooth/peer_manager/peer_manager.c
+++ b/lib/bluetooth/peer_manager/peer_manager.c
@@ -823,6 +823,10 @@ uint32_t pm_peer_data_store(uint16_t peer_id, enum pm_peer_data_id data_id, cons
 		return NRF_ERROR_NULL;
 	}
 
+	if (!IS_ALIGNED(data, BYTES_PER_WORD)) {
+		return NRF_ERROR_INVALID_ADDR;
+	}
+
 	if (data_id == PM_PEER_DATA_ID_BONDING) {
 		uint16_t dupl_peer_id;
 

--- a/lib/bluetooth/peer_manager/peer_manager.c
+++ b/lib/bluetooth/peer_manager/peer_manager.c
@@ -823,10 +823,6 @@ uint32_t pm_peer_data_store(uint16_t peer_id, enum pm_peer_data_id data_id, cons
 		return NRF_ERROR_NULL;
 	}
 
-	if (!IS_ALIGNED(length, 4)) {
-		return NRF_ERROR_INVALID_PARAM;
-	}
-
 	if (data_id == PM_PEER_DATA_ID_BONDING) {
 		uint16_t dupl_peer_id;
 


### PR DESCRIPTION
Fixes to  pm_peer_data_store() and pds_peer_data_read() functions. See commits for more details.