### PR TITLE
tests: extend timeout to 600 seconds

### DIFF
--- a/tests/subsys/bootloader/upgrade/mcuboot_recovery_retention/testcase.yaml
+++ b/tests/subsys/bootloader/upgrade/mcuboot_recovery_retention/testcase.yaml
@@ -16,7 +16,7 @@ tests:
     tags:
       - pytest
       - dfu
-    timeout: 300
+    timeout: 600
     harness: pytest
     harness_config:
       pytest_root:
@@ -41,7 +41,7 @@ tests:
     tags:
       - pytest
       - dfu
-    timeout: 300
+    timeout: 600
     harness: pytest
     harness_config:
       pytest_root:

--- a/tests/subsys/kmu/hello_for_kmu/testcase.yaml
+++ b/tests/subsys/kmu/hello_for_kmu/testcase.yaml
@@ -16,6 +16,7 @@ tests:
       - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
     tags:
       - kmu
+    timeout: 600
     harness: console
     harness_config:
       type: one_line
@@ -41,7 +42,7 @@ tests:
     tags:
       - pytest
       - kmu
-    timeout: 300
+    timeout: 600
     harness: pytest
     harness_config:
       pytest_root:


### PR DESCRIPTION
Extended twister timeout for samples where additional boards has been added.