### PR TITLE
samples: peripherals: uarte: use log instead of console

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -404,6 +404,10 @@ Peripheral samples
 
   * Updated to align with changes to the :ref:`driver_lpuarte` driver.
 
+* :ref:`uarte_sample` sample:
+
+   * Updated the sample to use the logging module instead of console.
+
 DFU samples
 -----------
 

--- a/samples/peripherals/uarte/prj.conf
+++ b/samples/peripherals/uarte/prj.conf
@@ -1,6 +1,6 @@
-# Console
-CONFIG_CONSOLE=y
-CONFIG_BM_UARTE_CONSOLE=y
+# Logging
+CONFIG_LOG=y
+CONFIG_LOG_BACKEND_BM_UARTE=y
 
 # Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
 CONFIG_SOFTDEVICE=y


### PR DESCRIPTION
Align with other samples. Use logging module instead of console.