### PR TITLE
lib: bluetooth: enforce app PHY mask and support multi-PHY config

### DIFF
--- a/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
@@ -115,15 +115,25 @@ Radio PHY mode
 
 The radio PHY mode defaults to 1 MB per second at the start of a connection.
 This can be changed by initiating a GAP radio PHY mode update procedure.
-If a specific radio PHY mode is required in connections, one of the following choice options must be enabled:
+Choose either automatic PHY selection, or disable auto and enable one or more allowed PHYs:
 
 * :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_AUTO` - The SoftDevice will automatically select the PHY mode.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_1MBPS` - Default speed of 1 MB per second.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_2MBPS` - Higher throughput of 2 MB per second.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` - Bluetooth LE Coded PHY mode (increased range and reliability of the transmission at the cost of reduced data throughput).
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_1MBPS` - Allow 1 MB per second.
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_2MBPS` - Allow 2 MB per second.
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` - Allow Bluetooth LE Coded PHY mode (increased range and reliability at the cost of reduced throughput).
+
+When :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_AUTO` is disabled, the PHY options above act as an allow-mask and can be enabled in combination (for example 1M + 2M).
+The effective request sent to the SoftDevice is filtered by:
+
+1. SoftDevice capability mask (:c:macro:`BLE_GAP_PHYS_SUPPORTED`)
+2. Application PHY allow-mask from Kconfig (:kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY`)
+
+This ensures that peer requests and local requests made through :c:func:`ble_conn_params_phy_radio_mode_set` stay within the application-defined PHY limits.
 
 .. note::
-   The S115 SoftDevice does not support the :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` Kconfig option.
+   Bluetooth LE Coded PHY can be enabled in configuration, but support depends on the selected SoftDevice and target hardware.
+   In the current BM SoftDevice context (including S115 and S145), coded PHY is not supported at runtime, so coded bits are filtered out from requests.
+   In that case, negotiation falls back to the remaining allowed PHY preferences (for example 1M or 2M), or to the default fallback path if no valid coded request remains.
 
 The :kconfig:option:`CONFIG_BLE_CONN_PARAMS_INITIATE_PHY_UPDATE` Kconfig option can be set to automatically initiate a radio PHY update on connection.
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -73,7 +73,7 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Libraries
 =========
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* **Bluetooth LE Connection Parameters** library: PHY preference enforcement (app mask + stack support), multi-PHY Kconfig and clearer PHY logs.
 
 Bluetooth LE Services
 ---------------------

--- a/lib/bluetooth/ble_conn_params/Kconfig
+++ b/lib/bluetooth/ble_conn_params/Kconfig
@@ -133,26 +133,46 @@ config BLE_CONN_PARAMS_AUTO_PHY_UPDATE
 	default y
 if BLE_CONN_PARAMS_AUTO_PHY_UPDATE
 
-choice
-	prompt "Preferred radio PHY mode in connection"
-	default BLE_CONN_PARAMS_PHY_AUTO
-
 config BLE_CONN_PARAMS_PHY_AUTO
-	bool "Auto"
+	bool "Preferred radio PHY mode: Auto"
+	default y
+	help
+	  Let the SoftDevice select PHY mode automatically.
+
 config BLE_CONN_PARAMS_PHY_1MBPS
-	bool "1 Megabit"
+	bool "Allow 1 Megabit PHY"
+	default n
+	depends on !BLE_CONN_PARAMS_PHY_AUTO
+
 config BLE_CONN_PARAMS_PHY_2MBPS
-	bool "2 Megabits"
+	bool "Allow 2 Megabits PHY"
+	default n
+	depends on !BLE_CONN_PARAMS_PHY_AUTO
+
 config BLE_CONN_PARAMS_PHY_CODED
-	bool "Coded"
-endchoice
+	bool "Allow Coded PHY"
+	default n
+	depends on !BLE_CONN_PARAMS_PHY_AUTO
+	help
+	  Enable Bluetooth LE Coded PHY mode (longer range/lower throughput).
+	  Note: support depends on selected SoftDevice.
 
 config BLE_CONN_PARAMS_PHY
 	hex
 	default 0x00 if BLE_CONN_PARAMS_PHY_AUTO
 	default 0x01 if BLE_CONN_PARAMS_PHY_1MBPS
 	default 0x02 if BLE_CONN_PARAMS_PHY_2MBPS
+	default 0x03 if BLE_CONN_PARAMS_PHY_1MBPS && BLE_CONN_PARAMS_PHY_2MBPS
 	default 0x04 if BLE_CONN_PARAMS_PHY_CODED
+	default 0x05 if BLE_CONN_PARAMS_PHY_1MBPS && BLE_CONN_PARAMS_PHY_CODED
+	default 0x06 if BLE_CONN_PARAMS_PHY_2MBPS && BLE_CONN_PARAMS_PHY_CODED
+	default 0x07 if BLE_CONN_PARAMS_PHY_1MBPS && BLE_CONN_PARAMS_PHY_2MBPS && \
+			BLE_CONN_PARAMS_PHY_CODED
+	default 0x00
+	help
+	  Effective application PHY allow-mask.
+	  0x00 means auto mode.
+	  0x01/0x02/0x04 map to 1M/2M/Coded and can be combined.
 
 config BLE_CONN_PARAMS_INITIATE_PHY_UPDATE
 	bool "Initiate PHY mode update on connection"

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -43,6 +43,32 @@ static struct {
 BUILD_ASSERT(BLE_CONN_PARAMS_PHY_IS_AUTO || BLE_CONN_PARAMS_PHY_HAS_STACK_SUPPORT,
 	     "Invalid PHY config");
 
+static const char *phy_mask_to_str(uint8_t phy_mask)
+{
+	switch (phy_mask) {
+	case BLE_GAP_PHY_AUTO:
+		return "AUTO";
+	case BLE_GAP_PHY_NOT_SET:
+		return "NOT_SET";
+	case BLE_GAP_PHY_1MBPS:
+		return "1M";
+	case BLE_GAP_PHY_2MBPS:
+		return "2M";
+	case BLE_GAP_PHY_CODED:
+		return "CODED";
+	case BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS:
+		return "1M|2M";
+	case BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_CODED:
+		return "1M|CODED";
+	case BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED:
+		return "2M|CODED";
+	case BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED:
+		return "1M|2M|CODED";
+	default:
+		return "UNKNOWN";
+	}
+}
+
 static ble_gap_phys_t radio_phy_mode_prepare(ble_gap_phys_t phy_mode)
 {
 	/* Apply app policy on top of what this SoftDevice can support. */
@@ -126,8 +152,9 @@ static void on_radio_phy_mode_update_evt(uint16_t conn_handle, int idx,
 		links[idx].phy_mode_update_pending = false;
 		links[idx].phy_mode.tx_phys = evt->tx_phy;
 		links[idx].phy_mode.rx_phys = evt->rx_phy;
-		LOG_INF("PHY updated for peer %#x, tx %u, rx %u", conn_handle,
-			links[idx].phy_mode.tx_phys, links[idx].phy_mode.rx_phys);
+		LOG_INF("PHY mode selected for peer %#x: tx=%s (%u), rx=%s (%u)", conn_handle,
+			phy_mask_to_str(links[idx].phy_mode.tx_phys), links[idx].phy_mode.tx_phys,
+			phy_mask_to_str(links[idx].phy_mode.rx_phys), links[idx].phy_mode.rx_phys);
 	} else if (evt->status == BLE_HCI_DIFFERENT_TRANSACTION_COLLISION) {
 		/* Retry */
 		links[idx].phy_mode_update_pending = true;
@@ -156,8 +183,11 @@ static void on_radio_phy_mode_update_request_evt(uint16_t conn_handle, int idx,
 {
 	ble_gap_phys_t peer_phys = evt->peer_preferred_phys;
 
-	LOG_INF("Peer %#x requested PHY update to tx %u, rx %u", conn_handle,
-		evt->peer_preferred_phys.tx_phys, evt->peer_preferred_phys.rx_phys);
+	LOG_INF("Peer %#x requested PHY preference mask: tx=%s (%u), rx=%s (%u)", conn_handle,
+		phy_mask_to_str(evt->peer_preferred_phys.tx_phys),
+		evt->peer_preferred_phys.tx_phys,
+		phy_mask_to_str(evt->peer_preferred_phys.rx_phys),
+		evt->peer_preferred_phys.rx_phys);
 
 	/* Respect peer request only within app + SoftDevice allowed masks. */
 	links[idx].phy_mode = radio_phy_mode_prepare(peer_phys);

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -13,57 +13,105 @@ LOG_MODULE_DECLARE(ble_conn_params, CONFIG_BLE_CONN_PARAMS_LOG_LEVEL);
 
 extern void ble_conn_params_event_send(const struct ble_conn_params_evt *evt);
 
+/* App-configured PHY allow-mask derived from Kconfig. */
+#define BLE_CONN_PARAMS_PHY_APP_MASK CONFIG_BLE_CONN_PARAMS_PHY
+/* Auto mode fallback uses 1M as a conservative recovery PHY. */
+#define BLE_CONN_PARAMS_PHY_AUTO_FALLBACK BLE_GAP_PHY_1MBPS
+#define BLE_CONN_PARAMS_PHY_IS_AUTO (BLE_CONN_PARAMS_PHY_APP_MASK == BLE_GAP_PHY_AUTO)
+#define BLE_CONN_PARAMS_PHY_HAS_STACK_SUPPORT ((BLE_CONN_PARAMS_PHY_APP_MASK & \
+						BLE_GAP_PHYS_SUPPORTED) != 0)
+#define BLE_CONN_PARAMS_PHY_EFFECTIVE_APP_MASK \
+	(BLE_CONN_PARAMS_PHY_IS_AUTO ? BLE_GAP_PHYS_SUPPORTED : \
+				       (BLE_CONN_PARAMS_PHY_APP_MASK & BLE_GAP_PHYS_SUPPORTED))
+/* Recovery mask used for one fallback retry on resource errors. */
+#define BLE_CONN_PARAMS_PHY_FALLBACK_MASK \
+	(BLE_CONN_PARAMS_PHY_IS_AUTO ? BLE_CONN_PARAMS_PHY_AUTO_FALLBACK : \
+				       BLE_CONN_PARAMS_PHY_APP_MASK)
+
 static struct {
+	/* Last requested/effective PHY preference for this link. */
 	ble_gap_phys_t phy_mode;
+	/* Deferred retry flag when SoftDevice reports busy/collision. */
 	uint8_t phy_mode_update_pending : 1;
 } links[CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT] = {
 	[0 ... CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT - 1] = {
-		.phy_mode.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
-		.phy_mode.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+		.phy_mode.tx_phys = BLE_CONN_PARAMS_PHY_APP_MASK,
+		.phy_mode.rx_phys = BLE_CONN_PARAMS_PHY_APP_MASK,
 	},
 };
 
-BUILD_ASSERT(CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO ||
-	     !!(CONFIG_BLE_CONN_PARAMS_PHY & BLE_GAP_PHYS_SUPPORTED), "Invalid PHY config");
+BUILD_ASSERT(BLE_CONN_PARAMS_PHY_IS_AUTO || BLE_CONN_PARAMS_PHY_HAS_STACK_SUPPORT,
+	     "Invalid PHY config");
+
+static ble_gap_phys_t radio_phy_mode_prepare(ble_gap_phys_t phy_mode)
+{
+	/* Apply app policy on top of what this SoftDevice can support. */
+	const uint8_t app_mask = BLE_CONN_PARAMS_PHY_EFFECTIVE_APP_MASK;
+	ble_gap_phys_t phys = phy_mode;
+
+	if (phys.tx_phys == BLE_GAP_PHY_AUTO) {
+		/* AUTO means "choose from allowed PHYs", so expand to effective allow-mask. */
+		phys.tx_phys = app_mask;
+	} else if (phys.tx_phys != BLE_GAP_PHY_NOT_SET) {
+		/* Keep caller/peer intent, but clamp it to the allowed PHY set. */
+		phys.tx_phys &= app_mask;
+	}
+
+	if (phys.rx_phys == BLE_GAP_PHY_AUTO) {
+		/* Same policy for RX direction: AUTO resolves to the allowed PHY mask. */
+		phys.rx_phys = app_mask;
+	} else if (phys.rx_phys != BLE_GAP_PHY_NOT_SET) {
+		/* Intersection avoids broadening an explicit peer/application request. */
+		phys.rx_phys &= app_mask;
+	}
+
+	/* If filtering removed all bits, fall back to app mask or 1M in auto mode. */
+	if (phys.tx_phys == 0) {
+		phys.tx_phys = app_mask ? app_mask : BLE_CONN_PARAMS_PHY_FALLBACK_MASK;
+	}
+	if (phys.rx_phys == 0) {
+		phys.rx_phys = app_mask ? app_mask : BLE_CONN_PARAMS_PHY_FALLBACK_MASK;
+	}
+
+	return phys;
+}
 
 static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 {
 	uint32_t nrf_err;
-	ble_gap_phys_t phys = links[idx].phy_mode;
+	ble_gap_phys_t phys;
 	struct ble_conn_params_evt app_evt = {
 		.evt_type = BLE_CONN_PARAMS_EVT_ERROR,
 		.conn_handle = conn_handle,
 	};
 
+	for (int attempt = 0; attempt < 2; attempt++) {
+		/* Always sanitize before calling into SoftDevice. */
+		phys = radio_phy_mode_prepare(links[idx].phy_mode);
 
-	if (phys.tx_phys != BLE_GAP_PHY_NOT_SET) {
-		phys.tx_phys &= BLE_GAP_PHYS_SUPPORTED;
-	}
+		nrf_err = sd_ble_gap_phy_update(conn_handle, &phys);
+		if (nrf_err == NRF_SUCCESS) {
+			return;
+		} else if (nrf_err == NRF_ERROR_BUSY) {
+			/* Retry */
+			links[idx].phy_mode_update_pending = true;
+			LOG_DBG("Failed PHY update procedure, another procedure is ongoing, "
+				"Will retry");
+			return;
+		} else if (nrf_err == NRF_ERROR_RESOURCES && attempt == 0) {
+			/* Retry once with fallback mask, avoids recursive call chain. */
+			LOG_WRN("Failed PHY update procedure. Retrying with app fallback PHY");
+			LOG_DBG("GAP event length (%d) may be too small",
+				CONFIG_NRF_SDH_BLE_GAP_EVENT_LENGTH);
+			links[idx].phy_mode.tx_phys = BLE_CONN_PARAMS_PHY_FALLBACK_MASK;
+			links[idx].phy_mode.rx_phys = BLE_CONN_PARAMS_PHY_FALLBACK_MASK;
+			continue;
+		}
 
-	if (phys.rx_phys != BLE_GAP_PHY_NOT_SET) {
-		phys.rx_phys &= BLE_GAP_PHYS_SUPPORTED;
-	}
-
-	nrf_err = sd_ble_gap_phy_update(conn_handle, &phys);
-	if (nrf_err == NRF_SUCCESS) {
-		return;
-	} else if (nrf_err == NRF_ERROR_BUSY) {
-		/* Retry */
-		links[idx].phy_mode_update_pending = true;
-		LOG_DBG("Failed PHY update procedure, another procedure is ongoing, "
-			"Will retry");
-	} else if (nrf_err == NRF_ERROR_RESOURCES) {
-		/* PHY update failed. Use current PHY. */
-		LOG_WRN("Failed PHY update procedure. Continue using current PHY mode");
-		LOG_DBG("GAP event length (%d) may be too small",
-			CONFIG_NRF_SDH_BLE_GAP_EVENT_LENGTH);
-		links[idx].phy_mode.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
-		links[idx].phy_mode.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
-		radio_phy_mode_update(conn_handle, idx);
-	} else {
 		LOG_ERR("Failed PHY update procedure, nrf_error %#x", nrf_err);
 		app_evt.error.reason = nrf_err;
 		ble_conn_params_event_send(&app_evt);
+		return;
 	}
 }
 
@@ -106,11 +154,13 @@ static void on_radio_phy_mode_update_evt(uint16_t conn_handle, int idx,
 static void on_radio_phy_mode_update_request_evt(uint16_t conn_handle, int idx,
 						 const ble_gap_evt_phy_update_request_t *evt)
 {
+	ble_gap_phys_t peer_phys = evt->peer_preferred_phys;
+
 	LOG_INF("Peer %#x requested PHY update to tx %u, rx %u", conn_handle,
 		evt->peer_preferred_phys.tx_phys, evt->peer_preferred_phys.rx_phys);
 
-	links[idx].phy_mode.tx_phys = evt->peer_preferred_phys.tx_phys;
-	links[idx].phy_mode.rx_phys = evt->peer_preferred_phys.rx_phys;
+	/* Respect peer request only within app + SoftDevice allowed masks. */
+	links[idx].phy_mode = radio_phy_mode_prepare(peer_phys);
 
 	radio_phy_mode_update(conn_handle, idx);
 }

--- a/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
@@ -592,9 +592,13 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 {
 	uint32_t nrf_err;
-	ble_gap_phys_t phy_config = {
-		.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
-		.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+	ble_gap_phys_t phy_fallback = {
+		.rx_phys = (CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO) ?
+				   BLE_GAP_PHY_1MBPS :
+				   CONFIG_BLE_CONN_PARAMS_PHY,
+		.tx_phys = (CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO) ?
+				   BLE_GAP_PHY_1MBPS :
+				   CONFIG_BLE_CONN_PARAMS_PHY,
 	};
 	ble_gap_phys_t phy_all = {
 		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
@@ -611,7 +615,7 @@ void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 
 	/* Operation is retried wirth default parameters. */
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_config, 1, NRF_SUCCESS);
+		CONN_HANDLE, &phy_fallback, 1, NRF_SUCCESS);
 
 	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_all);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);


### PR DESCRIPTION
Fix BLE PHY handling in `ble_conn_params` so application/project PHY preferences are respected consistently, including peer-initiated PHY update requests.

The change:

- Applies an app-defined PHY allow-mask on top of SoftDevice-supported PHYs before PHY updates.
- Converts PHY Kconfig from single-choice behavior to multi-select options (for example `1M + 2M`).
- Replaces recursive `NRF_ERROR_RESOURCES` retry in PHY update with a bounded non-recursive retry path.
- Improves PHY logs by printing human-readable PHY names/bitmasks and clearer wording.
- Updates documentation to describe the new auto vs allow-mask behavior and coded PHY limitations in BM SoftDevice context (S115/S145).