### PR TITLE
bluetooth: hrs: change hrm_encode return type to uint16_t

### DIFF
--- a/subsys/bluetooth/services/ble_hrs/hrs.c
+++ b/subsys/bluetooth/services/ble_hrs/hrs.c
@@ -37,11 +37,11 @@ LOG_MODULE_REGISTER(ble_hrs, CONFIG_BLE_HRS_LOG_LEVEL);
 /* RR-Interval bit. */
 #define HRM_FLAG_MASK_RR_INTERVAL_INCLUDED	BIT(4)
 
-static uint8_t hrm_encode(struct ble_hrs *hrs, uint16_t heart_rate, uint8_t *encoded_buffer)
+static uint16_t hrm_encode(struct ble_hrs *hrs, uint16_t heart_rate, uint8_t *encoded_buffer)
 {
 	uint8_t flags = 0;
 	/* Make space for flags. */
-	uint8_t len = 1;
+	uint16_t len = 1;
 	int i;
 
 	/* Set sensor contact related flags. */


### PR DESCRIPTION
hrm_encode() returned uint8_t, but both places that use it expect a uint16_t (ble_gatts_attr_t.init_len and ble_gatts_hvx_params_t.p_len from the SoftDevice API).

In practice the length never goes above 255, so this was not a real bug, just an inconsistency that forced the compiler to silently widen the value. Changing the return type (and the internal len variable) to uint16_t makes everything line up.

No functional change.