### PR TITLE
samples: bluetooth: fixes and cleanup central samples

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -165,6 +165,10 @@ Bluetooth LE samples
       * The allow list disabling button to only trigger on button press, and not on button release.
       * An issue with the endianness of the target peripheral address when displaying the address on a :c:enumerator:`BLE_SCAN_EVT_CONNECTED` event and when supplying the scan filter address with the :kconfig:option:`CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR` Kconfig option.
 
+* :ref:`ble_nus_central_sample` sample:
+
+   * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.
+
 NFC samples
 -----------
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -163,6 +163,7 @@ Bluetooth LE samples
 
       * The disconnect button handler to only disconnect on button press, and not on button release.
       * The allow list disabling button to only trigger on button press, and not on button release.
+      * An issue with the endianness of the target peripheral address when displaying the address on a :c:enumerator:`BLE_SCAN_EVT_CONNECTED` event and when supplying the scan filter address with the :kconfig:option:`CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR` Kconfig option.
 
 NFC samples
 -----------

--- a/samples/bluetooth/ble_hrs_central/README.rst
+++ b/samples/bluetooth/ble_hrs_central/README.rst
@@ -35,24 +35,24 @@ This sample scans for devices that advertise with the :ref:`lib_ble_service_hrs`
 When a device is connected, the sample starts the service discovery procedure.
 If this succeeds, the sample subscribes to the Heart Rate Measurement characteristic to receive heart rate notifications and the Battery Level characteristic to receive battery level notifications.
 
-.. _ble_hrs_central_sample_testing:
-
 User interface
 **************
 
 Button 0:
-  Press to disable allow list.
+   Press to disable allow list.
 
 Button 1:
-  Press to disconnect from the connected peer device.
+   Press to disconnect from the connected peer device.
 
-  Keep the button pressed while resetting the board to delete bonding information for all peers stored on the device.
+   Keep the button pressed while resetting the board to delete bonding information for all peers stored on the device.
 
 LED 0:
    Lit when the device is initialized.
 
 LED 1:
    Lit when a device is connected.
+
+.. _ble_hrs_central_sample_testing:
 
 Building and running
 ********************

--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -5,31 +5,25 @@
  */
 
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <ble.h>
-#include <ble_gap.h>
 #include <bm/bm_buttons.h>
 #include <hal/nrf_gpio.h>
-#include <nrf_soc.h>
 
-#include <bm/bluetooth/ble_conn_params.h>
 #include <bm/bluetooth/ble_db_discovery.h>
+#include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/ble_scan.h>
 #include <bm/bluetooth/peer_manager/nrf_ble_lesc.h>
 #include <bm/bluetooth/peer_manager/peer_manager.h>
 #include <bm/bluetooth/peer_manager/peer_manager_handler.h>
 #include <bm/bluetooth/peer_manager/peer_manager_types.h>
+#include <bm/softdevice_handler/nrf_sdh.h>
+#include <bm/softdevice_handler/nrf_sdh_ble.h>
 
-#include <bm/bluetooth/ble_gq.h>
 #include <bm/bluetooth/services/ble_bas_client.h>
 #include <bm/bluetooth/services/ble_hrs_client.h>
 #include <bm/bluetooth/services/uuid.h>
-#include <bm/softdevice_handler/nrf_sdh.h>
-#include <bm/softdevice_handler/nrf_sdh_ble.h>
-#include <bm/softdevice_handler/nrf_sdh_soc.h>
 
-#include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
@@ -39,15 +33,15 @@
 
 LOG_MODULE_REGISTER(sample, CONFIG_SAMPLE_BLE_HRS_CENTRAL_LOG_LEVEL);
 
-/* Structure used to identify the heart rate client module. */
+/* Heart rate service client instance. */
 BLE_HRS_CLIENT_DEF(ble_hrs_client);
 /* Battery service client instance. */
 BLE_BAS_CLIENT_DEF(ble_bas_client);
-/* Gatt queue instance. */
+/* GATT queue instance. */
 BLE_GQ_DEF(ble_gq);
-/* DB discovery module instance. */
+/* Database discovery instance. */
 BLE_DB_DISCOVERY_DEF(ble_db_disc);
-/* Scanning module instance. */
+/* Scanning instance. */
 BLE_SCAN_DEF(ble_scan);
 
 /* Current connection handle. */
@@ -81,10 +75,10 @@ static uint32_t active_conn_count(atomic_t *conn)
 	return set_flag_count;
 }
 
-static uint32_t scan_start(bool erase_bonds);
+static void scan_start(bool erase_bonds);
 
-static void db_disc_handler(struct ble_db_discovery *db_discovery,
-			    struct ble_db_discovery_evt *evt)
+static void db_disc_evt_handler(struct ble_db_discovery *db_discovery,
+				struct ble_db_discovery_evt *evt)
 {
 	ble_hrs_on_db_disc_evt(&ble_hrs_client, evt);
 	ble_bas_on_db_disc_evt(&ble_bas_client, evt);
@@ -220,7 +214,8 @@ static uint32_t peer_manager_init(void)
 
 	return NRF_SUCCESS;
 }
-static uint32_t delete_bonds(void)
+
+static void delete_bonds(void)
 {
 	uint32_t nrf_err;
 
@@ -229,10 +224,7 @@ static uint32_t delete_bonds(void)
 	nrf_err = pm_peers_delete();
 	if (nrf_err) {
 		LOG_ERR("Failed to delete bonds, nrf_error %#x", nrf_err);
-		return nrf_err;
 	}
-
-	return NRF_SUCCESS;
 }
 
 static void allow_list_disable(void)
@@ -240,7 +232,6 @@ static void allow_list_disable(void)
 	if (!allow_list_disabled) {
 		LOG_INF("allow list temporarily disabled");
 		allow_list_disabled = true;
-		ble_scan_stop(&ble_scan);
 		scan_start(false);
 	}
 }
@@ -267,7 +258,45 @@ static void button_handler_disconnect(uint8_t pin, uint8_t action)
 	}
 }
 
