### PR TITLE
samples: bluetooth: Fix button press handling for central samples

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -100,6 +100,13 @@ Bluetooth LE samples
 
    * Fixed the disconnect button handler to only disconnect on button press, and not on button release.
 
+* :ref:`ble_hrs_central_sample` sample:
+
+   * Fixed:
+
+      * The disconnect button handler to only disconnect on button press, and not on button release.
+      * The allow list disabling button to only trigger on button press, and not on button release.
+
 NFC samples
 -----------
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -96,7 +96,9 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Bluetooth LE samples
 --------------------
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* :ref:`ble_nus_central_sample` sample:
+
+   * Fixed the disconnect button handler to only disconnect on button press, and not on button release.
 
 NFC samples
 -----------

--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -138,6 +138,10 @@ static void on_ble_evt(const ble_evt_t *ble_evt, void *ctx)
 	case BLE_GAP_EVT_DISCONNECTED:
 		LOG_INF("Disconnected, reason %#x", gap_evt->params.disconnected.reason);
 
+		if (conn_handle == gap_evt->conn_handle) {
+			conn_handle = BLE_CONN_HANDLE_INVALID;
+		}
+
 		atomic_clear_bit(&central_conn, idx);
 
 		if (active_conn_count(&central_conn) < CONFIG_NRF_SDH_BLE_CENTRAL_LINK_COUNT) {
@@ -253,13 +257,18 @@ static void allow_list_disable(void)
 
 static void button_handler_allow_list_off(uint8_t pin, uint8_t action)
 {
-	LOG_INF("Button allow list off");
+	if (action != BM_BUTTONS_PRESS) {
+		return;
+	}
+
 	allow_list_disable();
 }
 
 static void button_handler_disconnect(uint8_t pin, uint8_t action)
 {
-	LOG_INF("Button disconnect");
+	if (conn_handle == BLE_CONN_HANDLE_INVALID || action != BM_BUTTONS_PRESS) {
+		return;
+	}
 
 	uint32_t nrf_err = sd_ble_gap_disconnect(conn_handle,
 						 BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -360,6 +360,10 @@ static void on_ble_nus_client_evt(struct ble_nus_client *ble_nus_c,
 
 static void button_disconnect_handler(uint8_t pin, uint8_t action)
 {
+	if (conn_handle == BLE_CONN_HANDLE_INVALID || action != BM_BUTTONS_PRESS) {
+		return;
+	}
+
 	uint32_t nrf_err =
 		sd_ble_gap_disconnect(conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 


### PR DESCRIPTION
Fix disconnect and allow list disabling buttons to only trigger on button press, and not trigger on button release.