### PR TITLE
samples: bluetooth: ble_pwr_profiling: disable CONFIG_BM_UARTE_CONSOLE

### DIFF
--- a/samples/bluetooth/ble_pwr_profiling/prj.conf
+++ b/samples/bluetooth/ble_pwr_profiling/prj.conf
@@ -1,5 +1,6 @@
 # Disable Console for power optimization
 CONFIG_CONSOLE=n
+CONFIG_BM_UARTE_CONSOLE=n
 
 # SoftDevice
 CONFIG_SOFTDEVICE=y


### PR DESCRIPTION
Disable CONFIG_BM_UARTE_CONSOLE to remove a build warning. It is already disabled as CONFIG_CONSOLE is disabled.