-static void hrs_c_evt_handler(struct ble_hrs_client *hrs, const struct ble_hrs_client_evt *evt)
+static int buttons_leds_init(void)
+{
+	int err;
+	static struct bm_buttons_config btn_cfg[] = {
+		{
+			.pin_number = BOARD_PIN_BTN_0,
+			.active_state = BM_BUTTONS_ACTIVE_LOW,
+			.pull_config = BM_BUTTONS_PIN_PULLUP,
+			.handler = button_handler_allow_list_off,
+		},
+		{
+			.pin_number = BOARD_PIN_BTN_1,
+			.active_state = BM_BUTTONS_ACTIVE_LOW,
+			.pull_config = BM_BUTTONS_PIN_PULLUP,
+			.handler = button_handler_disconnect,
+		},
+	};
+
+	err = bm_buttons_init(btn_cfg, ARRAY_SIZE(btn_cfg), BM_BUTTONS_DETECTION_DELAY_MIN_US);
+	if (err) {
+		LOG_ERR("Failed to initialize buttons, err %d", err);
+		return err;
+	}
+
+	err = bm_buttons_enable();
+	if (err) {
+		LOG_ERR("Failed to enable buttons, err %d", err);
+		return err;
+	}
+
+	nrf_gpio_cfg_output(BOARD_PIN_LED_0);
+	nrf_gpio_cfg_output(BOARD_PIN_LED_1);
+	nrf_gpio_pin_write(BOARD_PIN_LED_0, !BOARD_LED_ACTIVE_STATE);
+	nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
+
+	return 0;
+}
+
+static void hrs_client_evt_handler(struct ble_hrs_client *hrs, const struct ble_hrs_client_evt *evt)
 {
 
 	uint32_t nrf_err;
@@ -309,21 +338,15 @@ static void hrs_c_evt_handler(struct ble_hrs_client *hrs, const struct ble_hrs_c
 	}
 }
 
-static uint32_t hrs_c_init(void)
+static uint32_t hrs_client_init(void)
 {
-	uint32_t nrf_err;
 	struct ble_hrs_client_config hrs_client_cfg = {
-		.evt_handler = hrs_c_evt_handler,
+		.evt_handler = hrs_client_evt_handler,
 		.gatt_queue = &ble_gq,
-		.db_discovery = &ble_db_disc
+		.db_discovery = &ble_db_disc,
 	};
 
-	nrf_err = ble_hrs_client_init(&ble_hrs_client, &hrs_client_cfg);
-	if (nrf_err) {
-		LOG_ERR("Failed to init HRS client, nrf_error %#x", nrf_err);
-	}
-
-	return nrf_err;
+	return ble_hrs_client_init(&ble_hrs_client, &hrs_client_cfg);
 }
 
 static void bas_client_evt_handler(struct ble_bas_client *bas_client,
@@ -339,7 +362,7 @@ static void bas_client_evt_handler(struct ble_bas_client *bas_client,
 		if (nrf_err) {
 			LOG_ERR("Failed to assign handles, nrf_error %#x", nrf_err);
 		}
-		/** Battery service discovered. Enable notification of Battery Level. */
+		/* Battery service discovered. Enable notification of Battery Level. */
 		LOG_DBG("Battery Service discovered. Reading battery level.");
 		nrf_err = ble_bas_client_bl_read(bas_client);
 		if (nrf_err) {
@@ -369,29 +392,25 @@ static void bas_client_evt_handler(struct ble_bas_client *bas_client,
 	}
 }
 
-static uint32_t bas_c_init(void)
+static uint32_t bas_client_init(void)
 {
-	struct ble_bas_client_config bas_client_config = {.evt_handler = bas_client_evt_handler,
-							  .gatt_queue = &ble_gq,
-							  .db_discovery = &ble_db_disc};
+	struct ble_bas_client_config bas_client_cfg = {
+		.evt_handler = bas_client_evt_handler,
+		.gatt_queue = &ble_gq,
+		.db_discovery = &ble_db_disc,
+	};
 
-	return ble_bas_client_init(&ble_bas_client, &bas_client_config);
+	return ble_bas_client_init(&ble_bas_client, &bas_client_cfg);
 }
 
 static uint32_t db_discovery_init(void)
 {
-	uint32_t nrf_err;
-	struct ble_db_discovery_config db_init = {0};
+	struct ble_db_discovery_config db_cfg = {
+		.evt_handler = db_disc_evt_handler,
+		.gatt_queue = &ble_gq,
+	};
 
-	db_init.evt_handler = db_disc_handler;
-	db_init.gatt_queue = &ble_gq;
-
-	nrf_err = ble_db_discovery_init(&ble_db_disc, &db_init);
-	if (nrf_err) {
-		LOG_ERR("db discovery init failed, nrf_error %#x", nrf_err);
-	}
-
-	return nrf_err;
+	return ble_db_discovery_init(&ble_db_disc, &db_cfg);
 }
 
 static void peer_list_get(uint16_t *peers, uint32_t *size)
@@ -415,11 +434,11 @@ static void peer_list_get(uint16_t *peers, uint32_t *size)
 static uint32_t allow_list_load(void)
 {
 	uint32_t nrf_err;
-	uint16_t peers[8];
+	uint16_t peers[BLE_GAP_WHITELIST_ADDR_MAX_COUNT];
 	uint32_t peer_cnt;
 
 	memset(peers, PM_PEER_ID_INVALID, sizeof(peers));
-	peer_cnt = (sizeof(peers) / sizeof(*peers));
+	peer_cnt = BLE_GAP_WHITELIST_ADDR_MAX_COUNT;
 
 	peer_list_get(peers, &peer_cnt);
 
@@ -440,11 +459,10 @@ static uint32_t on_allow_list_req(void)
 {
 	uint32_t nrf_err;
 
-	ble_gap_addr_t allow_list_addrs[8] = {0};
-	ble_gap_irk_t allow_list_irks[8] = {0};
-
-	uint32_t addr_cnt = (sizeof(allow_list_addrs) / sizeof(ble_gap_addr_t));
-	uint32_t irk_cnt = (sizeof(allow_list_irks) / sizeof(ble_gap_irk_t));
+	ble_gap_addr_t allow_list_addrs[BLE_GAP_WHITELIST_ADDR_MAX_COUNT];
+	ble_gap_irk_t allow_list_irks[BLE_GAP_WHITELIST_ADDR_MAX_COUNT];
+	uint32_t addr_cnt = BLE_GAP_WHITELIST_ADDR_MAX_COUNT;
+	uint32_t irk_cnt = BLE_GAP_WHITELIST_ADDR_MAX_COUNT;
 
 	nrf_err = allow_list_load();
 	if (nrf_err) {
@@ -457,7 +475,7 @@ static uint32_t on_allow_list_req(void)
 	}
 
 	if (((addr_cnt == 0) && (irk_cnt == 0)) || (allow_list_disabled)) {
-		/* Don't use allow list.*/
+		/* Don't use allow list. */
 		nrf_err = ble_scan_params_set(&ble_scan, NULL);
 		if (nrf_err) {
 			return nrf_err;
@@ -467,7 +485,7 @@ static uint32_t on_allow_list_req(void)
 	return NRF_SUCCESS;
 }
 
-static uint32_t scan_start(bool erase_bonds)
+static void scan_start(bool erase_bonds)
 {
 	uint32_t nrf_err;
 
@@ -477,37 +495,13 @@ static uint32_t scan_start(bool erase_bonds)
 	} else {
 		nrf_err = ble_scan_start(&ble_scan);
 		if (nrf_err) {
-			LOG_ERR("ble_scan_start failed, nrf_error %#x", nrf_err);
-			return nrf_err;
+			LOG_ERR("Failed to start scanning, nrf_error %#x", nrf_err);
 		}
-	}
-
-	return NRF_SUCCESS;
-}
-
-static void conn_params_evt_handler(const struct ble_conn_params_evt *evt)
-{
-	switch (evt->evt_type) {
-	case BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED:
-		LOG_INF("GATT ATT MTU on connection %#x changed to %d", evt->conn_handle,
-			evt->att_mtu);
-		break;
-
-	case BLE_CONN_PARAMS_EVT_DATA_LENGTH_UPDATED:
-		LOG_INF("Data length for connection %#x updated to %d", evt->conn_handle,
-			evt->data_length.rx);
-		break;
-
-	default:
-		LOG_WRN("unhandled conn params event %d", evt->evt_type);
-		break;
 	}
 }
 
 static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 {
-	uint32_t nrf_err;
-
 	switch (scan_evt->evt_type) {
 	case BLE_SCAN_EVT_NOT_FOUND:
 		/* ignore */
@@ -520,8 +514,7 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 		break;
 
 	case BLE_SCAN_EVT_CONNECTING_ERROR:
-		nrf_err = scan_evt->connecting_err.reason;
-		LOG_INF("Scan connecting error");
+		LOG_ERR("Failed to connect, nrf_error %#x", scan_evt->connecting_err.reason);
 		break;
 
 	case BLE_SCAN_EVT_SCAN_TIMEOUT:
@@ -552,17 +545,6 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 	}
 }
 
-static uint32_t gatt_init(void)
-{
-	uint32_t nrf_err = ble_conn_params_evt_handler_set(conn_params_evt_handler);
-
-	if (nrf_err) {
-		LOG_ERR("ble_conn_params_evt_handler_set failed, nrf_error %#x", nrf_err);
-	}
-
-	return nrf_err;
-}
-
 static uint32_t scan_init(void)
 {
 	uint32_t nrf_err;
@@ -571,7 +553,6 @@ static uint32_t scan_init(void)
 			.active = 0x01,
 			.interval = BLE_GAP_SCAN_INTERVAL_US_MIN * 6,
 			.window = BLE_GAP_SCAN_WINDOW_US_MIN * 6,
-
 			.filter_policy = BLE_GAP_SCAN_FP_ACCEPT_ALL,
 			.timeout = BLE_GAP_SCAN_TIMEOUT_UNLIMITED,
 			.scan_phys = BLE_GAP_PHY_AUTO,
@@ -581,46 +562,52 @@ static uint32_t scan_init(void)
 		.conn_cfg_tag = CONFIG_NRF_SDH_BLE_CONN_TAG,
 		.evt_handler = scan_evt_handler,
 	};
-
-	nrf_err = ble_scan_init(&ble_scan, &scan_cfg);
-	if (nrf_err) {
-		LOG_ERR("nrf_ble_scan_init failed, nrf_error %#x", nrf_err);
-	}
-
 	struct ble_scan_filter_data filter_data = {
 		.uuid_filter.uuid = {
 			.uuid = BLE_UUID_HEART_RATE_SERVICE,
 			.type = BLE_UUID_TYPE_BLE,
 		},
 	};
+	uint8_t filter_mode_mask = BLE_SCAN_UUID_FILTER;
+
+	nrf_err = ble_scan_init(&ble_scan, &scan_cfg);
+	if (nrf_err) {
+		LOG_ERR("ble_scan_init failed, nrf_error %#x", nrf_err);
+		return nrf_err;
+	}
 
 	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_UUID_FILTER, &filter_data);
 	if (nrf_err) {
-		LOG_ERR("nrf_ble_scan_filter_add uuid failed, nrf_error %#x", nrf_err);
+		LOG_ERR("ble_scan_filter_add uuid failed, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_NAME)
-		filter_data.name_filter.name = CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME;
+	filter_data.name_filter.name = CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME;
+	filter_mode_mask |= BLE_SCAN_NAME_FILTER;
 
-		nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_NAME_FILTER, &filter_data);
-		if (nrf_err) {
-			LOG_ERR("nrf_ble_scan_filter_add name failed, nrf_error %#x", nrf_err);
-		}
+	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_NAME_FILTER, &filter_data);
+	if (nrf_err) {
+		LOG_ERR("ble_scan_filter_add name failed, nrf_error %#x", nrf_err);
+		return nrf_err;
+	}
 #endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_NAME */
 
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)
-		filter_data.addr_filter.addr = target_periph_addr;
-		nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_ADDR_FILTER, &filter_data);
-		if (nrf_err) {
-			LOG_ERR("nrf_ble_scan_filter_add address failed, nrf_error %#x", nrf_err);
-		}
+	filter_data.addr_filter.addr = target_periph_addr;
+	filter_mode_mask |= BLE_SCAN_ADDR_FILTER;
+
+	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_ADDR_FILTER, &filter_data);
+	if (nrf_err) {
+		LOG_ERR("ble_scan_filter_add address failed, nrf_error %#x", nrf_err);
+		return nrf_err;
+	}
 #endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR */
 
