### PR TITLE
lib: peer_manager: fix issue with deleting the same bond more than once

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -167,6 +167,7 @@ Libraries
      The PSA Crypto core can deduce the key slot buffer size based on the keys enabled in the build, so there is no need to define the size manually.
    * Fixed the :c:func:`pm_peer_data_store`, :c:func:`pm_peer_data_remote_db_store` and :c:func:`pm_peer_data_app_data_store` functions to allow data lengths that are not word aligned.
    * Added a missing word alignment check of the ``data`` parameter to the :c:func:`pm_peer_data_store` function.
+   * Fixed an issue where the :c:func:`pm_peer_delete` function under some circumstances could fail to delete peer data.
 
 * :ref:`lib_bm_buttons` library:
 

--- a/lib/bluetooth/peer_manager/modules/peer_data_storage.c
+++ b/lib/bluetooth/peer_manager/modules/peer_data_storage.c
@@ -467,7 +467,9 @@ uint32_t pds_peer_id_free(uint16_t peer_id)
 		return NRF_ERROR_INVALID_PARAM;
 	}
 
-	(void)peer_id_delete(peer_id);
+	if (!peer_id_delete(peer_id)) {
+		return NRF_ERROR_INVALID_PARAM;
+	}
 
 	/* Only start processing on the first delete request.
 	 * `peer_data_delete_process` will iteratively take care of processing all the peers marked


### PR DESCRIPTION
If queueing multiple deletes with the bond management service using the bond management control point, the first deletes would work, but if bonding again and then trying to delete bonds again the peer_manager would fail to start processing of the deletions.

Fix this by returning an error from the internal pds_peer_id_free() function if a peer ID have already been marked for deletion.