### PR TITLE
lib: bluetooth: ble_conn_params: fix PHY get when update in progress + support multi-PHY config

### DIFF
--- a/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_conn_params.rst
@@ -115,19 +115,20 @@ Radio PHY mode
 
 The radio PHY mode defaults to 1 MB per second at the start of a connection.
 This can be changed by initiating a GAP radio PHY mode update procedure.
-If a specific radio PHY mode is required in connections, one of the following choice options must be enabled:
+Choose either automatic PHY selection, or enable one or more PHY modes to set a preference for new connections:
 
 * :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_AUTO` - The SoftDevice will automatically select the PHY mode.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_1MBPS` - Default speed of 1 MB per second.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_2MBPS` - Higher throughput of 2 MB per second.
-* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` - Bluetooth LE Coded PHY mode (increased range and reliability of the transmission at the cost of reduced data throughput).
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_1MBPS` - Prefer the 1 Mbps PHY (1M PHY).
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_2MBPS` - Prefer the 2 Mbps PHY (2M PHY) for higher throughput.
+* :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` - Prefer Bluetooth LE Coded PHY mode (increased range and reliability at the cost of reduced throughput).
 
 .. note::
-   The S115 SoftDevice does not support the :kconfig:option:`CONFIG_BLE_CONN_PARAMS_PHY_CODED` Kconfig option.
+   Bluetooth LE Coded PHY can be enabled in configuration, but support depends on the selected SoftDevice and target hardware.
 
 The :kconfig:option:`CONFIG_BLE_CONN_PARAMS_INITIATE_PHY_UPDATE` Kconfig option can be set to automatically initiate a radio PHY update on connection.
 
 A radio PHY mode update procedure can be started using the :c:func:`ble_conn_params_phy_radio_mode_set` function.
+This will also update the preferred PHY modes for the specified connection handle.
 The current radio PHY mode can be retrieved using the :c:func:`ble_conn_params_phy_radio_mode_get` function.
 
 When a radio PHY mode update procedure completes, the Bluetooth LE connection parameter library event :c:enum:`BLE_CONN_PARAMS_EVT_RADIO_PHY_MODE_UPDATED` is raised.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -73,6 +73,8 @@ Libraries
 
 * :ref:`lib_ble_conn_params`:
 
+   * Updated the :c:func:`ble_conn_params_phy_radio_mode_set` function to return :c:macro:`NRF_ERROR_INVALID_PARAM` if the ``phy_pref`` parameter contains PHY modes not supported by the SoftDevice.
+
    * Fixed:
 
       * An issue where the :c:func:`ble_conn_params_phy_radio_mode_get` function would incorrectly return the PHY mode mask of a pending update rather than the currently active PHY mode if a PHY update initiated by the :c:func:`ble_conn_params_phy_radio_mode_set` function was still in progress.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -71,7 +71,12 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Libraries
 =========
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* :ref:`lib_ble_conn_params`:
+
+   * Fixed:
+
+      * An issue where the :c:func:`ble_conn_params_phy_radio_mode_get` function would incorrectly return the PHY mode mask of a pending update rather than the currently active PHY mode if a PHY update initiated by the :c:func:`ble_conn_params_phy_radio_mode_set` function was still in progress.
+      * An issue where the SoftDevice define :c:macro:`BLE_GAP_PHYS_SUPPORTED` was used instead of the PHY preferences set with Kconfig when initiating or responding to a PHY update procedure.
 
 Bluetooth LE Services
 ---------------------

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -73,6 +73,7 @@ Libraries
 
 * :ref:`lib_ble_conn_params`:
 
+   * Added support for selecting more than one PHY mode (1M, 2M, and Coded) when setting the PHY mode preference with Kconfig.
    * Updated the :c:func:`ble_conn_params_phy_radio_mode_set` function to return :c:macro:`NRF_ERROR_INVALID_PARAM` if the ``phy_pref`` parameter contains PHY modes not supported by the SoftDevice.
 
    * Fixed:

--- a/include/bm/bluetooth/ble_conn_params.h
+++ b/include/bm/bluetooth/ble_conn_params.h
@@ -218,7 +218,7 @@ uint32_t ble_conn_params_data_length_get(uint16_t conn_handle,
  * @param phy_pref Desired GAP radio PHY mode.
  *
  * @retval NRF_SUCCESS On success.
- * @retval NRF_ERROR_INVALID_PARAM Invalid data length or connection handle.
+ * @retval NRF_ERROR_INVALID_PARAM Invalid connection handle or unsupported PHY mode in @p phy_pref.
  */
 uint32_t ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t phy_pref);
 

--- a/lib/bluetooth/ble_conn_params/Kconfig
+++ b/lib/bluetooth/ble_conn_params/Kconfig
@@ -133,26 +133,21 @@ config BLE_CONN_PARAMS_AUTO_PHY_UPDATE
 	default y
 if BLE_CONN_PARAMS_AUTO_PHY_UPDATE
 
-choice
-	prompt "Preferred radio PHY mode in connection"
-	default BLE_CONN_PARAMS_PHY_AUTO
-
 config BLE_CONN_PARAMS_PHY_AUTO
-	bool "Auto"
-config BLE_CONN_PARAMS_PHY_1MBPS
-	bool "1 Megabit"
-config BLE_CONN_PARAMS_PHY_2MBPS
-	bool "2 Megabits"
-config BLE_CONN_PARAMS_PHY_CODED
-	bool "Coded"
-endchoice
+	bool "Automatic PHY mode selection"
+	depends on !BLE_CONN_PARAMS_PHY_1MBPS && \
+		   !BLE_CONN_PARAMS_PHY_2MBPS && \
+		   !BLE_CONN_PARAMS_PHY_CODED
+	default y
 
-config BLE_CONN_PARAMS_PHY
-	hex
-	default 0x00 if BLE_CONN_PARAMS_PHY_AUTO
-	default 0x01 if BLE_CONN_PARAMS_PHY_1MBPS
-	default 0x02 if BLE_CONN_PARAMS_PHY_2MBPS
-	default 0x04 if BLE_CONN_PARAMS_PHY_CODED
+config BLE_CONN_PARAMS_PHY_1MBPS
+	bool "Prefer 1 Mbps PHY"
+
+config BLE_CONN_PARAMS_PHY_2MBPS
+	bool "Prefer 2 Mbps PHY"
+
+config BLE_CONN_PARAMS_PHY_CODED
+	bool "Prefer Coded PHY"
 
 config BLE_CONN_PARAMS_INITIATE_PHY_UPDATE
 	bool "Initiate PHY mode update on connection"

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -32,31 +32,35 @@ BUILD_ASSERT(CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO ||
 static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 {
 	uint32_t nrf_err;
-	ble_gap_phys_t phys = links[idx].preferred;
 	struct ble_conn_params_evt app_evt = {
 		.evt_type = BLE_CONN_PARAMS_EVT_ERROR,
 		.conn_handle = conn_handle,
 	};
 
-	nrf_err = sd_ble_gap_phy_update(conn_handle, &phys);
-	if (nrf_err == NRF_SUCCESS) {
-		return;
-	} else if (nrf_err == NRF_ERROR_BUSY) {
-		/* Retry */
-		links[idx].phy_mode_update_pending = true;
-		LOG_DBG("Failed PHY update procedure, another procedure is ongoing, "
-			"Will retry");
-	} else if (nrf_err == NRF_ERROR_RESOURCES) {
+	nrf_err = sd_ble_gap_phy_update(conn_handle, &links[idx].preferred);
+
+	if (nrf_err == NRF_ERROR_RESOURCES) {
 		/* PHY update failed. Use current PHY. */
 		LOG_WRN("Failed PHY update procedure. Continue using current PHY mode");
 		LOG_DBG("GAP event length (%d) may be too small",
 			CONFIG_NRF_SDH_BLE_GAP_EVENT_LENGTH);
+
 		links[idx].preferred = links[idx].phy_mode;
-		radio_phy_mode_update(conn_handle, idx);
-	} else {
-		LOG_ERR("Failed PHY update procedure, nrf_error %#x", nrf_err);
-		app_evt.error.reason = nrf_err;
-		ble_conn_params_event_send(&app_evt);
+
+		nrf_err = sd_ble_gap_phy_update(conn_handle, &links[idx].preferred);
+	}
+
+	if (nrf_err) {
+		if (nrf_err == NRF_ERROR_BUSY) {
+			/* Retry */
+			links[idx].phy_mode_update_pending = true;
+			LOG_DBG("Failed PHY update procedure, another procedure is ongoing, "
+				"Will retry");
+		} else {
+			LOG_ERR("Failed PHY update procedure, nrf_error %#x", nrf_err);
+			app_evt.error.reason = nrf_err;
+			ble_conn_params_event_send(&app_evt);
+		}
 	}
 }
 

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -174,6 +174,11 @@ uint32_t ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t
 		return NRF_ERROR_INVALID_PARAM;
 	}
 
+	if ((phy_pref.tx_phys & ~BLE_GAP_PHYS_SUPPORTED) ||
+	    (phy_pref.rx_phys & ~BLE_GAP_PHYS_SUPPORTED)) {
+		return NRF_ERROR_INVALID_PARAM;
+	}
+
 	links[idx].preferred = phy_pref;
 	radio_phy_mode_update(conn_handle, idx);
 

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -13,6 +13,35 @@ LOG_MODULE_DECLARE(ble_conn_params, CONFIG_BLE_CONN_PARAMS_LOG_LEVEL);
 
 extern void ble_conn_params_event_send(const struct ble_conn_params_evt *evt);
 
+#ifdef CONFIG_BLE_CONN_PARAMS_PHY_1MBPS
+#define PHY_PREFERRED_1MBPS BLE_GAP_PHY_1MBPS
+#else
+#define PHY_PREFERRED_1MBPS 0
+#endif /* CONFIG_BLE_CONN_PARAMS_PHY_1MBPS */
+
+#ifdef CONFIG_BLE_CONN_PARAMS_PHY_2MBPS
+#define PHY_PREFERRED_2MBPS BLE_GAP_PHY_2MBPS
+#else
+#define PHY_PREFERRED_2MBPS 0
+#endif /* CONFIG_BLE_CONN_PARAMS_PHY_2MBPS */
+
+#ifdef CONFIG_BLE_CONN_PARAMS_PHY_CODED
+#define PHY_PREFERRED_CODED BLE_GAP_PHY_CODED
+#else
+#define PHY_PREFERRED_CODED 0
+#endif /* CONFIG_BLE_CONN_PARAMS_PHY_CODED */
+
+#if defined(CONFIG_BLE_CONN_PARAMS_PHY_1MBPS) || defined(CONFIG_BLE_CONN_PARAMS_PHY_2MBPS) || \
+	defined(CONFIG_BLE_CONN_PARAMS_PHY_CODED)
+#define PHY_PREFERRED_MASK (PHY_PREFERRED_1MBPS | PHY_PREFERRED_2MBPS | PHY_PREFERRED_CODED)
+BUILD_ASSERT(!(PHY_PREFERRED_MASK & ~BLE_GAP_PHYS_SUPPORTED), "Unsupported PHY mode(s) in mask");
+BUILD_ASSERT(!!(PHY_PREFERRED_MASK & BLE_GAP_PHYS_SUPPORTED), "No valid PHY mode(s) in mask");
+#elif defined(CONFIG_BLE_CONN_PARAMS_PHY_AUTO)
+#define PHY_PREFERRED_MASK BLE_GAP_PHY_AUTO
+#else
+#error "No valid PHY mode(s) in mask"
+#endif
+
 static struct {
 	ble_gap_phys_t phy_mode;
 	ble_gap_phys_t preferred;
@@ -21,13 +50,10 @@ static struct {
 	[0 ... CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT - 1] = {
 		.phy_mode.tx_phys = BLE_GAP_PHY_1MBPS,
 		.phy_mode.rx_phys = BLE_GAP_PHY_1MBPS,
-		.preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
-		.preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+		.preferred.tx_phys = PHY_PREFERRED_MASK,
+		.preferred.rx_phys = PHY_PREFERRED_MASK,
 	},
 };
-
-BUILD_ASSERT(CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO ||
-	     !!(CONFIG_BLE_CONN_PARAMS_PHY & BLE_GAP_PHYS_SUPPORTED), "Invalid PHY config");
 
 static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 {
@@ -123,8 +149,8 @@ static void on_disconnected(uint16_t conn_handle, int idx)
 
 	links[idx].phy_mode.tx_phys = BLE_GAP_PHY_1MBPS;
 	links[idx].phy_mode.rx_phys = BLE_GAP_PHY_1MBPS;
-	links[idx].preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
-	links[idx].preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
+	links[idx].preferred.tx_phys = PHY_PREFERRED_MASK;
+	links[idx].preferred.rx_phys = PHY_PREFERRED_MASK;
 	links[idx].phy_mode_update_pending = false;
 }
 

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -15,11 +15,14 @@ extern void ble_conn_params_event_send(const struct ble_conn_params_evt *evt);
 
 static struct {
 	ble_gap_phys_t phy_mode;
+	ble_gap_phys_t preferred;
 	uint8_t phy_mode_update_pending : 1;
 } links[CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT] = {
 	[0 ... CONFIG_NRF_SDH_BLE_TOTAL_LINK_COUNT - 1] = {
-		.phy_mode.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
-		.phy_mode.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+		.phy_mode.tx_phys = BLE_GAP_PHY_1MBPS,
+		.phy_mode.rx_phys = BLE_GAP_PHY_1MBPS,
+		.preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+		.preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
 	},
 };
 
@@ -29,20 +32,11 @@ BUILD_ASSERT(CONFIG_BLE_CONN_PARAMS_PHY == BLE_GAP_PHY_AUTO ||
 static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 {
 	uint32_t nrf_err;
-	ble_gap_phys_t phys = links[idx].phy_mode;
+	ble_gap_phys_t phys = links[idx].preferred;
 	struct ble_conn_params_evt app_evt = {
 		.evt_type = BLE_CONN_PARAMS_EVT_ERROR,
 		.conn_handle = conn_handle,
 	};
-
-
-	if (phys.tx_phys != BLE_GAP_PHY_NOT_SET) {
-		phys.tx_phys &= BLE_GAP_PHYS_SUPPORTED;
-	}
-
-	if (phys.rx_phys != BLE_GAP_PHY_NOT_SET) {
-		phys.rx_phys &= BLE_GAP_PHYS_SUPPORTED;
-	}
 
 	nrf_err = sd_ble_gap_phy_update(conn_handle, &phys);
 	if (nrf_err == NRF_SUCCESS) {
@@ -57,8 +51,8 @@ static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 		LOG_WRN("Failed PHY update procedure. Continue using current PHY mode");
 		LOG_DBG("GAP event length (%d) may be too small",
 			CONFIG_NRF_SDH_BLE_GAP_EVENT_LENGTH);
-		links[idx].phy_mode.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
-		links[idx].phy_mode.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
+		links[idx].preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
+		links[idx].preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
 		radio_phy_mode_update(conn_handle, idx);
 	} else {
 		LOG_ERR("Failed PHY update procedure, nrf_error %#x", nrf_err);
@@ -109,9 +103,6 @@ static void on_radio_phy_mode_update_request_evt(uint16_t conn_handle, int idx,
 	LOG_INF("Peer %#x requested PHY update to tx %u, rx %u", conn_handle,
 		evt->peer_preferred_phys.tx_phys, evt->peer_preferred_phys.rx_phys);
 
-	links[idx].phy_mode.tx_phys = evt->peer_preferred_phys.tx_phys;
-	links[idx].phy_mode.rx_phys = evt->peer_preferred_phys.rx_phys;
-
 	radio_phy_mode_update(conn_handle, idx);
 }
 
@@ -127,6 +118,10 @@ static void on_disconnected(uint16_t conn_handle, int idx)
 {
 	ARG_UNUSED(conn_handle);
 
+	links[idx].phy_mode.tx_phys = BLE_GAP_PHY_1MBPS;
+	links[idx].phy_mode.rx_phys = BLE_GAP_PHY_1MBPS;
+	links[idx].preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
+	links[idx].preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
 	links[idx].phy_mode_update_pending = false;
 }
 
@@ -179,7 +174,7 @@ uint32_t ble_conn_params_phy_radio_mode_set(uint16_t conn_handle, ble_gap_phys_t
 		return NRF_ERROR_INVALID_PARAM;
 	}
 
-	links[idx].phy_mode = phy_pref;
+	links[idx].preferred = phy_pref;
 	radio_phy_mode_update(conn_handle, idx);
 
 	return NRF_SUCCESS;

--- a/lib/bluetooth/ble_conn_params/phy_mode.c
+++ b/lib/bluetooth/ble_conn_params/phy_mode.c
@@ -51,8 +51,7 @@ static void radio_phy_mode_update(uint16_t conn_handle, int idx)
 		LOG_WRN("Failed PHY update procedure. Continue using current PHY mode");
 		LOG_DBG("GAP event length (%d) may be too small",
 			CONFIG_NRF_SDH_BLE_GAP_EVENT_LENGTH);
-		links[idx].preferred.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
-		links[idx].preferred.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY;
+		links[idx].preferred = links[idx].phy_mode;
 		radio_phy_mode_update(conn_handle, idx);
 	} else {
 		LOG_ERR("Failed PHY update procedure, nrf_error %#x", nrf_err);

--- a/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
@@ -568,11 +568,6 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
 	};
 
-	ble_gap_phys_t phy_supported = {
-		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
-		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
-	};
-
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &phy_1mbps, 1, NRF_SUCCESS);
@@ -583,7 +578,7 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 	/* Check that we filter out PHYs we do not support. */
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_supported, 1, NRF_SUCCESS);
+		CONN_HANDLE, &phy_all, 1, NRF_SUCCESS);
 
 	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_all);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
@@ -600,14 +595,10 @@ void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
 		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
 	};
-	ble_gap_phys_t phy_supported = {
-		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
-		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
-	};
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_supported, 1, NRF_ERROR_RESOURCES);
+		CONN_HANDLE, &phy_all, 1, NRF_ERROR_RESOURCES);
 
 	/* Operation is retried wirth default parameters. */
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
@@ -1105,9 +1096,9 @@ void test_ble_evt_phy_update_request(void)
 			},
 		},
 	};
-	ble_gap_phys_t phy_2mbps = {
-		.rx_phys = BLE_GAP_PHY_2MBPS,
-		.tx_phys = BLE_GAP_PHY_2MBPS,
+	ble_gap_phys_t phy_auto = {
+		.rx_phys = BLE_GAP_PHY_AUTO,
+		.tx_phys = BLE_GAP_PHY_AUTO,
 	};
 
 	/* Calls from BLE observers. */
@@ -1117,7 +1108,7 @@ void test_ble_evt_phy_update_request(void)
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_2mbps, 1, NRF_SUCCESS);
+		CONN_HANDLE, &phy_auto, 1, NRF_SUCCESS);
 
 	ble_evt_send(&ble_evt);
 }

--- a/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
@@ -596,9 +596,9 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 {
 	uint32_t nrf_err;
-	ble_gap_phys_t phy_config = {
-		.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
-		.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
+	ble_gap_phys_t phy_current = {
+		.rx_phys = BLE_GAP_PHY_1MBPS,
+		.tx_phys = BLE_GAP_PHY_1MBPS,
 	};
 	ble_gap_phys_t phy_1mbps_2mbps = {
 		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
@@ -611,7 +611,7 @@ void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 
 	/* Operation is retried with default parameters. */
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_config, 1, NRF_SUCCESS);
+		CONN_HANDLE, &phy_current, 1, NRF_SUCCESS);
 
 	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_1mbps_2mbps);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);

--- a/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/ble_conn_params/src/unity_test.c
@@ -549,10 +549,19 @@ void test_ble_conn_params_phy_radio_mode_set_error_invalid_param(void)
 {
 	uint32_t nrf_err;
 	ble_gap_phys_t phy_pref;
+	ble_gap_phys_t phy_invalid = {
+		.rx_phys = BLE_GAP_PHYS_SUPPORTED + 1,
+		.tx_phys = BLE_GAP_PHYS_SUPPORTED + 1,
+	};
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, -1);
 
 	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_pref);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
+
+	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
+
+	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_invalid);
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
@@ -563,9 +572,9 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 		.rx_phys = BLE_GAP_PHY_1MBPS,
 		.tx_phys = BLE_GAP_PHY_1MBPS,
 	};
-	ble_gap_phys_t phy_all = {
-		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
-		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
+	ble_gap_phys_t phy_1mbps_2mbps = {
+		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
+		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
 	};
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
@@ -578,9 +587,9 @@ void test_ble_conn_params_phy_radio_mode_set(void)
 	/* Check that we filter out PHYs we do not support. */
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_all, 1, NRF_SUCCESS);
+		CONN_HANDLE, &phy_1mbps_2mbps, 1, NRF_SUCCESS);
 
-	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_all);
+	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_1mbps_2mbps);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 
@@ -591,20 +600,20 @@ void test_ble_conn_params_phy_radio_mode_set_error_resources(void)
 		.rx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
 		.tx_phys = CONFIG_BLE_CONN_PARAMS_PHY,
 	};
-	ble_gap_phys_t phy_all = {
-		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
-		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED,
+	ble_gap_phys_t phy_1mbps_2mbps = {
+		.rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
+		.tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS,
 	};
 
 	__cmock_nrf_sdh_ble_idx_get_ExpectAndReturn(CONN_HANDLE, 0);
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
-		CONN_HANDLE, &phy_all, 1, NRF_ERROR_RESOURCES);
+		CONN_HANDLE, &phy_1mbps_2mbps, 1, NRF_ERROR_RESOURCES);
 
-	/* Operation is retried wirth default parameters. */
+	/* Operation is retried with default parameters. */
 	__cmock_sd_ble_gap_phy_update_ExpectWithArrayAndReturn(
 		CONN_HANDLE, &phy_config, 1, NRF_SUCCESS);
 
-	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_all);
+	nrf_err = ble_conn_params_phy_radio_mode_set(CONN_HANDLE, phy_1mbps_2mbps);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
 


### PR DESCRIPTION
* Fix PHY mode get when PHY update is in progress
* Fix `radio_phy_mode_update` function to use the preferred PHY mask when calling `sd_ble_gap_phy_update`, and not a combination of `BLE_GAP_PHYS_SUPPORTED` and the peer's preferred PHY mask. Which was incorrect.
* Return invalid param if `ble_conn_params_phy_radio_mode_set` is called with SoftDevice unsupported PHY mode
* Fix resource error fallback PHY to the current/active PHY mode.
* Added support for selecting more than one PHY mode when setting the PHY mode preference with Kconfig.

Alternative to https://github.com/nrfconnect/sdk-nrf-bm/pull/788.