### PR TITLE
samples: bluetooth: readme: miscellaneous sample doc fixes

### DIFF
--- a/samples/bluetooth/ble_bms/README.rst
+++ b/samples/bluetooth/ble_bms/README.rst
@@ -79,7 +79,7 @@ Testing
 #. Open `nRF Connect for Desktop`_.
 #. Open the `Bluetooth Low Energy app`_ and select the connected device that is used for communication.
 #. Connect to the device from the app.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. Bind with the device:
 
    a. Click the :guilabel:`Settings` button for the device in the app.

--- a/samples/bluetooth/ble_cgms/README.rst
+++ b/samples/bluetooth/ble_cgms/README.rst
@@ -84,7 +84,7 @@ Testing
    You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
    For information on how to do this, see `Configuring Kconfig`_.
 #. Connect to your device using the `nRF Toolbox`_ mobile application with the :guilabel:`Continuous Glucose` service.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. Your mobile phone should now attempt to pair with your device to encrypt the link.
    When prompted, check that the passkeys are the same before confirming by pressing **Button 0** on the kit and confirming on the mobile phone.
 

--- a/samples/bluetooth/ble_cgms/README.rst
+++ b/samples/bluetooth/ble_cgms/README.rst
@@ -89,6 +89,5 @@ Testing
    When prompted, check that the passkeys are the same before confirming by pressing **Button 0** on the kit and confirming on the mobile phone.
 
 #. Observe that the text ``Connected`` and ``CGMS Start Session`` is printed in the COM listener.
-#. Observe that you receive the simulated battery status of the kit in the mobile application.
 #. Observe that you receive the CGMS records in the mobile application.
    The default time between each record is one minute.

--- a/samples/bluetooth/ble_hids_keyboard/README.rst
+++ b/samples/bluetooth/ble_hids_keyboard/README.rst
@@ -92,12 +92,12 @@ Testing
     If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
+   The terminal output in |VSC| indicates ``Peer connected``.
+
    After having connected, your computer or mobile phone may attempt to pair or bond with your device in order to encrypt the link.
 
    You may be prompted to compare or enter a passkey as part of the authentication step.
    If prompted, provide the passkey from the terminal output, or confirm that the passkey is correct by pressing **Button 0** on the kit.
-
-   The terminal output in |VSC| indicates ``Peer connected``.
 #. Observe that the device is detected as a keyboard.
 #. Repeatedly press **Button 3** on the kit.
    Every button press sends one character of the test message "hello" to your device (the test message includes a carriage return).

--- a/samples/bluetooth/ble_hids_keyboard/README.rst
+++ b/samples/bluetooth/ble_hids_keyboard/README.rst
@@ -89,7 +89,7 @@ Testing
    You can configure the advertising name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
    For information on how to do this, see `Configuring Kconfig`_.
 #. On your computer or mobile phone, open the Bluetooth settings and scan for advertising devices.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
    The terminal output in |VSC| indicates ``Peer connected``.

--- a/samples/bluetooth/ble_hids_mouse/README.rst
+++ b/samples/bluetooth/ble_hids_mouse/README.rst
@@ -90,7 +90,7 @@ You can test this sample using a computer or a smartphone.
    You can configure the advertising name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
    For information on how to do this, see `Configuring Kconfig`_.
 #. On your computer or mobile phone, open the Bluetooth settings and scan for advertising devices.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
    The terminal output in |VSC| indicates ``Peer connected``.

--- a/samples/bluetooth/ble_hids_mouse/README.rst
+++ b/samples/bluetooth/ble_hids_mouse/README.rst
@@ -93,10 +93,10 @@ You can test this sample using a computer or a smartphone.
     If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
+   The terminal output in |VSC| indicates ``Peer connected``.
+
    After having connected, your computer or mobile phone may attempt to pair or bond with your device in order to encrypt the link.
 
    You may be prompted to compare or enter a passkey as part of the authentication step.
    If prompted, provide the passkey from the terminal output, or confirm that the passkey is correct by pressing **Button 0** on the kit.
-
-   The terminal output in |VSC| indicates ``Peer connected``.
 #. Observe that the device is detected as a mouse, and you can move the mouse by pressing the buttons on the DK.

