### PR TITLE
doc: nrf-bm: add templates for supported boards

### DIFF
--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
@@ -1,0 +1,26 @@
+**S115**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
+         * - `nRF54L15 DK`_
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+         * - `nRF54L15 DK`_ (emulating nRF54L10)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+         * - `nRF54L15 DK`_ (emulating nRF54L05)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+         * - `nRF54LM20 DK`_
+           - PCA10184
+           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+         * - nRF54LS05 DK
+           - PCA10214
+           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
+         * - `nRF54LV10 DK`_
+           - PCA10188
+           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot

--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
@@ -1,0 +1,26 @@
+**S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
+         * - `nRF54L15 DK`_
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+         * - `nRF54L15 DK`_ (emulating nRF54L10)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+         * - `nRF54L15 DK`_ (emulating nRF54L05)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+         * - `nRF54LM20 DK`_
+           - PCA10184
+           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+         * - nRF54LS05 DK
+           - PCA10214
+           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
+         * - `nRF54LV10 DK`_
+           - PCA10188
+           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
@@ -1,0 +1,26 @@
+**S115**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
+         * - `nRF54L15 DK`_
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+         * - `nRF54L15 DK`_ (emulating nRF54L10)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+         * - `nRF54L15 DK`_ (emulating nRF54L05)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+         * - `nRF54LM20 DK`_
+           - PCA10184
+           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+         * - nRF54LS05 DK
+           - PCA10214
+           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
+         * - `nRF54LV10 DK`_
+           - PCA10188
+           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
@@ -1,0 +1,26 @@
+**S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
+         * - `nRF54L15 DK`_
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+         * - `nRF54L15 DK`_ (emulating nRF54L10)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+         * - `nRF54L15 DK`_ (emulating nRF54L05)
+           - PCA10156
+           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+         * - `nRF54LM20 DK`_
+           - PCA10184
+           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+         * - nRF54LS05 DK
+           - PCA10214
+           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
+         * - `nRF54LV10 DK`_
+           - PCA10188
+           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice

--- a/samples/bluetooth/ble_bms/README.rst
+++ b/samples/bluetooth/ble_bms/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_cgms/README.rst
+++ b/samples/bluetooth/ble_cgms/README.rst
@@ -20,121 +20,18 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
+
 
 Overview
 ********

--- a/samples/bluetooth/ble_hids_keyboard/README.rst
+++ b/samples/bluetooth/ble_hids_keyboard/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_hids_mouse/README.rst
+++ b/samples/bluetooth/ble_hids_mouse/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_hrs/README.rst
+++ b/samples/bluetooth/ble_hrs/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_hrs_central/README.rst
+++ b/samples/bluetooth/ble_hrs_central/README.rst
@@ -20,73 +20,13 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
-
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
-
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_lbs/README.rst
+++ b/samples/bluetooth/ble_lbs/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_nus/README.rst
+++ b/samples/bluetooth/ble_nus/README.rst
@@ -21,121 +21,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_nus_central/README.rst
+++ b/samples/bluetooth/ble_nus_central/README.rst
@@ -21,73 +21,13 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
-
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
-
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -22,121 +22,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Optionally, you can use the `Power Profiler Kit II (PPK2)`_ for power profiling and optimizing your configuration.
 You can also use your proprietary solution for measuring the power consumption.

--- a/samples/bluetooth/ble_radio_notification/README.rst
+++ b/samples/bluetooth/ble_radio_notification/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/hello_softdevice/README.rst
+++ b/samples/bluetooth/hello_softdevice/README.rst
@@ -22,121 +22,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -30,88 +30,92 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
 
    .. group-tab:: MCUboot board variants
 
-      The following board variants have DFU capabilities.
+      The following board variants have DFU capabilities:
+
+      **S115**:
 
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
 
 The sample additionally requires an NFC polling device (for example, a smartphone or a tablet with NFC support).

