### PR TITLE
samples: boot: mcuboot_recovery_entry: nRF54LS05 enables oberon default

### DIFF
--- a/samples/boot/mcuboot_recovery_entry/sample.yaml
+++ b/samples/boot/mcuboot_recovery_entry/sample.yaml
@@ -8,6 +8,7 @@ tests:
     integration_platforms:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
     platform_allow:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
@@ -15,22 +16,12 @@ tests:
       - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
-      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
-      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-    tags:
-      - sysbuild
-  sample.boot.mcuboot_recovery_entry.nrf54ls05b:
-    sysbuild: true
-    build_only: true
-    integration_platforms:
-      - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-    platform_allow:
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
       - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
-    extra_args:
-      - mcuboot_CONFIG_NRF_OBERON=y
+      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
+      - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
     tags:
       - sysbuild
   sample.boot.mcuboot_recovery_entry.size_optimized:


### PR DESCRIPTION
No need for additional entry in sample.yaml.