-	nrf_err = ble_scan_filters_enable(&ble_scan, BLE_SCAN_UUID_FILTER |
-						     BLE_SCAN_NAME_FILTER |
-						     BLE_SCAN_ADDR_FILTER, false);
+	nrf_err = ble_scan_filters_enable(&ble_scan, filter_mode_mask, false);
 	if (nrf_err) {
 		LOG_ERR("Failed to enable scan filters, nrf_error %#x", nrf_err);
+		return nrf_err;
 	}
 
 	return NRF_SUCCESS;
@@ -631,37 +618,11 @@ int main(void)
 	int err;
 	uint32_t nrf_err;
 	ble_gap_conn_sec_mode_t device_name_write_sec;
-	static struct bm_buttons_config configs[] = {
-		{
-			.pin_number = BOARD_PIN_BTN_0,
-			.active_state = BM_BUTTONS_ACTIVE_LOW,
-			.pull_config = BM_BUTTONS_PIN_PULLUP,
-			.handler = button_handler_allow_list_off,
-		},
-		{
-			.pin_number = BOARD_PIN_BTN_1,
-			.active_state = BM_BUTTONS_ACTIVE_LOW,
-			.pull_config = BM_BUTTONS_PIN_PULLUP,
-			.handler = button_handler_disconnect,
-		},
-	};
 
 	LOG_INF("BLE HRS Central sample started.");
 
-	nrf_gpio_cfg_output(BOARD_PIN_LED_0);
-	nrf_gpio_cfg_output(BOARD_PIN_LED_1);
-	nrf_gpio_pin_write(BOARD_PIN_LED_0, !BOARD_LED_ACTIVE_STATE);
-	nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
-
-	err = bm_buttons_init(configs, ARRAY_SIZE(configs), BM_BUTTONS_DETECTION_DELAY_MIN_US);
+	err = buttons_leds_init();
 	if (err) {
-		LOG_ERR("Failed to initialize buttons, err %d", err);
-		goto idle;
-	}
-
-	err = bm_buttons_enable();
-	if (err) {
-		LOG_ERR("Failed to enable buttons, err %d", err);
 		goto idle;
 	}
 