--- a/samples/boot/mcuboot_recovery_entry/README.rst
+++ b/samples/boot/mcuboot_recovery_entry/README.rst
@@ -15,61 +15,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. list-table::
-   :header-rows: 1
+.. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-   * - Hardware platform
-     - PCA
-     - SoftDevice
-     - Board target
-   * - `nRF54L15 DK`_
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L10)
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L05)
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54LM20 DK`_
-     - PCA10184
-     - S115
-     - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-   * - nRF54LS05 DK
-     - PCA10214
-     - S115
-     - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54LV10 DK`_
-     - PCA10188
-     - S115
-     - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L10)
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L05)
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54LM20 DK`_
-     - PCA10184
-     - S145
-     - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-   * - nRF54LS05 DK
-     - PCA10214
-     - S145
-     - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54LV10 DK`_
-     - PCA10188
-     - S145
-     - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+.. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/boot/mcuboot_recovery_retention/README.rst
+++ b/samples/boot/mcuboot_recovery_retention/README.rst
@@ -15,61 +15,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. list-table::
-   :header-rows: 1
+.. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-   * - Hardware platform
-     - PCA
-     - SoftDevice
-     - Board target
-   * - `nRF54L15 DK`_
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L10)
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L05)
-     - PCA10156
-     - S115
-     - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54LM20 DK`_
-     - PCA10184
-     - S115
-     - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-   * - nRF54LS05 DK
-     - PCA10214
-     - S115
-     - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54LV10 DK`_
-     - PCA10188
-     - S115
-     - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-   * - `nRF54L15 DK`_
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L10)
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54L15 DK`_ (emulating nRF54L05)
-     - PCA10156
-     - S145
-     - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54LM20 DK`_
-     - PCA10184
-     - S145
-     - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-   * - nRF54LS05 DK
-     - PCA10214
-     - S145
-     - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-   * - `nRF54LV10 DK`_
-     - PCA10188
-     - S145
-     - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+.. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/nfc/record_text_t2t/README.rst
+++ b/samples/nfc/record_text_t2t/README.rst
@@ -21,88 +21,92 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
 
 The sample also requires a smartphone or tablet.

--- a/samples/nfc/record_text_t4t/README.rst
+++ b/samples/nfc/record_text_t4t/README.rst
@@ -21,88 +21,92 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
 
 The sample also requires a smartphone or tablet.

--- a/samples/peripherals/buttons/README.rst
+++ b/samples/peripherals/buttons/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 
 User interface

--- a/samples/peripherals/leds/README.rst
+++ b/samples/peripherals/leds/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/peripherals/lpuarte/README.rst
+++ b/samples/peripherals/lpuarte/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 The sample also requires the following pins to be connected, as defined in the boards :file:`board-config.h` header:
 

--- a/samples/peripherals/ppi/README.rst
+++ b/samples/peripherals/ppi/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/peripherals/pwm/README.rst
+++ b/samples/peripherals/pwm/README.rst
@@ -20,92 +20,95 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
+      **S115**:
+
       .. list-table::
          :header-rows: 1
 
          * - Hardware platform
            - PCA
-           - SoftDevice
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S115
            - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S115
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
          * - nRF54LS05 DK
            - PCA10214
-           - S115
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
+
+      **S145**:
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Hardware platform
+           - PCA
+           - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - S145
            - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
          * - `nRF54LM20 DK`_
            - PCA10184
-           - S145
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
 
 Overview

--- a/samples/peripherals/timer/README.rst
+++ b/samples/peripherals/timer/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/peripherals/uarte/README.rst
+++ b/samples/peripherals/uarte/README.rst
@@ -20,121 +20,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Overview
 ********

--- a/samples/subsys/fs/bm_zms/README.rst
+++ b/samples/subsys/fs/bm_zms/README.rst
@@ -23,113 +23,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Kconfig fragments
 *****************

--- a/samples/subsys/fs/bm_zms/sample.yaml
+++ b/samples/subsys/fs/bm_zms/sample.yaml
@@ -24,7 +24,9 @@ tests:
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
+      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
+      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice

--- a/samples/subsys/storage/bm_storage/README.rst
+++ b/samples/subsys/storage/bm_storage/README.rst
@@ -23,113 +23,17 @@ The sample supports the following development kits:
 
       The following board variants do **not** have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S115
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
-           - PCA10214
-           - S145
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+      .. include:: /includes/supported_boards_all_non-mcuboot_variants_s145.txt
 
    .. group-tab:: MCUboot board variants
 
       The following board variants have DFU capabilities:
 
-      .. list-table::
-         :header-rows: 1
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s115.txt
 
-         * - Hardware platform
-           - PCA
-           - SoftDevice
-           - Board target
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S115
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S115
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S115
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-         * - `nRF54L15 DK`_
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L10)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54L15 DK`_ (emulating nRF54L05)
-           - PCA10156
-           - S145
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LM20 DK`_
-           - PCA10184
-           - S145
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - `nRF54LV10 DK`_
-           - PCA10188
-           - S145
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+      .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
 Kconfig fragments
 *****************

--- a/samples/subsys/storage/bm_storage/sample.yaml
+++ b/samples/subsys/storage/bm_storage/sample.yaml
@@ -24,7 +24,9 @@ tests:
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
+      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
+      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice


### PR DESCRIPTION
Add templates for supported boards that can be used in sample documentation for samples that support all board variants, or selected subsets. For other samples with special support, we keep the tables.