### PR TITLE
bluetooth: services: dis: add runtime configuration support

### DIFF
--- a/doc/nrf-bm/libraries/bluetooth/services/ble_dis.rst
+++ b/doc/nrf-bm/libraries/bluetooth/services/ble_dis.rst
@@ -34,15 +34,15 @@ You can configure the service using the following Kconfig options that provide t
 * :kconfig:option:`CONFIG_BLE_DIS_HW_REVISION` - Sets the hardware revision.
 * :kconfig:option:`CONFIG_BLE_DIS_FW_REVISION` - Sets the firmware revision.
 * :kconfig:option:`CONFIG_BLE_DIS_SW_REVISION` - Sets the software revision.
-* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID` - Includes the system ID characteristic in the Device Information Service.
-* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID_OUI` - Sets the organization unique ID.
-* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID_MID` - Sets the manufacturer unique ID.
-* :kconfig:option:`CONFIG_BLE_DIS_PNP_ID` - Includes plug and play ID characteristic.
+* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID` - Includes the System ID characteristic in the Device Information Service.
+* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID_OUI` - Sets the Organizationally Unique ID.
+* :kconfig:option:`CONFIG_BLE_DIS_SYSTEM_ID_MID` - Sets the Manufacturer ID.
+* :kconfig:option:`CONFIG_BLE_DIS_PNP_ID` - Includes the Plug and Play ID characteristic.
 * :kconfig:option:`CONFIG_BLE_DIS_PNP_VID_SRC` - Sets the vendor ID source.
 * :kconfig:option:`CONFIG_BLE_DIS_PNP_VID` - Sets the vendor ID.
 * :kconfig:option:`CONFIG_BLE_DIS_PNP_PID` - Sets the product ID.
 * :kconfig:option:`CONFIG_BLE_DIS_PNP_VER` - Sets the product version.
-* :kconfig:option:`CONFIG_BLE_DIS_REGULATORY_CERT` - Includes IEEE regulatory certifications.
+* :kconfig:option:`CONFIG_BLE_DIS_REGULATORY_CERT` - Includes the IEEE 11073-20601 Regulatory Certification characteristic.
 * :kconfig:option:`CONFIG_BLE_DIS_REGULATORY_CERT_LIST` - Sets the regulatory certification list.
 
 Initialization

--- a/doc/nrf-bm/libraries/bluetooth/services/ble_dis.rst
+++ b/doc/nrf-bm/libraries/bluetooth/services/ble_dis.rst
@@ -15,12 +15,18 @@ Overview
 During initialization, the module adds the Device Information Service to the Bluetooth LE stack database.
 It then encodes the supplied information, and adds the corresponding characteristics.
 
+The characteristic values follow an all-or-nothing model:
+
+* If the application supplies a :c:struct:`ble_dis_values` instance at initialization, the values fully define every characteristic.
+  The Kconfig options are ignored and any member left ``NULL`` (or empty for strings) omits that characteristic.
+* If no run-time values are supplied, all characteristics are built from the :kconfig:option:`CONFIG_BLE_DIS_*` Kconfig build-time defaults.
+
 Configuration
 *************
 
 Set the :kconfig:option:`CONFIG_BLE_DIS` Kconfig option to enable the service.
 
-The DIS service can be configured by using the following Kconfig options:
+You can configure the service using the following Kconfig options that provide the build-time default values:
 
 * :kconfig:option:`CONFIG_BLE_DIS_MANUFACTURER_NAME` - Sets the manufacturer name.
 * :kconfig:option:`CONFIG_BLE_DIS_MODEL_NUMBER` - Sets the model number.
@@ -42,13 +48,16 @@ The DIS service can be configured by using the following Kconfig options:
 Initialization
 ==============
 
-The service is initialized by calling the :c:func:`ble_dis_init` function.
-Configuration is otherwise done through the Kconfig options.
+To initialize the service, call the :c:func:`ble_dis_init` function.
+See the :c:struct:`ble_dis_config` struct for configuration details.
+
+Set the ``values`` field of :c:struct:`ble_dis_config` to a :c:struct:`ble_dis_values` instance to supply run-time values, or to ``NULL`` to use the Kconfig build-time defaults.
 
 Usage
 *****
 
-When enabled, the module will add the Device Information Service with information as specified by the Kconfig options.
+When enabled, the module adds the Device Information Service with the characteristic values supplied at run time.
+If no run-time values are supplied, the values specified by the Kconfig options are used.
 
 Dependencies
 ************

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -106,6 +106,11 @@ Bluetooth LE Services
 
    * Changed :c:member:`ble_scan_filter_data.addr_filter.addr` and :c:member:`ble_scan_filter_data.name_filter.name` to ``const`` in the :c:struct:`ble_scan_filter_data` structure.
 
+* :ref:`lib_ble_service_dis`:
+
+   * Added support for configuring the Device Information Service characteristics at run time through the new :c:struct:`ble_dis_values` structure, passed using the ``values`` field of :c:struct:`ble_dis_config`.
+     When ``values`` is ``NULL``, the service is built from the Kconfig defaults as before.
+
 Libraries for NFC
 -----------------
 

--- a/include/bm/bluetooth/services/ble_dis.h
+++ b/include/bm/bluetooth/services/ble_dis.h
@@ -6,7 +6,7 @@
 /** @file
  *
  * @defgroup ble_dis Device Information Service
- *
+ * @{
  * @brief Device Information Service module.
  *
  * @details This module implements the Device Information Service.
@@ -19,6 +19,7 @@
 #define BLE_DIS_H__
 
 #include <stdint.h>
+#include <zephyr/sys/util.h>
 #include <bm/bluetooth/ble_common.h>
 
 #ifdef __cplusplus
@@ -31,9 +32,97 @@ extern "C" {
 		.device_info_char.read = BLE_GAP_CONN_SEC_MODE_OPEN,                               \
 	}
 
+/** @brief Default characteristic values, populated from the @c CONFIG_BLE_DIS_* Kconfig options. */
+#define BLE_DIS_VALUES_DEFAULTS                                                                    \
+	{                                                                                          \
+		.manufacturer_name = CONFIG_BLE_DIS_MANUFACTURER_NAME,                             \
+		.model_number      = CONFIG_BLE_DIS_MODEL_NUMBER,                                  \
+		.serial_number     = CONFIG_BLE_DIS_SERIAL_NUMBER,                                 \
+		.hw_revision       = CONFIG_BLE_DIS_HW_REVISION,                                   \
+		.fw_revision       = CONFIG_BLE_DIS_FW_REVISION,                                   \
+		.sw_revision       = CONFIG_BLE_DIS_SW_REVISION,                                   \
+		IF_ENABLED(CONFIG_BLE_DIS_SYSTEM_ID, (                                             \
+			.sys_id = &(const struct ble_dis_sys_id){                                  \
+				.manufacturer_id            = CONFIG_BLE_DIS_SYSTEM_ID_MID,        \
+				.organizationally_unique_id = CONFIG_BLE_DIS_SYSTEM_ID_OUI,        \
+			},))                                                                       \
+		IF_ENABLED(CONFIG_BLE_DIS_PNP_ID, (                                                \
+			.pnp_id = &(const struct ble_dis_pnp_id){                                  \
+				.vendor_id_source = CONFIG_BLE_DIS_PNP_VID_SRC,                    \
+				.vendor_id        = CONFIG_BLE_DIS_PNP_VID,                        \
+				.product_id       = CONFIG_BLE_DIS_PNP_PID,                        \
+				.product_version  = CONFIG_BLE_DIS_PNP_VER,                        \
+			},))                                                                       \
+		IF_ENABLED(CONFIG_BLE_DIS_REGULATORY_CERT, (                                       \
+			.reg_cert = &(const struct ble_dis_reg_cert){                              \
+				.list = (const uint8_t[8])                                         \
+					sys_uint64_to_array(CONFIG_BLE_DIS_REGULATORY_CERT_LIST),  \
+				.len  = 8,                                                         \
+			},))                                                                       \
+	}
+
 /**
- * @brief Device Information service configuration.
+ * @name PnP ID Vendor ID Source values
+ * @{
  */
+/** Vendor ID assigned by the Bluetooth SIG. */
+#define BLE_DIS_VENDOR_ID_SRC_BLUETOOTH_SIG 1
+/** Vendor ID assigned by the USB Implementer's Forum. */
+#define BLE_DIS_VENDOR_ID_SRC_USB_IMPL_FORUM 2
+/** @} */
+
+/** @brief System ID characteristic value. */
+struct ble_dis_sys_id {
+	/** Manufacturer ID. Only the 5 least significant octets are used. */
+	uint64_t manufacturer_id;
+	/** Organizationally unique ID. Only the 3 least significant octets are used. */
+	uint32_t organizationally_unique_id;
+};
+
+/** @brief PnP ID characteristic value. */
+struct ble_dis_pnp_id {
+	/** Vendor ID source. See @ref BLE_DIS_VENDOR_ID_SRC_BLUETOOTH_SIG. */
+	uint8_t vendor_id_source;
+	/** Vendor ID. */
+	uint16_t vendor_id;
+	/** Product ID. */
+	uint16_t product_id;
+	/** Product version. */
+	uint16_t product_version;
+};
+
+/** @brief IEEE 11073-20601 Regulatory Certification Data List characteristic value. */
+struct ble_dis_reg_cert {
+	/** Encoded opaque structure based on the IEEE 11073-20601 specification. */
+	const uint8_t *list;
+	/** Length of @ref ble_dis_reg_cert.list. */
+	uint16_t len;
+};
+
+/** @brief Device Information Service characteristic values. */
+struct ble_dis_values {
+	/** Manufacturer Name String. @c NULL or empty string omits the characteristic. */
+	const char *manufacturer_name;
+	/** Model Number String. @c NULL or empty string omits the characteristic. */
+	const char *model_number;
+	/** Serial Number String. @c NULL or empty string omits the characteristic. */
+	const char *serial_number;
+	/** Hardware Revision String. @c NULL or empty string omits the characteristic. */
+	const char *hw_revision;
+	/** Firmware Revision String. @c NULL or empty string omits the characteristic. */
+	const char *fw_revision;
+	/** Software Revision String. @c NULL or empty string omits the characteristic. */
+	const char *sw_revision;
+
+	/** System ID. @c NULL omits the characteristic. */
+	const struct ble_dis_sys_id *sys_id;
+	/** Plug and Play ID. @c NULL omits the characteristic. */
+	const struct ble_dis_pnp_id *pnp_id;
+	/** IEEE 11073-20601 Regulatory Certification Data List. @c NULL omits characteristic. */
+	const struct ble_dis_reg_cert *reg_cert;
+};
+
+/** @brief Device Information Service configuration. */
 struct ble_dis_config {
 	/** Security configuration. */
 	struct {
@@ -45,19 +134,29 @@ struct ble_dis_config {
 			ble_gap_conn_sec_mode_t read;
 		} device_info_char;
 	} sec_mode;
+
+	/** Characteristic values. @c NULL builds the service from the Kconfig defaults. */
+	const struct ble_dis_values *values;
 };
 
 /**
  * @brief Initialize the Device Information Service.
  *
  * @details This call allows the application to initialize the device information service.
- *          It adds the DIS service and DIS characteristics to the database, using the
- *          values supplied through the Kconfig options.
+ *          It adds the DIS service and DIS characteristics to the database.
  *
- * @param dis_config Device Information Service configuration.
+ * @param[in] dis_config Device Information Service configuration.
+ *                       If @ref ble_dis_config::values is @c NULL the values are set based on
+ *                       the @c CONFIG_BLE_DIS_* Kconfig options.
+ *                       If a member of @ref ble_dis_values is left @c NULL or empty string
+ *                       the characteristic is omitted.
  *
- * @return NRF_SUCCESS on successful initialization of service.
+ * @retval NRF_SUCCESS On success.
  * @retval NRF_ERROR_NULL If @p dis_config is @c NULL.
+ * @return In addition, this function may return any error
+ *         returned by the following SoftDevice functions:
+ *         - @ref sd_ble_gatts_service_add()
+ *         - @ref sd_ble_gatts_characteristic_add()
  */
 uint32_t ble_dis_init(const struct ble_dis_config *dis_config);
 

--- a/subsys/bluetooth/services/ble_dis/Kconfig
+++ b/subsys/bluetooth/services/ble_dis/Kconfig
@@ -4,100 +4,134 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 menuconfig BLE_DIS
-	bool "Device Information service"
+	bool "Device Information Service"
 	depends on SOFTDEVICE
+	help
+	  Enable the Bluetooth LE Device Information Service (DIS).
+	  The values configured here are used as the build-time defaults,
+	  applied when the application passes no run-time values to ble_dis_init().
 
 if BLE_DIS
 
 config BLE_DIS_MANUFACTURER_NAME
-	string "Manufacturer name"
+	string "Manufacturer Name"
 	default "Nordic Semiconductor"
 	help
-	  The device manufacturer name inside Device Information Service.
+	  Manufacturer Name characteristic value inside Device Information Service.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_MODEL_NUMBER
-	string "Model number"
+	string "Model Number"
 	default SOC
 	help
-	  The device module number inside Device Information Service.
+	  Model Number characteristic value inside Device Information Service.
+	  Defaults to the SoC name.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_SERIAL_NUMBER
-	string "Serial number"
+	string "Serial Number"
 	help
-	  The device serial number inside Device Information Service.
+	  Serial Number characteristic value inside Device Information Service.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_HW_REVISION
-	string "Hardware revision"
+	string "Hardware Revision"
 	help
-	  The device hardware revision inside Device Information Service.
+	  Hardware Revision characteristic value inside Device Information Service.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_FW_REVISION
-	string "Firmware revision"
+	string "Firmware Revision"
 	help
-	  The device firmware revision inside Device Information Service.
+	  Firmware Revision characteristic value inside Device Information Service.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_SW_REVISION
-	string "Software revision"
+	string "Software Revision"
 	help
-	  The device software revision inside Device Information Service.
+	  Software Revision characteristic value inside Device Information Service.
+	  Leave empty to omit the characteristic from the service.
 
 config BLE_DIS_SYSTEM_ID
 	bool "Include System ID characteristic"
 	help
-	  Include the System ID characteristic in Device Information Serivce.
+	  Include the System ID characteristic in the Device Information Service.
+	  The System ID is an 8-octet value built from a Manufacturer Identifier
+	  (5 octets) and an Organizationally Unique Identifier (3 octets).
 
 config BLE_DIS_SYSTEM_ID_OUI
-	hex "Organizationally unique ID"
+	hex "Organizationally Unique Identifier (OUI)"
 	depends on BLE_DIS_SYSTEM_ID
 	range 0 0xFFFFFF # 3 bytes
+	help
+	  Organizationally Unique Identifier (OUI). Only the 3 least significant
+	  octets are used.
 
 config BLE_DIS_SYSTEM_ID_MID
-	hex "Manufacturer unique ID"
+	hex "Manufacturer Identifier (MID)"
 	depends on BLE_DIS_SYSTEM_ID
 	range 0 0xFFFFFFFFFF # 5 bytes
+	help
+	  Manufacturer Identifier. Only the 5 least significant octets are used.
 
 config BLE_DIS_PNP_ID
 	bool "Include Plug and Play ID characteristic"
 	help
-	  Include the Plug and Play ID characteristic in Device Information Serivce.
+	  Include the PnP ID characteristic in the Device Information Service.
 
 if BLE_DIS_PNP_ID
 
 config BLE_DIS_PNP_VID_SRC
-	hex "PnP vendor ID source"
+	hex "PnP Vendor ID source"
 	range 1 2
 	default 1
+	help
+	  Source of the Vendor ID field:
+	    1 - Vendor ID assigned by the Bluetooth SIG.
+	    2 - Vendor ID assigned by the USB Implementer's Forum.
 
 config BLE_DIS_PNP_VID
-	hex "PnP vendor ID"
+	hex "PnP Vendor ID"
 	range 0 0xFFFF
 	default 0
+	help
+	  Vendor ID, assigned by the body selected in BLE_DIS_PNP_VID_SRC.
 
 config BLE_DIS_PNP_PID
-	hex "PnP product ID"
+	hex "PnP Product ID"
 	range 0 0xFFFF
 	default 0
+	help
+	  Product ID, assigned by the vendor.
 
 config BLE_DIS_PNP_VER
-	hex "PnP product version"
+	hex "PnP Product Version"
 	range 0 0xFFFF
 	default 1
+	help
+	  Product version, assigned by the vendor.
 
-endif # BLE_DIS_PNP
+endif # BLE_DIS_PNP_ID
 
 config BLE_DIS_REGULATORY_CERT
-	bool "Include IEEE regulatory certifications"
+	bool "Include IEEE 11073-20601 Regulatory Certification characteristic"
+	help
+	  Include the IEEE 11073-20601 Regulatory Certification Data List characteristic in the
+	  Device Information Service.
 
 if BLE_DIS_REGULATORY_CERT
 
 config BLE_DIS_REGULATORY_CERT_LIST
-	hex "Regulatory certification list"
+	hex "Regulatory Certification Data List"
 	range 0 0xFFFFFFFFFFFFFFFF # 8 bytes, 1 byte per entry
+	help
+	  Opaque value encoded according to the IEEE 11073-20601 specification.
+	  Provided as an 8-octet value, one byte per certification entry.
 
-endif
+endif # BLE_DIS_REGULATORY_CERT
 
 module=BLE_DIS
-module-str=BLE Device information service
+module-str=BLE Device Information Service
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # BLE_DIS

--- a/subsys/bluetooth/services/ble_dis/dis.c
+++ b/subsys/bluetooth/services/ble_dis/dis.c
@@ -6,6 +6,7 @@
 
 #include <nrf_error.h>
 #include <stdint.h>
+#include <string.h>
 #include <ble_gatts.h>
 #include <bm/bluetooth/services/uuid.h>
 #include <zephyr/logging/log.h>
@@ -26,47 +27,61 @@
 			    (.len = __VA_ARGS__,))                                                 \
 	}
 
-#if CONFIG_BLE_DIS_SYSTEM_ID
-static const uint8_t sys_id[SYS_ID_LEN] = {
-	[0] = (CONFIG_BLE_DIS_SYSTEM_ID_MID & 0x00000000ff),
-	[1] = (CONFIG_BLE_DIS_SYSTEM_ID_MID & 0x000000ff00) >> 8,
-	[2] = (CONFIG_BLE_DIS_SYSTEM_ID_MID & 0x0000ff0000) >> 16,
-	[3] = (CONFIG_BLE_DIS_SYSTEM_ID_MID & 0x00ff000000) >> 24,
-	[4] = (CONFIG_BLE_DIS_SYSTEM_ID_MID & 0xff00000000) >> 32,
-	[5] = (CONFIG_BLE_DIS_SYSTEM_ID_OUI & 0x0000ff),
-	[6] = (CONFIG_BLE_DIS_SYSTEM_ID_OUI & 0x00ff00) >> 8,
-	[7] = (CONFIG_BLE_DIS_SYSTEM_ID_OUI & 0xff0000) >> 16,
-};
-#endif
-
-#if CONFIG_BLE_DIS_PNP_ID
-static const uint8_t pnp_id[PNP_ID_LEN] = {
-	[0] = (CONFIG_BLE_DIS_PNP_VID_SRC),
-	[1] = (CONFIG_BLE_DIS_PNP_VID & 0x00ff),
-	[2] = (CONFIG_BLE_DIS_PNP_VID & 0xff00) >> 8,
-	[3] = (CONFIG_BLE_DIS_PNP_PID & 0x00ff),
-	[4] = (CONFIG_BLE_DIS_PNP_PID & 0xff00) >> 8,
-	[5] = (CONFIG_BLE_DIS_PNP_VER & 0x00ff),
-	[6] = (CONFIG_BLE_DIS_PNP_VER & 0xff00) >> 8,
-};
-#endif
-
-#if CONFIG_BLE_DIS_REGULATORY_CERT
-static const uint8_t regulatory_certifications[IEEE_CERT_LEN] =
-	sys_uint64_to_array(CONFIG_BLE_DIS_REGULATORY_CERT_LIST);
-#endif
+/* Resolve the value of a string characteristic:
+ *  - No run-time values (vals == NULL): use the Kconfig build-time default.
+ *  - Run-time values given: use the field, or "" when the field is NULL.
+ *  - An empty value ("") is skipped later, which omits the characteristic.
+ */
+#define resolve_str(vals, runtime_val, kconfig_val)                                                \
+	(vals == NULL ? kconfig_val :                                                              \
+		runtime_val != NULL ? runtime_val :                                                \
+			"")
 
 LOG_MODULE_REGISTER(ble_dis, CONFIG_BLE_DIS_LOG_LEVEL);
+
+/* Encode a run-time System ID into its on-air representation. */
+static void sys_id_encode(uint8_t *buf, const struct ble_dis_sys_id *id)
+{
+	sys_put_le40(id->manufacturer_id, &buf[0]);
+	sys_put_le24(id->organizationally_unique_id, &buf[5]);
+}
+
+/* Encode a run-time PnP ID into its on-air representation. */
+static void pnp_id_encode(uint8_t *buf, const struct ble_dis_pnp_id *id)
+{
+	buf[0] = id->vendor_id_source;
+	sys_put_le16(id->vendor_id, &buf[1]);
+	sys_put_le16(id->product_id, &buf[3]);
+	sys_put_le16(id->product_version, &buf[5]);
+}
+
+/* Encode a run-time Regulatory Certification Data List into its on-air representation. */
+static void reg_cert_encode(uint8_t *buf, uint64_t val)
+{
+	sys_put_le64(val, buf);
+}
 
 uint32_t ble_dis_init(const struct ble_dis_config *dis_config)
 {
 	uint32_t nrf_err;
 	uint16_t service_handle;
 	ble_uuid_t ble_uuid;
+	uint8_t sys_id_buf[SYS_ID_LEN];
+	uint8_t pnp_id_buf[PNP_ID_LEN];
+	uint8_t reg_cert_buf[IEEE_CERT_LEN];
+	const uint8_t *sys_id_val = NULL;
+	const uint8_t *pnp_id_val = NULL;
+	const uint8_t *reg_cert_val = NULL;
+	uint16_t sys_id_len = 0;
+	uint16_t pnp_id_len = 0;
+	uint16_t reg_cert_len = 0;
 
 	if (!dis_config) {
 		return NRF_ERROR_NULL;
 	}
+
+	/* Run-time characteristic values, or NULL to fall back to the Kconfig defaults. */
+	const struct ble_dis_values *vals = dis_config->values;
 
 	ble_gatts_char_handles_t char_handles = {0};
 	ble_gatts_char_md_t char_md = {
@@ -83,27 +98,85 @@ uint32_t ble_dis_init(const struct ble_dis_config *dis_config)
 		.p_attr_md = &attr_md,
 	};
 
+	/* Get the binary values from the runtime config if it was given,
+	 * otherwise fall back to the Kconfig defaults.
+	 */
+	if (vals) {
+		if (vals->sys_id != NULL) {
+			sys_id_encode(sys_id_buf, vals->sys_id);
+			sys_id_val = sys_id_buf;
+			sys_id_len = sizeof(sys_id_buf);
+		}
+		if (vals->pnp_id != NULL) {
+			pnp_id_encode(pnp_id_buf, vals->pnp_id);
+			pnp_id_val = pnp_id_buf;
+			pnp_id_len = sizeof(pnp_id_buf);
+		}
+		if (vals->reg_cert != NULL) {
+			reg_cert_val = vals->reg_cert->list;
+			reg_cert_len = vals->reg_cert->len;
+		}
+	} else {
+#if CONFIG_BLE_DIS_SYSTEM_ID
+		const struct ble_dis_sys_id kconfig_sys_id = {
+			.manufacturer_id            = CONFIG_BLE_DIS_SYSTEM_ID_MID,
+			.organizationally_unique_id = CONFIG_BLE_DIS_SYSTEM_ID_OUI,
+		};
+		sys_id_encode(sys_id_buf, &kconfig_sys_id);
+		sys_id_val = sys_id_buf;
+		sys_id_len = sizeof(sys_id_buf);
+#endif
+#if CONFIG_BLE_DIS_PNP_ID
+		const struct ble_dis_pnp_id kconfig_pnp_id = {
+			.vendor_id_source = CONFIG_BLE_DIS_PNP_VID_SRC,
+			.vendor_id        = CONFIG_BLE_DIS_PNP_VID,
+			.product_id       = CONFIG_BLE_DIS_PNP_PID,
+			.product_version  = CONFIG_BLE_DIS_PNP_VER,
+		};
+		pnp_id_encode(pnp_id_buf, &kconfig_pnp_id);
+		pnp_id_val = pnp_id_buf;
+		pnp_id_len = sizeof(pnp_id_buf);
+#endif
+#if CONFIG_BLE_DIS_REGULATORY_CERT
+		reg_cert_encode(reg_cert_buf, CONFIG_BLE_DIS_REGULATORY_CERT_LIST);
+		reg_cert_val = reg_cert_buf;
+		reg_cert_len = sizeof(reg_cert_buf);
+#endif
+	}
+
+	/* Put all characteristics in one table.
+	 * Empty ones (zero length) are skipped later, so they won't be added.
+	 */
 	const struct {
 		const uint8_t *value;
 		uint16_t uuid;
-		uint8_t len;
+		uint16_t len;
 	} chars[] = {
-		gatt_char(BLE_UUID_MANUFACTURER_NAME_STRING_CHAR, CONFIG_BLE_DIS_MANUFACTURER_NAME),
-		gatt_char(BLE_UUID_MODEL_NUMBER_STRING_CHAR, CONFIG_BLE_DIS_MODEL_NUMBER),
-		gatt_char(BLE_UUID_SERIAL_NUMBER_STRING_CHAR, CONFIG_BLE_DIS_SERIAL_NUMBER),
-		gatt_char(BLE_UUID_HARDWARE_REVISION_STRING_CHAR, CONFIG_BLE_DIS_HW_REVISION),
-		gatt_char(BLE_UUID_FIRMWARE_REVISION_STRING_CHAR, CONFIG_BLE_DIS_FW_REVISION),
-		gatt_char(BLE_UUID_SOFTWARE_REVISION_STRING_CHAR, CONFIG_BLE_DIS_SW_REVISION),
-#if CONFIG_BLE_DIS_SYSTEM_ID
-		gatt_char(BLE_UUID_SYSTEM_ID_CHAR, sys_id, sizeof(sys_id)),
-#endif
-#if CONFIG_BLE_DIS_PNP_ID
-		gatt_char(BLE_UUID_PNP_ID_CHAR, pnp_id, sizeof(pnp_id)),
-#endif
-#if CONFIG_BLE_DIS_REGULATORY_CERT
+		gatt_char(BLE_UUID_MANUFACTURER_NAME_STRING_CHAR,
+			  resolve_str(vals, vals->manufacturer_name,
+				      CONFIG_BLE_DIS_MANUFACTURER_NAME)),
+		gatt_char(BLE_UUID_MODEL_NUMBER_STRING_CHAR,
+			  resolve_str(vals, vals->model_number,
+				      CONFIG_BLE_DIS_MODEL_NUMBER)),
+		gatt_char(BLE_UUID_SERIAL_NUMBER_STRING_CHAR,
+			  resolve_str(vals, vals->serial_number,
+				      CONFIG_BLE_DIS_SERIAL_NUMBER)),
+		gatt_char(BLE_UUID_HARDWARE_REVISION_STRING_CHAR,
+			  resolve_str(vals, vals->hw_revision,
+				      CONFIG_BLE_DIS_HW_REVISION)),
+		gatt_char(BLE_UUID_FIRMWARE_REVISION_STRING_CHAR,
+			  resolve_str(vals, vals->fw_revision,
+				      CONFIG_BLE_DIS_FW_REVISION)),
+		gatt_char(BLE_UUID_SOFTWARE_REVISION_STRING_CHAR,
+			  resolve_str(vals, vals->sw_revision,
+				      CONFIG_BLE_DIS_SW_REVISION)),
+
+		gatt_char(BLE_UUID_SYSTEM_ID_CHAR,
+			  sys_id_val, sys_id_len),
+		gatt_char(BLE_UUID_PNP_ID_CHAR,
+			  pnp_id_val, pnp_id_len),
 		gatt_char(BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR,
-			  regulatory_certifications, sizeof(regulatory_certifications)),
-#endif
+			  reg_cert_val, reg_cert_len),
 	};
 
 	/* Add service */
@@ -117,7 +190,7 @@ uint32_t ble_dis_init(const struct ble_dis_config *dis_config)
 
 	for (size_t i = 0; i < ARRAY_SIZE(chars); i++) {
 		if (!chars[i].len) {
-			/* If the user didn't add any */
+			/* Skip characteristics with no value (omitted by config or Kconfig). */
 			continue;
 		}
 

--- a/tests/unit/subsys/bluetooth/services/ble_dis/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_dis/src/unity_test.c
@@ -15,178 +15,729 @@
 
 #include "cmock_ble_gatts.h"
 
-#define HANDLE 0xa4
+/* Arbitrary service handle returned by the stubbed service add. */
+#define SERVICE_HANDLE 0xA4
 
-struct ble_dis_config dis_config = {
-		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+/* Runtime test values. */
+#define TEST_MANUFACTURER_NAME "Manufacturer"
+#define TEST_MODEL_NUMBER      "Model"
+#define TEST_SERIAL_NUMBER     "Serial"
+#define TEST_HW_REVISION       "HWrev"
+#define TEST_FW_REVISION       "FWrev"
+#define TEST_SW_REVISION       "SWrev"
+
+/* Expected on-air encodings for the binary characteristics. */
+static const uint8_t sys_id_expected[8]   = {0x15, 0x14, 0x13, 0x12, 0x11, 0x03, 0x02, 0x01};
+static const uint8_t pnp_id_expected[7]   = {0x01, 0x03, 0x02, 0x05, 0x04, 0x07, 0x06};
+static const uint8_t reg_cert_expected[8] = {0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01};
+
+/* Runtime config that exercises every characteristic. */
+static const struct ble_dis_sys_id test_sys_id = {
+	.manufacturer_id            = 0x1112131415, /* -> 0x15 0x14 0x13 0x12 0x11 */
+	.organizationally_unique_id = 0x010203,     /* -> 0x03 0x02 0x01 */
 };
 
-uint32_t stub_sd_ble_gatts_service_add_invalid_param(uint8_t type, const ble_uuid_t *p_uuid,
-						     uint16_t *p_handle, int cmock_num_calls)
-{
-	return NRF_ERROR_INVALID_PARAM;
-}
+static const struct ble_dis_pnp_id test_pnp_id = {
+	.vendor_id_source = 0x01,
+	.vendor_id        = 0x0203,
+	.product_id       = 0x0405,
+	.product_version  = 0x0607,
+};
 
-uint32_t stub_sd_ble_gatts_service_add(uint8_t type, const ble_uuid_t *p_uuid, uint16_t *p_handle,
-				       int cmock_num_calls)
+static const struct ble_dis_reg_cert test_reg_cert = {
+	.list = reg_cert_expected,
+	.len  = sizeof(reg_cert_expected),
+};
+
+static const struct ble_dis_values test_values = {
+	.manufacturer_name = TEST_MANUFACTURER_NAME,
+	.model_number      = TEST_MODEL_NUMBER,
+	.serial_number     = TEST_SERIAL_NUMBER,
+	.hw_revision       = TEST_HW_REVISION,
+	.fw_revision       = TEST_FW_REVISION,
+	.sw_revision       = TEST_SW_REVISION,
+	.sys_id            = &test_sys_id,
+	.pnp_id            = &test_pnp_id,
+	.reg_cert          = &test_reg_cert,
+};
+
+static const struct ble_dis_config config_runtime = {
+	.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+	.values   = &test_values,
+};
+
+static const struct ble_dis_config config_defaults = {
+	.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+	/* .values left NULL -> Kconfig defaults. */
+};
+
+/* Per-characteristic "was this characteristic added" flags, reset in setUp().
+ * Each flag is set individually inside stub_char_add()'s switch  statement below,
+ * so tests can assert exactly which characteristics were added and that no others were.
+ */
+struct dis_chars_added {
+	bool manufacturer_name;
+	bool model_number;
+	bool serial_number;
+	bool hw_revision;
+	bool fw_revision;
+	bool sw_revision;
+	bool sys_id;
+	bool pnp_id;
+	bool reg_cert;
+};
+
+static struct dis_chars_added chars_added;
+
+/* Stub functions for SoftDevice specific functionalities */
+static uint32_t stub_service_add(uint8_t type, const ble_uuid_t *p_uuid, uint16_t *p_handle,
+				 int cmock_num_calls)
 {
+	/* Verify the DIS service is added as a primary service with the correct UUID. */
+	(void)cmock_num_calls;
 	TEST_ASSERT_EQUAL(BLE_GATTS_SRVC_TYPE_PRIMARY, type);
 	TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_uuid->type);
 	TEST_ASSERT_EQUAL(BLE_UUID_DEVICE_INFORMATION_SERVICE, p_uuid->uuid);
 
-	*p_handle = HANDLE;
-
+	*p_handle = SERVICE_HANDLE;
 	return NRF_SUCCESS;
 }
 
-uint32_t stub_sd_ble_gatts_characteristic_add_invalid_param(
-	uint16_t service_handle, const ble_gatts_char_md_t *p_char_md,
-	const ble_gatts_attr_t *p_attr_char_value, ble_gatts_char_handles_t *p_handles,
-	int cmock_num_calls)
+/* Assert the common, characteristic-independent properties of every add call. */
+static void assert_common_char(uint16_t service_handle, const ble_gatts_char_md_t *p_char_md,
+			       const ble_gatts_attr_t *p_attr_char_value,
+			       ble_gatts_char_handles_t *p_handles)
 {
-	return NRF_ERROR_INVALID_PARAM;
-}
-
-uint32_t stub_sd_ble_gatts_characteristic_add(
-	uint16_t service_handle, const ble_gatts_char_md_t *p_char_md,
-	const ble_gatts_attr_t *p_attr_char_value, ble_gatts_char_handles_t *p_handles,
-	int cmock_num_calls)
-{
-	ble_gatts_char_md_t char_md_expected = {
+	const ble_gatts_char_md_t char_md_expected = {
 		.char_props = {
 			.read = true,
 		},
 	};
-	ble_gatts_char_handles_t char_handles_expected = {0};
-	uint8_t sys_id_expected[8] = {0x15, 0x14, 0x13, 0x12, 0x11, 0x03, 0x02, 0x01};
-	uint8_t pnp_id_expected[7] = {0x01, 0x03, 0x02, 0x05, 0x04, 0x07, 0x06};
-	uint8_t regulatory_certifications_expected[8] = {0x08, 0x07, 0x06, 0x05,
-							 0x04, 0x03, 0x02, 0x01};
+	const ble_gatts_char_handles_t char_handles_expected = {0};
 
-	TEST_ASSERT_EQUAL(HANDLE, service_handle);
+	TEST_ASSERT_EQUAL(SERVICE_HANDLE, service_handle);
+	TEST_ASSERT_EQUAL_MEMORY(&char_md_expected, p_char_md, sizeof(char_md_expected));
+	TEST_ASSERT_EQUAL_MEMORY(&char_handles_expected, p_handles, sizeof(char_handles_expected));
+	TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
+}
 
-	TEST_ASSERT_EQUAL_MEMORY(&char_md_expected, p_char_md, sizeof(ble_gatts_char_md_t));
-	TEST_ASSERT_EQUAL_MEMORY(&char_handles_expected, p_handles,
-				 sizeof(ble_gatts_char_handles_t));
+/* Assert a string characteristic: UUID, value and (init/max) length. */
+static void assert_string_char(const ble_gatts_attr_t *attr, uint16_t uuid, const char *value)
+{
+	TEST_ASSERT_EQUAL(uuid, attr->p_uuid->uuid);
+	TEST_ASSERT_EQUAL_STRING(value, attr->p_value);
+	TEST_ASSERT_EQUAL(strlen(value), attr->max_len);
+	TEST_ASSERT_EQUAL(strlen(value), attr->init_len);
+}
 
-	switch (cmock_num_calls) {
-	case 0:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_MANUFACTURER_NAME_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("Manufacturer", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(12, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(12, p_attr_char_value->init_len);
+/* Assert a binary characteristic: UUID, value bytes and (init/max) length. */
+static void assert_binary_char(const ble_gatts_attr_t *attr, uint16_t uuid, const uint8_t *value,
+			       uint16_t value_len)
+{
+	TEST_ASSERT_EQUAL(uuid, attr->p_uuid->uuid);
+	TEST_ASSERT_EQUAL_MEMORY(value, attr->p_value, value_len);
+	TEST_ASSERT_EQUAL(value_len, attr->max_len);
+	TEST_ASSERT_EQUAL(value_len, attr->init_len);
+}
+
+/* Dispatch by UUID so the stub works for any subset of characteristics.
+ * Each call is matched against its expected value,
+ * and sets that characteristic's own flag in chars_added.
+ */
+static uint32_t stub_char_add(uint16_t service_handle, const ble_gatts_char_md_t *p_char_md,
+			      const ble_gatts_attr_t *p_attr_char_value,
+			      ble_gatts_char_handles_t *p_handles, int cmock_num_calls)
+{
+	(void)cmock_num_calls;
+
+	assert_common_char(service_handle, p_char_md, p_attr_char_value, p_handles);
+
+	switch (p_attr_char_value->p_uuid->uuid) {
+	case BLE_UUID_MANUFACTURER_NAME_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_MANUFACTURER_NAME_STRING_CHAR,
+				   TEST_MANUFACTURER_NAME);
+		chars_added.manufacturer_name = true;
 		break;
-	case 1:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_MODEL_NUMBER_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("Model", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->init_len);
+	case BLE_UUID_MODEL_NUMBER_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_MODEL_NUMBER_STRING_CHAR,
+				   TEST_MODEL_NUMBER);
+		chars_added.model_number = true;
 		break;
-	case 2:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_SERIAL_NUMBER_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("Serial", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(6, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(6, p_attr_char_value->init_len);
+	case BLE_UUID_SERIAL_NUMBER_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_SERIAL_NUMBER_STRING_CHAR,
+				   TEST_SERIAL_NUMBER);
+		chars_added.serial_number = true;
 		break;
-	case 3:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_HARDWARE_REVISION_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("HWrev", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->init_len);
+	case BLE_UUID_HARDWARE_REVISION_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_HARDWARE_REVISION_STRING_CHAR,
+				   TEST_HW_REVISION);
+		chars_added.hw_revision = true;
 		break;
-	case 4:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_FIRMWARE_REVISION_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("FWrev", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->init_len);
+	case BLE_UUID_FIRMWARE_REVISION_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_FIRMWARE_REVISION_STRING_CHAR,
+				   TEST_FW_REVISION);
+		chars_added.fw_revision = true;
 		break;
-	case 5:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_SOFTWARE_REVISION_STRING_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_STRING("SWrev", p_attr_char_value->p_value);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(5, p_attr_char_value->init_len);
+	case BLE_UUID_SOFTWARE_REVISION_STRING_CHAR:
+		assert_string_char(p_attr_char_value, BLE_UUID_SOFTWARE_REVISION_STRING_CHAR,
+				   TEST_SW_REVISION);
+		chars_added.sw_revision = true;
 		break;
-	case 6:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_SYSTEM_ID_CHAR, p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_MEMORY(sys_id_expected, p_attr_char_value->p_value,
-					 sizeof(sys_id_expected));
-		TEST_ASSERT_EQUAL(8, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(8, p_attr_char_value->init_len);
+	case BLE_UUID_SYSTEM_ID_CHAR:
+		assert_binary_char(p_attr_char_value, BLE_UUID_SYSTEM_ID_CHAR,
+				   sys_id_expected, sizeof(sys_id_expected));
+		chars_added.sys_id = true;
 		break;
-	case 7:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_PNP_ID_CHAR, p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_MEMORY(pnp_id_expected, p_attr_char_value->p_value,
-					 sizeof(pnp_id_expected));
-		TEST_ASSERT_EQUAL(7, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(7, p_attr_char_value->init_len);
+	case BLE_UUID_PNP_ID_CHAR:
+		assert_binary_char(p_attr_char_value, BLE_UUID_PNP_ID_CHAR,
+				   pnp_id_expected, sizeof(pnp_id_expected));
+		chars_added.pnp_id = true;
 		break;
-	case 8:
-		TEST_ASSERT_EQUAL(BLE_UUID_TYPE_BLE, p_attr_char_value->p_uuid->type);
-		TEST_ASSERT_EQUAL(BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR,
-				  p_attr_char_value->p_uuid->uuid);
-		TEST_ASSERT_EQUAL_MEMORY(regulatory_certifications_expected,
-					 p_attr_char_value->p_value,
-					 sizeof(regulatory_certifications_expected));
-		TEST_ASSERT_EQUAL(8, p_attr_char_value->max_len);
-		TEST_ASSERT_EQUAL(8, p_attr_char_value->init_len);
+	case BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR:
+		assert_binary_char(p_attr_char_value,
+				   BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR,
+				   reg_cert_expected, sizeof(reg_cert_expected));
+		chars_added.reg_cert = true;
 		break;
 	default:
-		TEST_ASSERT_TRUE_MESSAGE(false, "Unreachable");
+		TEST_ASSERT_TRUE_MESSAGE(false, "Unexpected characteristic UUID");
 		break;
 	}
 
 	return NRF_SUCCESS;
 }
 
+/* ble_dis_init() => Error path Unit Tests */
 void test_ble_dis_init_error_null(void)
 {
+	/* A NULL config is rejected, security is mandatory. */
 	uint32_t nrf_err;
 
 	nrf_err = ble_dis_init(NULL);
 	TEST_ASSERT_EQUAL(NRF_ERROR_NULL, nrf_err);
 }
 
-void test_ble_dis_init_error_invalid_param(void)
+void test_ble_dis_init_error_service_add(void)
 {
+	/* sd_ble_gatts_service_add() fails, error propagated. */
 	uint32_t nrf_err;
 
-	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add_invalid_param);
+	__cmock_sd_ble_gatts_service_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
 
-	nrf_err = ble_dis_init(&dis_config);
-	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
-
-	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
-	__cmock_sd_ble_gatts_characteristic_add_Stub(
-		stub_sd_ble_gatts_characteristic_add_invalid_param);
-
-	nrf_err = ble_dis_init(&dis_config);
+	nrf_err = ble_dis_init(&config_runtime);
 	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
 }
 
-void test_ble_dis_init(void)
+void test_ble_dis_init_error_char_add(void)
 {
+	/* sd_ble_gatts_characteristic_add() fails, error propagated. */
 	uint32_t nrf_err;
 
-	__cmock_sd_ble_gatts_service_add_Stub(stub_sd_ble_gatts_service_add);
-	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_sd_ble_gatts_characteristic_add);
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_ExpectAnyArgsAndReturn(NRF_ERROR_INVALID_PARAM);
 
-	nrf_err = ble_dis_init(&dis_config);
+	nrf_err = ble_dis_init(&config_runtime);
+	TEST_ASSERT_EQUAL(NRF_ERROR_INVALID_PARAM, nrf_err);
+}
+
+/* ble_dis_init() => Runtime config Unit Tests */
+void test_ble_dis_init_runtime_all_chars(void)
+{
+	/* All 9 characteristics added with the supplied runtime values. */
+	uint32_t nrf_err;
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config_runtime);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_TRUE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_TRUE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_omits_null_fields(void)
+{
+	/* A runtime config with everything NULL/empty must omit every characteristic:
+	 * the service is added but sd_ble_gatts_characteristic_add() is never called.
+	 */
+	uint32_t nrf_err;
+	static const struct ble_dis_values empty_values = {0};
+	static const struct ble_dis_config config_empty = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &empty_values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config_empty);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+/* ble_dis_init() => Partial runtime config Unit Tests */
+void test_ble_dis_init_runtime_partial_strings(void)
+{
+	/* Only a few string characteristics are set, the rest are omitted. */
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.manufacturer_name = TEST_MANUFACTURER_NAME,
+		.serial_number     = TEST_SERIAL_NUMBER,
+		.sw_revision       = TEST_SW_REVISION,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_TRUE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_partial_binaries(void)
+{
+	/* Only the System ID and Regulatory Cert binaries are set. */
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.sys_id   = &test_sys_id,
+		.reg_cert = &test_reg_cert,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_partial_mixed(void)
+{
+	/* A mix of strings and binaries with gaps in between. */
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.model_number = TEST_MODEL_NUMBER,
+		.hw_revision  = TEST_HW_REVISION,
+		.sys_id       = &test_sys_id,
+		.pnp_id       = &test_pnp_id,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+/* ble_dis_init() => Single characteristic Unit Tests */
+void test_ble_dis_init_runtime_only_manufacturer_name(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.manufacturer_name = TEST_MANUFACTURER_NAME,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_model_number(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.model_number = TEST_MODEL_NUMBER,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_serial_number(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.serial_number = TEST_SERIAL_NUMBER,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_TRUE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_hw_revision(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.hw_revision = TEST_HW_REVISION,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_fw_revision(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.fw_revision = TEST_FW_REVISION,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_TRUE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_sw_revision(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.sw_revision = TEST_SW_REVISION,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_sys_id(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.sys_id = &test_sys_id,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_pnp_id(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.pnp_id = &test_pnp_id,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_FALSE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_runtime_only_reg_cert(void)
+{
+	uint32_t nrf_err;
+	static const struct ble_dis_values values = {
+		.reg_cert = &test_reg_cert,
+	};
+	static const struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &values,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_FALSE(chars_added.manufacturer_name);
+	TEST_ASSERT_FALSE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_FALSE(chars_added.hw_revision);
+	TEST_ASSERT_FALSE(chars_added.fw_revision);
+	TEST_ASSERT_FALSE(chars_added.sw_revision);
+	TEST_ASSERT_FALSE(chars_added.sys_id);
+	TEST_ASSERT_FALSE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+/* ble_dis_init() => BLE_DIS_VALUES_DEFAULTS macro Unit Tests */
+void test_ble_dis_init_defaults_macro_succeeds(void)
+{
+	/* BLE_DIS_VALUES_DEFAULTS produces a valid config and initializes successfully.
+	 * Exact characteristic values depend on Kconfig, so only success is asserted.
+	 */
+	uint32_t nrf_err;
+	struct ble_dis_values vals = BLE_DIS_VALUES_DEFAULTS;
+	struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &vals,
+	};
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_IgnoreAndReturn(NRF_SUCCESS);
+
+	nrf_err = ble_dis_init(&config);
 	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
 }
+
+void test_ble_dis_init_defaults_macro_override_serial_number(void)
+{
+	/* Override serial_number after loading defaults:
+	 * all 9 characteristics must be added, including the overridden serial number.
+	 */
+	uint32_t nrf_err;
+	struct ble_dis_values vals = BLE_DIS_VALUES_DEFAULTS;
+	struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &vals,
+	};
+
+	vals.serial_number = TEST_SERIAL_NUMBER;
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_TRUE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_TRUE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+void test_ble_dis_init_defaults_macro_null_field_omits_char(void)
+{
+	/* Clear serial_number after loading defaults:
+	 * every characteristic except serial number must be added.
+	 */
+	uint32_t nrf_err;
+	struct ble_dis_values vals = BLE_DIS_VALUES_DEFAULTS;
+	struct ble_dis_config config = {
+		.sec_mode = BLE_DIS_CONFIG_SEC_MODE_DEFAULT,
+		.values   = &vals,
+	};
+
+	vals.serial_number = NULL;
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_FALSE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_TRUE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+/* ble_dis_init() => Kconfig default Unit Tests */
+void test_ble_dis_init_defaults(void)
+{
+	/* With values == NULL the service is built from the Kconfig defaults:
+	 * all 9 characteristics must be added with their Kconfig values.
+	 */
+	uint32_t nrf_err;
+
+	__cmock_sd_ble_gatts_service_add_Stub(stub_service_add);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(stub_char_add);
+
+	nrf_err = ble_dis_init(&config_defaults);
+	TEST_ASSERT_EQUAL(NRF_SUCCESS, nrf_err);
+	TEST_ASSERT_TRUE(chars_added.manufacturer_name);
+	TEST_ASSERT_TRUE(chars_added.model_number);
+	TEST_ASSERT_TRUE(chars_added.serial_number);
+	TEST_ASSERT_TRUE(chars_added.hw_revision);
+	TEST_ASSERT_TRUE(chars_added.fw_revision);
+	TEST_ASSERT_TRUE(chars_added.sw_revision);
+	TEST_ASSERT_TRUE(chars_added.sys_id);
+	TEST_ASSERT_TRUE(chars_added.pnp_id);
+	TEST_ASSERT_TRUE(chars_added.reg_cert);
+}
+
+/* Unit Test Setup */
+void setUp(void)
+{
+	__cmock_sd_ble_gatts_service_add_Stub(NULL);
+	__cmock_sd_ble_gatts_characteristic_add_Stub(NULL);
+	memset(&chars_added, 0, sizeof(chars_added));
+}
+
+void tearDown(void) {}
 
 extern int unity_main(void);
 


### PR DESCRIPTION
Allow the Device Information Service to be configured at run time through the new `ble_dis_values` structure, passed via the `values` field of `ble_dis_config`. When `values` is `NULL`, the service is built from the Kconfig defaults as before, otherwise it fully defines the characteristics, with any `NULL` or empty field omitting its characteristic. This lets a single precompiled binary serve multiple devices, for example by setting only the serial number at run time.

A `BLE_DIS_VALUES_DEFAULTS` macro is also added to pre-populate a `ble_dis_values` struct from the Kconfig defaults at run time, making it easy to load all defaults and selectively override individual fields before calling `ble_dis_init`.

Also updates the surrounding documentation and tests. Documented the Kconfig options, refreshed the `BLE_DIS` API docs to cover the runtime configuration, and reworked the unit tests into focused cases covering the runtime, partial, single-characteristic, Kconfig default, and macro-based configuration paths.