### PR TITLE
samples: bluetooth: Remove redundant bluetooth LE event handling in main source

### DIFF
--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -104,7 +104,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 	{
 		/* No system attributes have been stored */
-		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gatts_evt.conn_handle, NULL, 0, 0);
 
 		if (nrf_err) {
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -80,13 +80,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		break;
 	}
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-	{
-		LOG_INF("Authentication status %#x",
-			evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-	}
-
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 	{
 		/* Pairing not supported */

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -66,11 +66,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
-
-		if (nrf_err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
-		}
 		break;
 	}
 

--- a/applications/firmware_loader/ble_mcumgr/src/main.c
+++ b/applications/firmware_loader/ble_mcumgr/src/main.c
@@ -108,7 +108,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 	{
-		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
 		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -110,6 +110,11 @@ Peripheral samples
 Bluetooth LE samples
 --------------------
 
+* :ref:`ble_cgms_sample` sample:
+
+   * Removed the call to the :c:func:`sd_ble_gatts_sys_attr_set` function from the main source file.
+     The :ref:`lib_peer_manager` library takes care of calling this function when :ref:`lib_peer_manager` is used.
+
 * :ref:`ble_hrs_sample` sample:
 
    * Removed redundant logging of authentication status from the main source file.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -110,6 +110,13 @@ Peripheral samples
 Bluetooth LE samples
 --------------------
 
+* Updated the following samples and applications that do not support pairing to call the :c:func:`sd_ble_gatts_sys_attr_set` function only in response to the :c:macro:`BLE_GATTS_EVT_SYS_ATTR_MISSING` event and not as a response to a :c:macro:`BLE_GAP_EVT_CONNECTED` event:
+
+   * :ref:`ug_dfu_firmware_loader` (Bluetooth LE)
+   * :ref:`ble_lbs_sample`
+   * :ref:`ble_nus_sample`
+   * :ref:`ble_mcuboot_recovery_entry_sample`
+
 * :ref:`ble_cgms_sample` sample:
 
    * Removed the call to the :c:func:`sd_ble_gatts_sys_attr_set` function from the main source file.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -110,6 +110,11 @@ Peripheral samples
 Bluetooth LE samples
 --------------------
 
+* :ref:`ble_hrs_sample` sample:
+
+   * Removed redundant logging of authentication status from the main source file.
+     Authentication status is logged by :ref:`lib_peer_manager` library.
+
 * :ref:`ble_nus_central_sample` sample:
 
    * Fixed the disconnect button handler to only disconnect on button press, and not on button release.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -117,6 +117,14 @@ Bluetooth LE samples
    * :ref:`ble_nus_sample`
    * :ref:`ble_mcuboot_recovery_entry_sample`
 
+* Removed the authentication status logging from the following samples and applications that do not support pairing (do not use the :ref:`lib_peer_manager` library):
+
+   * :ref:`ug_dfu_firmware_loader` (Bluetooth LE)
+   * :ref:`ble_lbs_sample`
+   * :ref:`ble_nus_sample`
+   * :ref:`ble_pwr_profiling_sample`
+   * :ref:`ble_mcuboot_recovery_entry_sample`
+
 * :ref:`ble_cgms_sample` sample:
 
    * Removed the call to the :c:func:`sd_ble_gatts_sys_attr_set` function from the main source file.

--- a/samples/bluetooth/ble_cgms/src/main.c
+++ b/samples/bluetooth/ble_cgms/src/main.c
@@ -362,12 +362,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		if (nrf_err) {
 			LOG_ERR("Failed to assign BLE CGMS conn handle, nrf_error %#x", nrf_err);
 		}
-
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
-		if (nrf_err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
-		}
-
 		break;
 	case BLE_GAP_EVT_DISCONNECTED:
 		LOG_INF("Disconnected");

--- a/samples/bluetooth/ble_hrs/src/main.c
+++ b/samples/bluetooth/ble_hrs/src/main.c
@@ -232,15 +232,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
 		break;
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-		LOG_INF("Authentication status: %#x",
-		       evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-
-	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
-		LOG_INF("BLE_GAP_EVT_SEC_PARAMS_REQUEST");
-		break;
-
 	case BLE_GAP_EVT_PASSKEY_DISPLAY:
 		LOG_INF("Passkey: %.*s", BLE_GAP_PASSKEY_LEN,
 			evt->evt.gap_evt.params.passkey_display.passkey);

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -48,11 +48,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
 		break;
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-		LOG_INF("Authentication status: %#x",
-		       evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 		/* Pairing not supported */
 		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -68,7 +68,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		break;
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
-		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
 		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
 		if (nrf_err) {

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -37,10 +37,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	case BLE_GAP_EVT_CONNECTED:
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
-		if (nrf_err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
-		}
 		nrf_gpio_pin_write(BOARD_PIN_LED_1, BOARD_LED_ACTIVE_STATE);
 		break;
 

--- a/samples/bluetooth/ble_lbs/src/main.c
+++ b/samples/bluetooth/ble_lbs/src/main.c
@@ -65,7 +65,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 		/* No system attributes have been stored */
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gatts_evt.conn_handle, NULL, 0, 0);
 		if (nrf_err) {
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -225,11 +225,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 		break;
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-		LOG_INF("Authentication status: %#x",
-			evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 		/* Pairing not supported */
 		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -245,7 +245,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		break;
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
-		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
 		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
 		if (nrf_err) {

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -201,10 +201,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		LOG_INF("Peer connected");
 		ble_nus_max_data_len = BLE_NUS_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
-		if (nrf_err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
-		}
 
 		nrf_err = ble_qwr_conn_handle_assign(&ble_qwr, conn_handle);
 		if (nrf_err) {

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -242,7 +242,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 		/* No system attributes have been stored */
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gatts_evt.conn_handle, NULL, 0, 0);
 		if (nrf_err) {
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -329,11 +329,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 #endif
 		break;
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-		LOG_INF("Authentication status: %#x",
-			evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 		/* Pairing not supported */
 		nrf_err = sd_ble_gap_sec_params_reply(evt->evt.gap_evt.conn_handle,

--- a/samples/bluetooth/ble_pwr_profiling/src/main.c
+++ b/samples/bluetooth/ble_pwr_profiling/src/main.c
@@ -346,7 +346,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 		/* No system attributes have been stored */
-		nrf_err = sd_ble_gatts_sys_attr_set(conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gatts_evt.conn_handle, NULL, 0, 0);
 		if (nrf_err) {
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
 		}

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -100,7 +100,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 	{
-		LOG_INF("BLE_GATTS_EVT_SYS_ATTR_MISSING");
 		/* No system attributes have been stored */
 		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
 

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -96,7 +96,7 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	case BLE_GATTS_EVT_SYS_ATTR_MISSING:
 	{
 		/* No system attributes have been stored */
-		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
+		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gatts_evt.conn_handle, NULL, 0, 0);
 
 		if (nrf_err) {
 			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -58,11 +58,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 	{
 		LOG_INF("Peer connected");
 		conn_handle = evt->evt.gap_evt.conn_handle;
-		nrf_err = sd_ble_gatts_sys_attr_set(evt->evt.gap_evt.conn_handle, NULL, 0, 0);
-
-		if (nrf_err) {
-			LOG_ERR("Failed to set system attributes, nrf_error %#x", nrf_err);
-		}
 		break;
 	}
 

--- a/samples/boot/mcuboot_recovery_entry/src/main.c
+++ b/samples/boot/mcuboot_recovery_entry/src/main.c
@@ -72,13 +72,6 @@ static void on_ble_evt(const ble_evt_t *evt, void *ctx)
 		break;
 	}
 
-	case BLE_GAP_EVT_AUTH_STATUS:
-	{
-		LOG_INF("Authentication status: %#x",
-			evt->evt.gap_evt.params.auth_status.auth_status);
-		break;
-	}
-
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 	{
 		/* Pairing not supported */


### PR DESCRIPTION
* Log cleanup around `BLE_GAP_EVT_AUTH_STATUS`, `BLE_GATTS_EVT_SYS_ATTR_MISSING` and `BLE_GAP_EVT_SEC_PARAMS_REQUEST`.

* Update some samples/applications to only call `sd_ble_gatts_sys_attr_set` in response to a `BLE_GATTS_EVT_SYS_ATTR_MISSING` event. It is not necessary to call this from `BLE_GAP_EVT_CONNECTED`.