### PR TITLE
samples: Remove Shell sample build warning

### DIFF
--- a/samples/subsys/shell/bm_uarte/prj.conf
+++ b/samples/subsys/shell/bm_uarte/prj.conf
@@ -3,6 +3,9 @@ CONFIG_LOG=y
 CONFIG_LOG_BACKEND_BM_UARTE=y
 CONFIG_SAMPLE_SHELL_BM_UARTE_LOG_LEVEL_INF=y
 
+# Enabling SoftDevice is not strictly needed, though we are building with SoftDevice boards.
+CONFIG_SOFTDEVICE=y
+
 # Shell
 CONFIG_SHELL=y
 CONFIG_SHELL_BACKEND_BM_UARTE=y


### PR DESCRIPTION
Remove Shell sample build warning by adding CONFIG_SOFTDEVICE=y to prj.conf