### PR TITLE
doc: post-release doc updates

### DIFF
--- a/doc/nrf-bm/doxygen/mainpage.dox
+++ b/doc/nrf-bm/doxygen/mainpage.dox
@@ -1,5 +1,5 @@
 /**
-@mainpage nRF Connect SDK Bare Metal option v2.0.0 API documentation
+@mainpage nRF Connect SDK Bare Metal option v2.0.99 API documentation
 
 <a href="topics.html">API Reference</a>
 

--- a/doc/nrf-bm/release_notes.rst
+++ b/doc/nrf-bm/release_notes.rst
@@ -10,6 +10,7 @@ The following is a list of all release notes documents for various releases of t
    :caption: Subpages:
 
    release_notes/bm_software_maturity
+   release_notes/release_notes_changelog
    release_notes/release_notes_2.0.0
    release_notes/release_notes_1.0.0
    release_notes/release_notes_0.9.0

--- a/doc/nrf-bm/release_notes/bm_software_maturity.rst
+++ b/doc/nrf-bm/release_notes/bm_software_maturity.rst
@@ -128,7 +128,7 @@ The following table indicates the software maturity levels of the support for ea
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
    * - **ESB**
@@ -240,35 +240,35 @@ The following table indicates the software maturity levels of the support for ea
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
    * - **NFC Type 4 Tag (read/write)**
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
    * - **NDEF encoding and decoding**
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
    * - **NFC Record Type Definition: URI, text**
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
    * - **NFC Connection Handover to Bluetooth carrier, Static and Negotiated Handover**
      - Supported
      - Supported
      - Supported
-     - Experimental
+     - Supported
      - n/a
      - n/a
 

--- a/doc/nrf-bm/release_notes/release_notes_2.0.0.rst
+++ b/doc/nrf-bm/release_notes/release_notes_2.0.0.rst
@@ -463,7 +463,7 @@ Bluetooth LE samples
 NFC samples
 -----------
 
-* Included nRF54LM20A as an available SoC for the :ref:`peripheral_nfc_pairing_sample`, :ref:`record_text_t4t_sample` and :ref:`record_text_t2t_sample` samples, but the NFC libraries for this SoC are still in Experimental quality.
+* Included nRF54LM20A as an available SoC for the :ref:`peripheral_nfc_pairing_sample`, :ref:`record_text_t4t_sample`, and :ref:`record_text_t2t_sample` samples.
 * Updated to use ``CONFIG_BM_NFC_*`` Kconfig options provided by |BMshort| instead of ``CONFIG_NFC_*`` options provided by |NCS|.
   Use ``#include <bm/nfc/...>`` headers provided by |BMshort| instead of ``#include <nfc/...>`` headers from |NCS|.
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _nrf_bm_release_notes_2099:
 
 Changelog for |BMlong| v2.0.99

--- a/doc/nrf-bm/shortcuts.txt
+++ b/doc/nrf-bm/shortcuts.txt
@@ -8,7 +8,7 @@
 .. ### Versions
 
 .. |ncs_release| replace:: v3.3.0
-.. |release| replace:: v2.0.0
+.. |release| replace:: v2.0.99
 
 .. ### Other shortcuts
 


### PR DESCRIPTION
Typical doc updates after release.
Additionally, corrected a statement about support of NFC on nRF54LM20A.