### PR TITLE
lib: bluetooth: scan: Make name and address filter const

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -76,7 +76,9 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Bluetooth LE Services
 ---------------------
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* :ref:`lib_ble_scan`
+
+   * Changed :c:member:`ble_scan_filter_data.addr_filter.addr` and :c:member:`ble_scan_filter_data.name_filter.name` to ``const`` in the :c:struct:`ble_scan_filter_data` structure.
 
 Libraries for NFC
 -----------------

--- a/include/bm/bluetooth/ble_scan.h
+++ b/include/bm/bluetooth/ble_scan.h
@@ -116,11 +116,11 @@ struct ble_scan_filter_data {
 	union {
 		/** Name filter data */
 		struct {
-			char *name;
+			const char *name;
 		} name_filter;
 		/** Address filter data */
 		struct {
-			uint8_t *addr;
+			const uint8_t *addr;
 		} addr_filter;
 		/** UUID filter data */
 		struct {

--- a/lib/bluetooth/ble_scan/ble_scan.c
+++ b/lib/bluetooth/ble_scan/ble_scan.c
@@ -70,7 +70,7 @@ static bool adv_addr_compare(const ble_gap_evt_adv_report_t *adv_report,
 
 static int addr_filter_add(struct ble_scan *scan, const struct ble_scan_filter_data *data)
 {
-	uint8_t *addr = data->addr_filter.addr;
+	const uint8_t *addr = data->addr_filter.addr;
 	ble_gap_addr_t *addr_filter = scan->scan_filters.addr_filter.target_addr;
 	uint8_t *counter = &scan->scan_filters.addr_filter.addr_cnt;
 
@@ -177,7 +177,7 @@ static bool adv_name_compare(const struct ble_scan *scan, uint8_t *data, uint16_
 
 static int name_filter_add(struct ble_scan *scan, const struct ble_scan_filter_data *data)
 {
-	char *name = data->name_filter.name;
+	const char *name = data->name_filter.name;
 	uint8_t *counter = &scan->scan_filters.name_filter.name_cnt;
 	uint8_t name_len = strlen(name);
 


### PR DESCRIPTION
Currently, the name and address filter members in the `ble_scan_filter_data` struct are not `const` even though they are never modified in the scan library. I think the API should guarantee that they are not modified since I do not see a reason for why we want to modify in the library