### PR TITLE
Add new DK doc links

### DIFF
--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
@@ -18,7 +18,7 @@
          * - `nRF54LM20 DK`_
            - PCA10184
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
+         * - `nRF54LS05 DK`_
            - PCA10214
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
          * - `nRF54LV10 DK`_

--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
@@ -18,7 +18,7 @@
          * - `nRF54LM20 DK`_
            - PCA10184
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
-         * - nRF54LS05 DK
+         * - `nRF54LS05 DK`_
            - PCA10214
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
          * - `nRF54LV10 DK`_

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
@@ -18,7 +18,7 @@
          * - `nRF54LM20 DK`_
            - PCA10184
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
-         * - nRF54LS05 DK
+         * - `nRF54LS05 DK`_
            - PCA10214
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
          * - `nRF54LV10 DK`_

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
@@ -18,7 +18,7 @@
          * - `nRF54LM20 DK`_
            - PCA10184
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
-         * - nRF54LS05 DK
+         * - `nRF54LS05 DK`_
            - PCA10214
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
          * - `nRF54LV10 DK`_

--- a/doc/nrf-bm/links.txt
+++ b/doc/nrf-bm/links.txt
@@ -23,12 +23,15 @@
 .. _`nRF Connect SDK NFC Data Exchange Format`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/nfc/index.html#ug-nfc-ndef
 .. _`nRF Connect SDK NDEF message and record format`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/nfc/index.html#ug_nfc_ndef_format
 
-.. _`nRF54L15 DK`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf54l15dk/doc/index.html#nrf54l15dk-nrf54l15
+.. _`nRF54L15 DK`: https://docs.nordicsemi.com/bundle/ug_nrf54l15_dk/page/UG/nRF54L15_DK/intro/intro.html
 .. _`nRF54L15 DK v1.0.0`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_ic_rev_comp_with_dev_hw.html
 .. _`nRF54L15 DK v0.9.3`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_ic_rev_comp_with_dev_hw.html
-.. _`nRF54LM20 DK`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf54lm20dk/doc/index.html
+
+.. _`nRF54LM20 DK`: https://docs.nordicsemi.com/bundle/ug_nrf54lm20_dk/page/UG/nRF54LM20_DK/intro/intro.html
 
 .. _`nRF54LV10 DK`: https://docs.nordicsemi.com/bundle/ug_nrf54lv10_dk/page/UG/nRF54LV10_DK/intro/intro.html
+
+.. _`nRF54LS05 DK`: https://www.nordicsemi.com/Products/Development-hardware/nRF54LS05-DK
 
 .. _`v3.2.0 software maturity levels`: https://docs.nordicsemi.com/bundle/ncs-3.2.0/page/nrf/releases_and_maturity/software_maturity.html
 

--- a/doc/nrf-bm/release_notes/release_notes_2.0.0-preview1.rst
+++ b/doc/nrf-bm/release_notes/release_notes_2.0.0-preview1.rst
@@ -15,7 +15,7 @@ The following are the major changes introduced by the v2.0.0-preview1 tag:
 
    * PCA10188 (`nRF54LV10 DK`_)
    * PCA10184 (`nRF54LM20 DK`_)
-   * PCA10214 (nRF54LS05 DK)
+   * PCA10214 (`nRF54LS05 DK`_)
 
   Support for the new boards is added in the :ref:`ble_hrs_sample` and :ref:`ble_nus_sample` samples.
 
@@ -54,7 +54,7 @@ Boards
 
    * PCA10188 (`nRF54LV10 DK`_)
    * PCA10184 (`nRF54LM20 DK`_)
-   * PCA10214 (nRF54LS05 DK)
+   * PCA10214 (`nRF54LS05 DK`_)
 
 * Adjusted SRAM sizes for the ``bm_nrf54l15dk`` board target to not overlap with VPR context.
 * Adjusted the board memory layout for all boards to align with the new SoftDevice.
@@ -170,7 +170,7 @@ Bluetooth LE samples
 
      * PCA10188 (`nRF54LV10 DK`_)
      * PCA10184 (`nRF54LM20 DK`_)
-     * PCA10214 (nRF54LS05 DK)
+     * PCA10214 (`nRF54LS05 DK`_)
 
 * :ref:`ble_hids_keyboard_sample`:
 
@@ -186,7 +186,7 @@ Bluetooth LE samples
 
      * PCA10188 (`nRF54LV10 DK`_)
      * PCA10184 (`nRF54LM20 DK`_)
-     * PCA10214 (nRF54LS05 DK)
+     * PCA10214 (`nRF54LS05 DK`_)
 
    * Updated to align with changes to the :ref:`driver_lpuarte` driver.
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -49,7 +49,7 @@ Boards
 
    * PCA10188 (`nRF54LV10 DK`_)
    * PCA10184 (`nRF54LM20 DK`_)
-   * PCA10214 (nRF54LS05 DK)
+   * PCA10214 (`nRF54LS05 DK`_)
 
 * Updated:
 
@@ -355,7 +355,7 @@ Samples
 
 * Aligned LED and button behavior across samples.
 
-* All samples that are compatible with the new board targets PCA10188 (`nRF54LV10 DK`_), PCA10184 (`nRF54LM20 DK`_), and PCA10214 (nRF54LS05 DK) have been updated to reflect support for these boards.
+* All samples that are compatible with the new board targets PCA10188 (`nRF54LV10 DK`_), PCA10184 (`nRF54LM20 DK`_), and PCA10214 (`nRF54LS05 DK`_) have been updated to reflect support for these boards.
 
 Bluetooth LE samples
 --------------------

--- a/samples/peripherals/pwm/README.rst
+++ b/samples/peripherals/pwm/README.rst
@@ -86,7 +86,7 @@ The sample supports the following development kits:
          * - `nRF54LM20 DK`_
            - PCA10184
            - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
-         * - nRF54LS05 DK
+         * - `nRF54LS05 DK`_
            - PCA10214
            - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
 


### PR DESCRIPTION
Change DK documentation links to point to Nordic internal documentation

Added Link to the high level nRF54LS05 DK documentation.  
This link needs to be updated again once we have the detailed nRF54 LS05 DK doc in place