@@ -691,12 +652,6 @@ int main(void)
 		goto idle;
 	}
 
-	nrf_err = gatt_init();
-	if (nrf_err) {
-		LOG_ERR("Failed to initialize gatt, nrf_error %#x", nrf_err);
-		goto idle;
-	}
-
 	nrf_err = peer_manager_init();
 	if (nrf_err) {
 		LOG_ERR("Failed to initialize peer manager, nrf_error %#x", nrf_err);
@@ -709,15 +664,15 @@ int main(void)
 		goto idle;
 	}
 
-	nrf_err = hrs_c_init();
+	nrf_err = hrs_client_init();
 	if (nrf_err) {
-		LOG_ERR("Failed to initialize HRS Client, nrf_error %#x", nrf_err);
+		LOG_ERR("Failed to initialize HRS client, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 
-	nrf_err = bas_c_init();
+	nrf_err = bas_client_init();
 	if (nrf_err) {
-		LOG_ERR("Failed to initialize BAS Client, nrf_error %#x", nrf_err);
+		LOG_ERR("Failed to initialize BAS client, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 

--- a/samples/bluetooth/ble_hrs_central/src/main.c
+++ b/samples/bluetooth/ble_hrs_central/src/main.c
@@ -52,13 +52,14 @@ static bool allow_list_disabled;
 static atomic_t central_conn;
 
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)
-uint8_t target_periph_addr[BLE_GAP_ADDR_LEN] = {
-	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 40) & 0xff,
-	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 32) & 0xff,
-	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 24) & 0xff,
-	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 16) & 0xff,
-	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 8) & 0xff,
+/* Target peripheral address (little-endian). */
+static const uint8_t target_periph_addr[BLE_GAP_ADDR_LEN] = {
 	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 8) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 16) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 24) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 32) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 40) & 0xff,
 };
 #endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR */
 
@@ -531,12 +532,11 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 		break;
 
 	case BLE_SCAN_EVT_CONNECTED: {
-		const ble_gap_evt_connected_t *p_connected = scan_evt->connected.connected;
+		const ble_gap_addr_t *const peer_addr = &scan_evt->connected.connected->peer_addr;
 
-		LOG_INF("Connecting to target %02x%02x%02x%02x%02x%02x",
-			p_connected->peer_addr.addr[0], p_connected->peer_addr.addr[1],
-			p_connected->peer_addr.addr[2], p_connected->peer_addr.addr[3],
-			p_connected->peer_addr.addr[4], p_connected->peer_addr.addr[5]);
+		LOG_INF("Connecting to target %02X:%02X:%02X:%02X:%02X:%02X",
+			peer_addr->addr[5], peer_addr->addr[4], peer_addr->addr[3],
+			peer_addr->addr[2], peer_addr->addr[1], peer_addr->addr[0]);
 	} break;
 
 	default:

--- a/samples/bluetooth/ble_nus_central/Kconfig
+++ b/samples/bluetooth/ble_nus_central/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "BLE NUS Central sample"
+menu "Bluetooth LE NUS central sample"
 
 config SAMPLE_BLE_DEVICE_NAME
 	string "Device name"
@@ -27,12 +27,12 @@ config SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE
 	help
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
+config SAMPLE_NUS_CENTRAL_LPUARTE
+	bool "NUS Client Low Power UARTE"
+
 config SAMPLE_USE_TARGET_PERIPHERAL_NAME
 	bool "Use target peripheral name"
 	default y
-
-config SAMPLE_NUS_CENTRAL_LPUARTE
-	bool "NUS Client Low Power UARTE"
 
 if SAMPLE_USE_TARGET_PERIPHERAL_NAME
 

--- a/samples/bluetooth/ble_nus_central/README.rst
+++ b/samples/bluetooth/ble_nus_central/README.rst
@@ -42,7 +42,7 @@ In addition, the sample enables peer TX notifications to receive data from the p
 User interface
 **************
 
-Button 3:
+Button 1:
    Press to disconnect from the connected peer device.
 
 LED 0:

--- a/samples/bluetooth/ble_nus_central/README.rst
+++ b/samples/bluetooth/ble_nus_central/README.rst
@@ -39,27 +39,27 @@ When connected, the sample forwards any data received on the RX pin of the UART 
 
 In addition, the sample enables peer TX notifications to receive data from the peer.
 
-.. _ble_nus_central_sample_testing:
-
 User interface
 **************
 
+Button 3:
+   Press to disconnect from the connected peer device.
+
 LED 0:
-  Lit when the device is initialized.
+   Lit when the device is initialized.
 
 LED 1:
-  Lit when a device is connected.
-
-Button 3:
-  Disconnects from the peer when pressed.
+   Lit when a device is connected.
 
 .. note::
 
-  LEDs are only used in the normal UARTE configuration.
-  In LPUARTE mode, LEDs are disabled to avoid interfering with the RX pin and to allow proper low-power operation.
+   LEDs are only used in the normal UARTE configuration.
+   In LPUARTE mode, LEDs are disabled to avoid interfering with the RX pin and to allow proper low-power operation.
 
-  In LPUARTE mode, **LED 1** may appear lit even when no device is connected for some development kits, because it shares a pin with the RX signal; RX activity can toggle the LED, which is expected behavior.
+   In LPUARTE mode, **LED 1** may appear lit even when no device is connected for some development kits, because it shares a pin with the RX signal.
+   RX activity can toggle the LED, which is expected behavior.
 
+.. _ble_nus_central_sample_testing:
 
 Building and running
 ********************
@@ -94,12 +94,12 @@ You can test the sample in two ways, depending on the selected UART configuratio
       #. Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_) for both UARTs on both development kits.
       #. Reset the kits.
       #. Observe that the device running the :ref:`ble_nus_central_sample` sample is configured to connect to ``nRF_BM_NUS``.
