### PR TITLE
firmware_loader, mcuboot_recovery_entry: improved adv name persistency over two stage updates

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -277,11 +277,6 @@ int main(void)
 		memcpy(log_name_buffer, custom_advertising_name, custom_advertising_name_size);
 		log_name_buffer[custom_advertising_name_size] = '\0';
 #endif
-		err = bm_rmem_clear(&clipboard_ctx);
-		if (err) {
-			LOG_ERR("Failed to clear retained clipboard, err %d", err);
-			return 0;
-		}
 	}
 #endif /* CONFIG_BM_FLAT_SETTINGS_BLUETOOTH_NAME */
 

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -226,8 +226,7 @@ int main(void)
 
 	err = bm_rmem_init(&clipboard_ctx);
 	if (err) {
-		LOG_INF("Failed to initialize retained clipboard reader, err %d", err);
-		/* Error is expected if retained RAM is empty or data are corrupted. */
+		LOG_ERR("Failed to initialize retained clipboard reader, err %d", err);
 	}
 #endif
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -82,6 +82,8 @@ DFU
      New solution is enabled by the :kconfig:option:`CONFIG_BM_FLAT_SETTINGS_BLUETOOTH_NAME` Kconfig option.
      It empploys newly added Inter application RAM Clipboard storage.
    * Support for nRF54L15, nRF54L10, and nRF54L05 SoCs is no longer experimental and is now fully supported and ready to be used.
+   * Firmware loader to not clear the retained DFU Device Bluetooth name after loading it from retained memory.
+     This allows the advertising name to persist after updating SoftDevice and/or firmware loader, or if the application image validation fails and the device reboots into firmware loader.
 
 Removed:
 
@@ -418,6 +420,8 @@ DFU samples
      To enable the size-optimized configuration, set :makevar:`FILE_SUFFIX` to ``size_opt`` when building the sample.
    * The :ref:`ble_mcuboot_recovery_entry_sample` migrates to new soultion for Setting up DFU Device Bluetooth name remotely.
      See the :ref:`ug_dfu` page for details.
+   * The :ref:`ble_mcuboot_recovery_entry_sample` to clear the retained DFU Device Bluetooth name on boot.
+     This was previously done by the firmware loader.
 
 Subsystem samples
 -----------------

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -7,6 +7,7 @@
 #include <ble_gap.h>
 #include <bm/softdevice_handler/nrf_sdh.h>
 #include <bm/softdevice_handler/nrf_sdh_ble.h>
+#include <bm/storage/bm_rmem.h>
 #include <bm/bluetooth/ble_adv.h>
 #include <bm/bluetooth/services/ble_mcumgr.h>
 
@@ -151,6 +152,22 @@ static enum mgmt_cb_return os_mgmt_reboot_hook(uint32_t event, enum mgmt_cb_retu
 	return MGMT_CB_OK;
 }
 
+static void retained_adv_name_clear(void)
+{
+	int err;
+	struct bm_retained_clipboard_ctx clipboard_ctx;
+
+	err = bm_rmem_init(&clipboard_ctx);
+	if (err) {
+		LOG_ERR("Failed to initialize retained clipboard, err %d", err);
+	}
+
+	err = bm_rmem_clear(&clipboard_ctx);
+	if (err) {
+		LOG_ERR("Failed to clear retained clipboard, err %d", err);
+	}
+}
+
 int main(void)
 {
 	int err;
@@ -226,6 +243,8 @@ int main(void)
 	}
 
 	LOG_INF("Advertising as %s", CONFIG_SAMPLE_BLE_DEVICE_NAME);
+
+	retained_adv_name_clear();
 
 	while (notification_sent == false && device_disconnected == false) {
 		log_flush();


### PR DESCRIPTION
When doing update of SoftDevice+firmware_loader followed by application upload, the firmware loader advertising name set by the "old" application would only be used by the "old" firmware loader.

After having updated SoftDevice+firmware_loader and the next step is upload of application image, the name set by the "old" application would already be cleared by the old firmware loader and the new firmware loader would always use the default name.

Improve this by moving the responsibility of clearing the advertising name from firmware loader startup to application startup. The configured advertising name would then persist over the full two stage update.