### PR TITLE
samples: bluetooth: move initialized log before adv_start

### DIFF
--- a/samples/bluetooth/ble_bms/src/main.c
+++ b/samples/bluetooth/ble_bms/src/main.c
@@ -697,6 +697,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE BMS sample initialized");
+
 	nrf_err = advertising_start(erase_bonds);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -704,9 +707,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE BMS sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -872,6 +872,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE CGMS sample initialized");
+
 	nrf_err = advertising_start(erase_bonds);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -879,9 +882,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE CGMS sample initialized");
 
 idle:
 	/* Enter main loop. */

--- a/samples/bluetooth/ble_hids_keyboard/src/main.c
+++ b/samples/bluetooth/ble_hids_keyboard/src/main.c
@@ -950,6 +950,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE HIDS Keyboard sample initialized");
+
 	nrf_err = advertising_start(erase_bonds);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -957,9 +960,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE HIDS Keyboard sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_hids_mouse/src/main.c
+++ b/samples/bluetooth/ble_hids_mouse/src/main.c
@@ -771,6 +771,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE HIDS Mouse sample initialized");
+
 	nrf_err = advertising_start(erase_bonds);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -778,9 +781,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE HIDS Mouse sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -543,12 +543,12 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE HRS sample initialized");
+
 	simulated_meas_start();
 
 	advertising_start(erase_bonds);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE HRS sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -728,10 +728,10 @@ int main(void)
 		goto idle;
 	}
 
-	scan_start(erase_bonds);
-
 	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 	LOG_INF("BLE HRS Central sample initialized");
+
+	scan_start(erase_bonds);
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -230,6 +230,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE LBS sample initialized");
+
 	nrf_err = ble_adv_start(&ble_adv, BLE_ADV_MODE_FAST);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -237,9 +240,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE LBS sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -545,6 +545,12 @@ int main(void)
 	}
 #endif
 
+#if !defined(CONFIG_SAMPLE_NUS_LPUARTE)
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+#endif
+
+	LOG_INF("BLE NUS sample initialized");
+
 	nrf_err = ble_adv_start(&ble_adv, BLE_ADV_MODE_FAST);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -552,12 +558,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-#if !defined(CONFIG_SAMPLE_NUS_LPUARTE)
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-#endif
-
-	LOG_INF("BLE NUS sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -703,7 +703,11 @@ int main(void)
 		goto idle;
 	}
 
-	LOG_INF("Services initialized");
+#if defined(CONFIG_SAMPLE_BLE_PWR_PROFILING_LED)
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+#endif
+
+	LOG_INF("BLE PWR Profiling sample initialized");
 
 	err = bm_buttons_enable();
 	if (err) {
@@ -723,12 +727,6 @@ int main(void)
 		LOG_INF("No advertising selected, schedule power off in 5 seconds");
 		err = bm_timer_start(&poweroff_timer, BM_TIMER_MS_TO_TICKS(5000), NULL);
 	}
-
-#if defined(CONFIG_SAMPLE_BLE_PWR_PROFILING_LED)
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-#endif
-
-	LOG_INF("BLE PWR Profiling sample initialized");
 
 idle:
 	while (true) {

--- a/samples/bluetooth/ble_radio_notification/src/main.c
+++ b/samples/bluetooth/ble_radio_notification/src/main.c
@@ -156,6 +156,9 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
+	LOG_INF("BLE Radio Notification sample initialized");
+
 	nrf_err = ble_adv_start(&ble_adv, BLE_ADV_MODE_FAST);
 	if (nrf_err) {
 		LOG_ERR("Failed to start advertising, nrf_error %#x", nrf_err);
@@ -163,9 +166,6 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
-
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
-	LOG_INF("BLE Radio Notification sample initialized");
 
 idle:
 	while (true) {


### PR DESCRIPTION
Advertising start is not part of the initialization. This also matches the expected output in the documentation.