### PR TITLE
tests: disable Fprotect for KMU tests

### DIFF
--- a/tests/subsys/kmu/hello_for_kmu/testcase.yaml
+++ b/tests/subsys/kmu/hello_for_kmu/testcase.yaml
@@ -78,6 +78,7 @@ tests:
       - mcuboot_CONFIG_BOOT_KEYS_REVOCATION=y
       - mcuboot_CONFIG_LTO=n
       - mcuboot_CONFIG_BOOT_SIGNATURE_KMU_SLOTS=3
+      - mcuboot_CONFIG_FPROTECT=n
   mcuboot.kmu.west.provision.key_revocation_with_two_slots:
     integration_platforms:
       - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot


### PR DESCRIPTION
Some tests are failing due to enabled by default
Fprotect which blocks flashing device without erase.