### PR TITLE
license: Add softdevice license

### DIFF
--- a/components/softdevice/license.txt
+++ b/components/softdevice/license.txt
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * NCS-SBOM-Apply-To-File: ./**/*_softdevice.hex
+ */


### PR DESCRIPTION
Define license for the .hex artifacts inside softdevice.