--- a/samples/bluetooth/ble_hrs/README.rst
+++ b/samples/bluetooth/ble_hrs/README.rst
@@ -91,10 +91,11 @@ Make sure that these are installed before starting the testing procedure.
     If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
+   The terminal output in |VSC| indicates ``Peer connected``.
+
    After having connected, your computer or mobile phone may attempt to pair or bond with your device in order to encrypt the link.
 
    You may be prompted to enter a passkey as part of the authentication step.
    If prompted, provide the passkey from the terminal output.
-   The terminal output in |VSC| indicates ``Peer connected``.
 #. Observe that the services are shown in the connected device and that you can start receiving values for the Heart Rate and the Battery Service by clicking the Play button.
    Heart Rate notifications are received every second, and Battery Level notifications are received every two seconds.

--- a/samples/bluetooth/ble_hrs/README.rst
+++ b/samples/bluetooth/ble_hrs/README.rst
@@ -88,7 +88,7 @@ Make sure that these are installed before starting the testing procedure.
    You can configure the advertising name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
    For information on how to do this, see `Configuring Kconfig`_.
 #. In nRF Connect for Desktop, scan for advertising devices.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
 
    The terminal output in |VSC| indicates ``Peer connected``.

--- a/samples/bluetooth/ble_lbs/README.rst
+++ b/samples/bluetooth/ble_lbs/README.rst
@@ -80,3 +80,5 @@ Make sure that these are installed before starting the testing procedure.
    The terminal output in |VSC| indicates ``Received LED ON!``.
 #. Change the :guilabel:`Blinky LED state` value back to :guilabel:`00`.
    The terminal output in |VSC| indicates ``Received LED OFF!``.
+#. In the :guilabel:`Blinky Button State` characteristic, subscribe to button notifications by pressing the :guilabel:`Toggle notifications` button.
+#. Observe that you receive a button state notification when pressing **Button 2** on the kit.

--- a/samples/bluetooth/ble_lbs/README.rst
+++ b/samples/bluetooth/ble_lbs/README.rst
@@ -73,7 +73,7 @@ Make sure that these are installed before starting the testing procedure.
    You can configure the advertising name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
    For information on how to do this, see `Configuring Kconfig`_.
 #. In nRF Connect for Desktop, scan for advertising devices.
-    If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+   If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
 #. :guilabel:`Connect` to your device.
    The terminal output in |VSC| indicates ``Peer connected``.
 #. In nRF Connect for Desktop, go to :guilabel:`Nordic LED and Button Service` and change :guilabel:`Blinky LED state` to :guilabel:`01`.

--- a/samples/bluetooth/ble_nus/README.rst
+++ b/samples/bluetooth/ble_nus/README.rst
@@ -91,7 +91,7 @@ The sample can be tested in two ways, depending on the selected UART configurati
          You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
          For information on how to do this, see `Configuring Kconfig`_.
       #. Connect to your device using the `nRF Toolbox`_ mobile application with the :guilabel:`Universal Asynchronous Receiver/Transmitter (UART)` service.