-         You can configure this name using the :kconfig:option:`SAMPLE_TARGET_PERIPHERAL_NAME` Kconfig option.
+         You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME` Kconfig option.
          For information on how to do this, see `Configuring Kconfig`_.
       #. Observe that the device running the :ref:`ble_nus_sample` sample is advertising under the default name ``nRF_BM_NUS``.
          You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
          For information on how to do this, see `Configuring Kconfig`_.
-      #. Observe that the text ``BLE NUS central example started.`` is printed on the COM listener connected to the device running the :ref:`ble_nus_central_sample` sample.
+      #. Observe that the text ``BLE NUS central sample initialized`` is printed on the COM listener connected to the device running the :ref:`ble_nus_central_sample` sample.
       #. Observe that the text ``BLE NUS sample initialized`` is printed on the COM listener connected to the device running the :ref:`ble_nus_sample` sample.
       #. Write a text in the COM listener running on the computer and press Enter.
       #. Observe that the text is displayed in the second COM listener running on the computer.

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -76,6 +76,18 @@ static uint16_t ble_nus_max_data_len = BLE_NUS_CLIENT_MAX_DATA_LEN_CALC(BLE_GATT
 static uint8_t uarte_rx_buf[CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE][2];
 static int buf_idx;
 
+#if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)
+/* Target peripheral address (little-endian). */
+static const uint8_t target_periph_addr[BLE_GAP_ADDR_LEN] = {
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 8) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 16) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 24) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 32) & 0xff,
+	(CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR >> 40) & 0xff,
+};
+#endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR */
+
 /* Forward declaration. */
 static void scan_start(void);
 
@@ -267,12 +279,12 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 		break;
 
 	case BLE_SCAN_EVT_CONNECTED:
-		const ble_gap_evt_connected_t *connected = scan_evt->connected.connected;
+		const ble_gap_addr_t *const peer_addr = &scan_evt->connected.connected->peer_addr;
+
 		/* Scan is automatically stopped by the connection. */
-		LOG_INF("Connecting to target %02x%02x%02x%02x%02x%02x",
-			connected->peer_addr.addr[0], connected->peer_addr.addr[1],
-			connected->peer_addr.addr[2], connected->peer_addr.addr[3],
-			connected->peer_addr.addr[4], connected->peer_addr.addr[5]);
+		LOG_INF("Connecting to target %02X:%02X:%02X:%02X:%02X:%02X",
+			peer_addr->addr[5], peer_addr->addr[4], peer_addr->addr[3],
+			peer_addr->addr[2], peer_addr->addr[1], peer_addr->addr[0]);
 		break;
 
 	case BLE_SCAN_EVT_SCAN_TIMEOUT:
@@ -514,6 +526,17 @@ static uint32_t scan_init(void)
 		return nrf_err;
 	}
 #endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_NAME */
+
+#if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)
+	filter_data.addr_filter.addr = target_periph_addr;
+	filter_mode_mask |= BLE_SCAN_ADDR_FILTER;
+
+	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_ADDR_FILTER, &filter_data);
+	if (nrf_err) {
+		LOG_ERR("ble_scan_filter_add address failed, nrf_error %#x", nrf_err);
+		return nrf_err;
+	}
+#endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR */
 
 	nrf_err = ble_scan_filters_enable(&ble_scan, filter_mode_mask, false);
 	if (nrf_err) {

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -4,17 +4,27 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <bm/bluetooth/ble_conn_params.h>
-#include <bm/bluetooth/ble_scan.h>
-#include <bm/bluetooth/services/ble_nus.h>
-#include <bm/bluetooth/services/ble_nus_client.h>
+#include <stdint.h>
+#include <ble.h>
 #include <bm/bm_buttons.h>
 #include <bm/bm_irq.h>
+#include <hal/nrf_gpio.h>
 #include <nrfx_uarte.h>
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 #include <bm/drivers/bm_lpuarte.h>
 #endif
 
+#include <bm/bluetooth/ble_conn_params.h>
+#include <bm/bluetooth/ble_db_discovery.h>
+#include <bm/bluetooth/ble_gq.h>
+#include <bm/bluetooth/ble_scan.h>
+#include <bm/softdevice_handler/nrf_sdh.h>
+#include <bm/softdevice_handler/nrf_sdh_ble.h>
+
+#include <bm/bluetooth/services/ble_nus.h>
+#include <bm/bluetooth/services/ble_nus_client.h>
+
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
 
@@ -22,19 +32,19 @@
 
 LOG_MODULE_REGISTER(sample, CONFIG_SAMPLE_BLE_NUS_CENTRAL_LOG_LEVEL);
 
-/** BLE Nordic UART Service (NUS) client instance. */
+/* BLE Nordic UART Service (NUS) client instance. */
 BLE_NUS_CLIENT_DEF(ble_nus_client);
-/** Database discovery module instance. */
+/* Database discovery module instance. */
 BLE_DB_DISCOVERY_DEF(ble_db_disc);
-/** Scanning Module instance. */
+/* Scanning Module instance. */
 BLE_SCAN_DEF(ble_scan);
-/** BLE GATT Queue instance. */
+/* BLE GATT Queue instance. */
 BLE_GQ_DEF(ble_gq);
 
-/** Handle of the current connection. */
+/* Handle of the current connection. */
 static uint16_t conn_handle = BLE_CONN_HANDLE_INVALID;
 
-/** NUS UARTE instance and board config */
+/* NUS UARTE instance and board config */
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 #define NUS_UARTE_INST	  BOARD_APP_LPUARTE_INST
 #define NUS_UARTE_PIN_TX  BOARD_APP_LPUARTE_PIN_TX
@@ -51,23 +61,23 @@ static struct bm_lpuarte lpu;
 #define NUS_UARTE_PIN_RTS BOARD_APP_UARTE_PIN_RTS
 #endif /* CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE */
 
-/** UUID type for the Nordic UART Service (vendor specific). */
+/* UUID type for the Nordic UART Service (vendor specific). */
 #define NUS_SERVICE_UUID_TYPE BLE_UUID_TYPE_VENDOR_BEGIN
 
-/** NUS Client UARTE instance. */
+/* NUS Client UARTE instance. */
 static nrfx_uarte_t nus_uarte_inst = NRFX_UARTE_INSTANCE(NUS_UARTE_INST);
 
-/** Maximum length of data (in bytes) that can be transmitted to the peer by the Nordic UART
- *  service module.
+/* Maximum length of data (in bytes) that can be transmitted to the peer by the Nordic UART
+ * service module.
  */
 static uint16_t ble_nus_max_data_len = BLE_NUS_CLIENT_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 
-/** Receive buffers used in UART ISR callback. */
+/* Receive buffers used in UART ISR callback. */
 static uint8_t uarte_rx_buf[CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE][2];
 static int buf_idx;
 
 /* Forward declaration. */
-static uint32_t scan_start(void);
+static void scan_start(void);
 
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 static void lpuarte_rx_handler(char *data, size_t data_len)
@@ -91,7 +101,7 @@ static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
 	uint8_t c;
-	/** receive buffer used in UART ISR callback. */
+	/* Receive buffer used in UART ISR callback. */
 	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
 	static uint16_t rx_buf_idx;
 	uint16_t len;
@@ -105,7 +115,7 @@ static void uarte_rx_handler(char *data, size_t data_len)
 
 		if ((c == '\n' || c == '\r') || (rx_buf_idx >= ble_nus_max_data_len)) {
 			if (rx_buf_idx == 0) {
-				/** RX buffer is empty, nothing to send. */
+				/* RX buffer is empty, nothing to send. */
 				continue;
 			}
 
@@ -162,28 +172,17 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 	}
 }
 
-static void on_ble_evt(ble_evt_t const *ble_evt, void *context)
+static void on_ble_evt(const ble_evt_t *ble_evt, void *context)
 {
 	uint32_t nrf_err;
-	ble_gap_evt_t const *gap_evt = &ble_evt->evt.gap_evt;
-	ble_gap_phys_t const phys = {
-		.rx_phys = BLE_GAP_PHY_AUTO,
-		.tx_phys = BLE_GAP_PHY_AUTO,
-	};
+	const ble_gap_evt_t *const gap_evt = &ble_evt->evt.gap_evt;
 
 	switch (ble_evt->header.evt_id) {
 	case BLE_GAP_EVT_CONNECTED:
-		nrf_err = ble_nus_client_handles_assign(&ble_nus_client,
-							    ble_evt->evt.gap_evt.conn_handle,
-							    NULL);
-		conn_handle = ble_evt->evt.gap_evt.conn_handle;
-		if (nrf_err) {
-			LOG_ERR("Failed to assign handles, nrf_error %#x", nrf_err);
-		}
+		conn_handle = gap_evt->conn_handle;
 
-		/** Start discovery of services. The NUS Client waits for a discovery result. */
-		nrf_err = ble_db_discovery_start(&ble_db_disc,
-						     ble_evt->evt.gap_evt.conn_handle);
+		/* Start discovery of services. The NUS Client waits for a discovery result. */
+		nrf_err = ble_db_discovery_start(&ble_db_disc, gap_evt->conn_handle);
 		if (nrf_err) {
 			LOG_ERR("Failed to start db discovery, nrf_error %#x", nrf_err);
 		}
@@ -192,14 +191,16 @@ static void on_ble_evt(ble_evt_t const *ble_evt, void *context)
 #endif
 		break;
 	case BLE_GAP_EVT_DISCONNECTED:
-		LOG_INF("Disconnected. conn_handle: 0x%x, reason: 0x%x", gap_evt->conn_handle,
-			gap_evt->params.disconnected.reason);
-		if (conn_handle == gap_evt->conn_handle) {
+		LOG_INF("Disconnected conn_handle %#x, reason %#x",
+			gap_evt->conn_handle, gap_evt->params.disconnected.reason);
+		if (gap_evt->conn_handle == conn_handle) {
 			conn_handle = BLE_CONN_HANDLE_INVALID;
-		}
+
 #if !defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
-		nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
+			nrf_gpio_pin_write(BOARD_PIN_LED_1, !BOARD_LED_ACTIVE_STATE);
 #endif
+			scan_start();
+		}
 		break;
 	case BLE_GAP_EVT_TIMEOUT:
 		if (gap_evt->params.timeout.src == BLE_GAP_TIMEOUT_SRC_CONN) {
@@ -207,23 +208,16 @@ static void on_ble_evt(ble_evt_t const *ble_evt, void *context)
 		}
 		break;
 	case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
-		/** Pairing not supported. */
+		/* Pairing not supported. */
 		nrf_err = sd_ble_gap_sec_params_reply(ble_evt->evt.gap_evt.conn_handle,
-						       BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL,
-						       NULL);
+						      BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL,
+						      NULL);
 		if (nrf_err) {
 			LOG_ERR("gap_sec_params_reply failed, nrf_error %#x", nrf_err);
 		}
 		break;
-	case BLE_GAP_EVT_PHY_UPDATE_REQUEST:
-		LOG_DBG("PHY update request");
-		nrf_err = sd_ble_gap_phy_update(ble_evt->evt.gap_evt.conn_handle, &phys);
-		if (nrf_err) {
-			LOG_ERR("gap_phy_update failed, nrf_error %#x", nrf_err);
-		}
-		break;
 	case BLE_GATTC_EVT_TIMEOUT:
-		/** Disconnect on GATT Client timeout event. */
+		/* Disconnect on GATT Client timeout event. */
 		LOG_DBG("GATT Client Timeout");
 		nrf_err = sd_ble_gap_disconnect(ble_evt->evt.gattc_evt.conn_handle,
 						 BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
@@ -232,7 +226,7 @@ static void on_ble_evt(ble_evt_t const *ble_evt, void *context)
 		}
 		break;
 	case BLE_GATTS_EVT_TIMEOUT:
-		/** Disconnect on GATT Server timeout event. */
+		/* Disconnect on GATT Server timeout event. */
 		LOG_DBG("GATT Server Timeout");
 		nrf_err = sd_ble_gap_disconnect(ble_evt->evt.gatts_evt.conn_handle,
 						 BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
@@ -247,109 +241,101 @@ static void on_ble_evt(ble_evt_t const *ble_evt, void *context)
 
 NRF_SDH_BLE_OBSERVER(sdh_ble, on_ble_evt, NULL, USER_LOW);
 
-static void on_conn_params_evt(const struct ble_conn_params_evt *evt)
+static void conn_params_evt_handler(const struct ble_conn_params_evt *evt)
 {
 	switch (evt->evt_type) {
 	case BLE_CONN_PARAMS_EVT_ATT_MTU_UPDATED:
-		LOG_INF("GATT ATT MTU on connection 0x%x changed to %d", evt->conn_handle,
-			evt->att_mtu);
 		ble_nus_max_data_len = BLE_NUS_MAX_DATA_LEN_CALC(evt->att_mtu);
 		break;
-	case BLE_CONN_PARAMS_EVT_DATA_LENGTH_UPDATED:
-		LOG_INF("Data length for connection 0x%x updated to %d", evt->conn_handle,
-			evt->data_length.rx);
-		break;
+
 	default:
-		LOG_WRN("unhandled conn params event %d", evt->evt_type);
 		break;
 	}
 }
 
-static void on_db_disc_evt(struct ble_db_discovery *ble_db_discovery,
-			       struct ble_db_discovery_evt *evt)
+static void db_disc_evt_handler(struct ble_db_discovery *ble_db_discovery,
+				struct ble_db_discovery_evt *evt)
 {
 	ble_nus_client_on_db_disc_evt(&ble_nus_client, evt);
 }
 
-static void on_ble_scan_evt(struct ble_scan_evt const *ble_scan_evt)
+static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 {
-	uint32_t nrf_err;
-
-	switch (ble_scan_evt->evt_type) {
+	switch (scan_evt->evt_type) {
 	case BLE_SCAN_EVT_CONNECTING_ERROR:
-		nrf_err = ble_scan_evt->connecting_err.reason;
-		if (nrf_err) {
-			LOG_ERR("Failed to connect, nrf_error %#x", nrf_err);
-		}
+		LOG_ERR("Failed to connect, nrf_error %#x", scan_evt->connecting_err.reason);
 		break;
+
 	case BLE_SCAN_EVT_CONNECTED:
-		ble_gap_evt_connected_t const *connected = ble_scan_evt->connected.connected;
-		/** Scan is automatically stopped by the connection. */
+		const ble_gap_evt_connected_t *connected = scan_evt->connected.connected;
+		/* Scan is automatically stopped by the connection. */
 		LOG_INF("Connecting to target %02x%02x%02x%02x%02x%02x",
 			connected->peer_addr.addr[0], connected->peer_addr.addr[1],
 			connected->peer_addr.addr[2], connected->peer_addr.addr[3],
 			connected->peer_addr.addr[4], connected->peer_addr.addr[5]);
 		break;
+
 	case BLE_SCAN_EVT_SCAN_TIMEOUT:
 		LOG_INF("Scan timed out");
-		(void)scan_start();
+		scan_start();
 		break;
+
 	default:
 		break;
 	}
 }
 
-static void on_ble_nus_client_evt(struct ble_nus_client *ble_nus_c,
-				  const struct ble_nus_client_evt *ble_nus_evt)
+static void nus_client_evt_handler(struct ble_nus_client *nus_c,
+				   const struct ble_nus_client_evt *nus_evt)
 {
 	int err;
 	uint32_t nrf_err;
 
-	switch (ble_nus_evt->evt_type) {
+	switch (nus_evt->evt_type) {
 	case BLE_NUS_CLIENT_EVT_DISCOVERY_COMPLETE:
-		LOG_INF("Discovery complete");
-		nrf_err = ble_nus_client_handles_assign(ble_nus_c, ble_nus_evt->conn_handle,
-							&ble_nus_evt->discovery_complete.handles);
+		LOG_INF("NUS discovered");
+		nrf_err = ble_nus_client_handles_assign(nus_c, nus_evt->conn_handle,
+							&nus_evt->discovery_complete.handles);
 		if (nrf_err) {
 			LOG_ERR("Failed to assign handles, nrf_error %#x", nrf_err);
+			break;
 		}
-		nrf_err = ble_nus_client_tx_notif_enable(ble_nus_c);
+		nrf_err = ble_nus_client_tx_notif_enable(nus_c);
 		if (nrf_err) {
 			LOG_ERR("Failed to enable peer tx notifications, nrf_error %#x", nrf_err);
+			break;
 		}
 		LOG_INF("Connected to device with Nordic UART Service");
 		break;
 	case BLE_NUS_CLIENT_EVT_TX_DATA:
-		LOG_INF("NUS TX data event, len: %d",
-			ble_nus_evt->tx_data.length);
+		LOG_INF("NUS TX data event, len: %d", nus_evt->tx_data.length);
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
-		err = bm_lpuarte_tx(&lpu, ble_nus_evt->tx_data.data,
-				    ble_nus_evt->tx_data.length, 3000);
+		err = bm_lpuarte_tx(&lpu, nus_evt->tx_data.data,
+				    nus_evt->tx_data.length, 3000);
 		if (err) {
 			LOG_ERR("bm_lpuarte_tx failed, err %d", err);
 		}
 #else
-		err = nrfx_uarte_tx(&nus_uarte_inst, ble_nus_evt->tx_data.data,
-				    ble_nus_evt->tx_data.length, NRFX_UARTE_TX_BLOCKING);
+		err = nrfx_uarte_tx(&nus_uarte_inst, nus_evt->tx_data.data,
+				    nus_evt->tx_data.length, NRFX_UARTE_TX_BLOCKING);
 		if (err) {
 			LOG_ERR("nrfx_uarte_tx failed, err %d", err);
 		}
 #endif
 		break;
 	case BLE_NUS_CLIENT_EVT_DISCONNECTED:
-		LOG_INF("Disconnected");
-		(void)scan_start();
+		LOG_INF("NUS disconnected");
 		break;
 	case BLE_NUS_CLIENT_EVT_ERROR:
-		LOG_ERR("NUS error, nrf_error %#x", ble_nus_evt->error.reason);
+		LOG_ERR("NUS error, nrf_error %#x", nus_evt->error.reason);
 		break;
 	default:
-		LOG_ERR("Unhandled ble_nus_evt %d", ble_nus_evt->evt_type);
+		LOG_ERR("Unhandled NUS event %d", nus_evt->evt_type);
 		break;
 	}
 }
 
-static void button_disconnect_handler(uint8_t pin, uint8_t action)
+static void button_handler_disconnect(uint8_t pin, uint8_t action)
 {
 	if (conn_handle == BLE_CONN_HANDLE_INVALID || action != BM_BUTTONS_PRESS) {
 		return;
@@ -403,7 +389,7 @@ static int uarte_init(void)
 
 	uarte_cfg->interrupt_priority = CONFIG_SAMPLE_NUS_UART_IRQ_PRIO;
 
-	/** We need to connect the IRQ ourselves. */
+	/* We need to connect the IRQ ourselves. */
 	BM_IRQ_DIRECT_CONNECT(NRFX_IRQ_NUMBER_GET(NUS_UARTE_INST),
 			      CONFIG_SAMPLE_NUS_UART_IRQ_PRIO,
 			      uarte_direct_isr, 0);
@@ -437,20 +423,13 @@ static int uarte_init(void)
 
 static uint32_t nus_client_init(void)
 {
-	uint32_t nrf_err;
-
 	struct ble_nus_client_config ble_nus_client_config = {
-		.evt_handler = on_ble_nus_client_evt,
+		.evt_handler = nus_client_evt_handler,
 		.gatt_queue = &ble_gq,
 		.db_discovery = &ble_db_disc,
 	};
 
-	nrf_err = ble_nus_client_init(&ble_nus_client, &ble_nus_client_config);
-	if (nrf_err) {
-		LOG_ERR("Failed to initialize NUS, nrf_error %#x", nrf_err);
-	}
-
-	return nrf_err;
+	return ble_nus_client_init(&ble_nus_client, &ble_nus_client_config);
 }
 
 static int buttons_leds_init(void)
@@ -462,7 +441,7 @@ static int buttons_leds_init(void)
 			.pin_number = BOARD_PIN_BTN_3,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
-			.handler = button_disconnect_handler,
+			.handler = button_handler_disconnect,
 		},
 	};
 
@@ -491,8 +470,7 @@ static int buttons_leds_init(void)
 static uint32_t scan_init(void)
 {
 	uint32_t nrf_err;
-
-	struct ble_scan_config ble_scan_cfg = {
+	struct ble_scan_config scan_cfg = {
 		.scan_params = {
 			.active = 0x01,
 			.interval = BLE_GAP_SCAN_INTERVAL_US_MIN * 6,
@@ -504,39 +482,42 @@ static uint32_t scan_init(void)
 		.conn_params = BLE_SCAN_CONN_PARAMS_DEFAULT,
 		.connect_if_match = true,
 		.conn_cfg_tag = CONFIG_NRF_SDH_BLE_CONN_TAG,
-		.evt_handler = on_ble_scan_evt,
+		.evt_handler = scan_evt_handler,
 	};
+	struct ble_scan_filter_data filter_data = {
+		.uuid_filter.uuid = {
+			.uuid = BLE_UUID_NUS_SERVICE,
+			.type = BLE_UUID_TYPE_BLE,
+		},
+	};
+	uint8_t filter_mode_mask = BLE_SCAN_UUID_FILTER;
 
-	nrf_err = ble_scan_init(&ble_scan, &ble_scan_cfg);
+	nrf_err = ble_scan_init(&ble_scan, &scan_cfg);
 	if (nrf_err) {
-		LOG_ERR("Failed to initialize ble_scanning, nrf_error %#x", nrf_err);
+		LOG_ERR("ble_scan_init failed, nrf_error %#x", nrf_err);
 		return nrf_err;
 	}
 
-	const struct ble_scan_filter_data uuid_filter = {
-		.uuid_filter = {.uuid = {.uuid = BLE_UUID_NUS_SERVICE, .type = BLE_UUID_TYPE_BLE}}};
-
-	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_UUID_FILTER, &uuid_filter);
+	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_UUID_FILTER, &filter_data);
 	if (nrf_err) {
-		LOG_ERR("nrf_ble_scan_filter_add uuid failed, nrf_error %#x", nrf_err);
+		LOG_ERR("ble_scan_filter_add uuid failed, nrf_error %#x", nrf_err);
 		return nrf_err;
 	}
 
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_NAME)
-	const struct ble_scan_filter_data name_filter = {
-		.name_filter = {.name = CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME}};
+	filter_data.name_filter.name = CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME;
+	filter_mode_mask |= BLE_SCAN_NAME_FILTER;
 
-	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_NAME_FILTER, &name_filter);
+	nrf_err = ble_scan_filter_add(&ble_scan, BLE_SCAN_NAME_FILTER, &filter_data);
 	if (nrf_err) {
-		LOG_ERR("Failed to set filter, nrf_error %#x", nrf_err);
+		LOG_ERR("ble_scan_filter_add name failed, nrf_error %#x", nrf_err);
 		return nrf_err;
 	}
-#endif
-	nrf_err = ble_scan_filters_enable(&ble_scan,
-					      BLE_SCAN_NAME_FILTER | BLE_SCAN_UUID_FILTER,
-					      false);
+#endif /* CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_NAME */
+
+	nrf_err = ble_scan_filters_enable(&ble_scan, filter_mode_mask, false);
 	if (nrf_err) {
-		LOG_ERR("Enabling filter failed, nrf_error %#x", nrf_err);
+		LOG_ERR("Failed to enable scan filters, nrf_error %#x", nrf_err);
 		return nrf_err;
 	}
 
@@ -545,31 +526,22 @@ static uint32_t scan_init(void)
 
 static uint32_t db_discovery_init(void)
 {
-	uint32_t nrf_err;
-
 	struct ble_db_discovery_config db_cfg = {
-		.evt_handler = on_db_disc_evt,
+		.evt_handler = db_disc_evt_handler,
 		.gatt_queue = &ble_gq,
 	};
 
-	nrf_err = ble_db_discovery_init(&ble_db_disc, &db_cfg);
-	if (nrf_err) {
-		LOG_ERR("Failed to enable db discovery, nrf_error %#x", nrf_err);
-	}
-
-	return nrf_err;
+	return ble_db_discovery_init(&ble_db_disc, &db_cfg);
 }
 
-static uint32_t scan_start(void)
+static void scan_start(void)
 {
 	uint32_t nrf_err;
 
 	nrf_err = ble_scan_start(&ble_scan);
 	if (nrf_err) {
-		LOG_ERR("Failed to start ble_scanning, nrf_error %#x", nrf_err);
+		LOG_ERR("Failed to start scanning, nrf_error %#x", nrf_err);
 	}
-
-	return nrf_err;
 }
 
 int main(void)
@@ -577,6 +549,8 @@ int main(void)
 	int err;
 	uint32_t nrf_err;
 	ble_gap_conn_sec_mode_t device_name_write_sec;
+
+	LOG_INF("BLE NUS central sample started");
 
 	err = nrf_sdh_enable_request();
 	if (err) {
@@ -602,15 +576,16 @@ int main(void)
 		goto idle;
 	}
 
+	nrf_err = ble_conn_params_evt_handler_set(conn_params_evt_handler);
+	if (nrf_err) {
+		LOG_ERR("Failed to setup conn params event handler, nrf_error %#x", nrf_err);
+		goto idle;
+	}
+
 	err = uarte_init();
 	if (err) {
 		LOG_ERR("Failed to enable UARTE, err %d", err);
 		goto idle;
-	}
-
-	nrf_err = ble_conn_params_evt_handler_set(on_conn_params_evt);
-	if (nrf_err) {
-		LOG_ERR("ble_conn_params_evt_handler_set failed, nrf_error %#x", nrf_err);
 	}
 
 	err = buttons_leds_init();
@@ -620,11 +595,13 @@ int main(void)
 
 	nrf_err = db_discovery_init();
 	if (nrf_err) {
+		LOG_ERR("Failed to initialize db discovery, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 
 	nrf_err = nus_client_init();
 	if (nrf_err) {
+		LOG_ERR("Failed to initialize NUS client, nrf_error %#x", nrf_err);
 		goto idle;
 	}
 
@@ -633,19 +610,15 @@ int main(void)
 		goto idle;
 	}
 
-	/** Start execution.*/
-	LOG_INF("BLE NUS central example started");
-	nrf_err = scan_start();
-	if (nrf_err) {
-		goto idle;
-	}
-
 #if !defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);
 #endif
 
+	LOG_INF("BLE NUS central sample initialized");
+
+	scan_start();
+
 idle:
-	/** Enter main loop.*/
 	while (true) {
 		log_flush();
 

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -450,7 +450,7 @@ static int buttons_leds_init(void)
 
 	static struct bm_buttons_config btn_configs[] = {
 		{
-			.pin_number = BOARD_PIN_BTN_3,
+			.pin_number = BOARD_PIN_BTN_1,
 			.active_state = BM_BUTTONS_ACTIVE_LOW,
 			.pull_config = BM_BUTTONS_PIN_PULLUP,
 			.handler = button_handler_disconnect,


### PR DESCRIPTION
* Cleanup of `ble_hrs_central` and `ble_nus_central` main source files.
* Fix an issue where the address of connected target was printed reversed and the `target_periph_addr` had wrong endianness in the `ble_hrs_central` sample.
* Add missing address scan filter code to the `ble_nus_central` sample.
* Align `ble_nus_central` sample to use button 1 to disconnect from peripheral device.