-          If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
+         If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
       #. Write a text in the second COM listener running on the computer and press Enter.
       #. Write a text in the terminal on the mobile phone and press :guilabel:`Send`.
          Observe that the text is displayed in the second COM listener running on the computer.

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -132,44 +132,24 @@ The Peripheral Power Profiling sample allows configuring some of its settings us
 You can set different options to monitor the power consumption of your development kit.
 You can modify the following options (available in the Kconfig file at :file:`samples/bluetooth/ble_pwr_profiling`):
 
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_CHAR_VALUE_LEN:
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CHAR_VALUE_LEN` - Sets the length of the data sent through notification mechanism.
 
-CONFIG_SAMPLE_BLE_PWR_PROFILING_CHAR_VALUE_LEN - Notification data length
-   Sets the length of the data sent through notification mechanism.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT` - Sets the notification timeout in milliseconds.
+  When the timeout is reached, the device will stop sending notifications.
+  After that, the sample disconnects and enters the system off mode.
 
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT:
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT` - Sets the connectable advertising duration in N*10 milliseconds unit.
+  If the connection is not established during advertising, the device enters the system off state.
 
-CONFIG_SAMPLE_BLE_PWR_PROFILING_NOTIF_CONNECTION_TIMEOUT - Notification timeout
-   Sets the notification timeout in milliseconds.
-   When this timeout fires the device will stop sending notifications.
-   After that, the sample disconnects and enters the system off mode.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL` - Sets the connectable advertising interval in 0.625 milliseconds unit.
 
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT:
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT` - Sets the non-connectable advertising duration in N*10 milliseconds unit.
+  When the advertising ends, the device enters the system off state if there is no outgoing connection.
 
-CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT - Connectable advertising timeout
-   Sets the connectable advertising duration in N*10 milliseconds unit.
-   If the connection is not established during advertising, the device enters the system off state.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL` - Sets the non-connectable advertising interval in 0.625 milliseconds unit.
 
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL:
-
-CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL - Connectable advertising interval
-   Sets the connectable advertising interval in 0.625 milliseconds unit.
-
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT:
-
-CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT - Non-connectable advertising timeout
-   Sets the non-connectable advertising duration in N*10 milliseconds unit.
-   When the advertising ends, the device enters the system off state if there is no outgoing connection.
-
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL:
-
-CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL - Non-connectable advertising interval
-   Sets the non-connectable advertising interval in 0.625 milliseconds unit.
-
-.. _CONFIG_SAMPLE_BLE_PWR_PROFILING_LED:
-
-CONFIG_SAMPLE_BLE_PWR_PROFILING_LED - Enable LEDs
-   Enabled by default. The LEDs can be disabled to reduce power consumption.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_LED` - Enable LEDs.
+  Disabled by default to reduce power consumption.
 
 Building and running
 ********************

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -181,6 +181,7 @@ For details on how to create, configure, and program a sample, see :ref:`getting
 .. note::
    The sample has logging disabled as default.
    To enable terminal messages (at the cost of a small increase in power consumption), enable the following Kconfig options:
+
    * :kconfig:option:`CONFIG_LOG`
    * :kconfig:option:`CONFIG_CONSOLE`
    * :kconfig:option:`CONFIG_LOG_BACKEND_BM_UARTE`

--- a/samples/bluetooth/ble_pwr_profiling/README.rst
+++ b/samples/bluetooth/ble_pwr_profiling/README.rst
@@ -138,15 +138,15 @@ You can modify the following options (available in the Kconfig file at :file:`sa
   When the timeout is reached, the device will stop sending notifications.
   After that, the sample disconnects and enters the system off mode.
 
-* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT` - Sets the connectable advertising duration in N*10 milliseconds unit.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_TIMEOUT` - Sets the connectable advertising duration in 10-millisecond units.
   If the connection is not established during advertising, the device enters the system off state.
 
-* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL` - Sets the connectable advertising interval in 0.625 milliseconds unit.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_CONN_ADVERTISING_INTERVAL` - Sets the connectable advertising interval in 0.625-millisecond units.
 
-* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT` - Sets the non-connectable advertising duration in N*10 milliseconds unit.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_TIMEOUT` - Sets the non-connectable advertising duration in 10-millisecond units.
   When the advertising ends, the device enters the system off state if there is no outgoing connection.
 
-* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL` - Sets the non-connectable advertising interval in 0.625 milliseconds unit.
+* :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_NONCONN_ADVERTISING_INTERVAL` - Sets the non-connectable advertising interval in 0.625-millisecond units.
 
 * :kconfig:option:`CONFIG_SAMPLE_BLE_PWR_PROFILING_LED` - Enable LEDs.
   Disabled by default to reduce power consumption.


### PR DESCRIPTION
* Remove a step in the testing section of the `ble_cgms` sample docs after removal of simulated battery. Battery level is static and does not change.
* Reposition "Peer connected" observation step to better reflect the order of events.
* Add missing testing steps for button notification to `ble_lbs` sample docs.
* Fix incorrectly rendered list in `ble_pwr_profiling` sample docs.
* Align Kconfig option description in `ble_pwr_profiling` sample docs.
* Update time unit wording in description of Kconfig options in `ble_pwr_profiling` sample docs.
* Fix unintentional bold text format for some testing steps.