### PR TITLE
samples: fix uarte RX buffer indexing

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -172,10 +172,6 @@ Bluetooth LE samples
    * Removed redundant logging of authentication status from the main source file.
      Authentication status is logged by :ref:`lib_peer_manager` library.
 
-* :ref:`ble_nus_central_sample` sample:
-
-   * Fixed the disconnect button handler to only disconnect on button press, and not on button release.
-
 * :ref:`ble_hrs_central_sample` sample:
 
    * Fixed:
@@ -184,9 +180,18 @@ Bluetooth LE samples
       * The allow list disabling button to only trigger on button press, and not on button release.
       * An issue with the endianness of the target peripheral address when displaying the address on a :c:enumerator:`BLE_SCAN_EVT_CONNECTED` event and when supplying the scan filter address with the :kconfig:option:`CONFIG_SAMPLE_TARGET_PERIPHERAL_ADDR` Kconfig option.
 
+* :ref:`ble_nus_sample` sample:
+
+   * Fixed a bug with the UARTE RX buffer address provided with index 1.
+
 * :ref:`ble_nus_central_sample` sample:
 
    * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.
+
+   * Fixed:
+
+      * The disconnect button handler to only disconnect on button press, and not on button release.
+      * A bug with the UARTE RX buffer address provided with index 1.
 
 NFC samples
 -----------

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -62,7 +62,7 @@ static nrfx_uarte_t nus_uarte_inst = NRFX_UARTE_INSTANCE(NUS_UARTE_INST);
 static volatile uint16_t ble_nus_max_data_len = BLE_NUS_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 
 /* Receive buffers used in UART ISR callback. */
-static uint8_t uarte_rx_buf[CONFIG_SAMPLE_NUS_UART_RX_BUF_SIZE][2];
+static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_UART_RX_BUF_SIZE];
 static int buf_idx;
 
 /**

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -73,7 +73,7 @@ static nrfx_uarte_t nus_uarte_inst = NRFX_UARTE_INSTANCE(NUS_UARTE_INST);
 static uint16_t ble_nus_max_data_len = BLE_NUS_CLIENT_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 
 /* Receive buffers used in UART ISR callback. */
-static uint8_t uarte_rx_buf[CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE][2];
+static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE];
 static int buf_idx;
 
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)

--- a/samples/peripherals/lpuarte/src/main.c
+++ b/samples/peripherals/lpuarte/src/main.c
@@ -19,13 +19,15 @@
 
 LOG_MODULE_REGISTER(sample, CONFIG_SAMPLE_LPUARTE_LOG_LEVEL);
 
+#define SAMPLE_LPUARTE_RX_BUF_SIZE 128
+
 static nrfx_uarte_t uarte_inst = NRFX_UARTE_INSTANCE(BOARD_APP_LPUARTE_INST);
 
 /** Application Low Power UARTE instance */
 struct bm_lpuarte lpu;
 
 /* Receive buffer used in UARTE ISR callback */
-static uint8_t uarte_rx_buf[256];
+static uint8_t uarte_rx_buf[2][SAMPLE_LPUARTE_RX_BUF_SIZE];
 static int buf_idx;
 
 /* Handle data received from UARTE. */
@@ -46,9 +48,9 @@ static void lpuarte_event_handler(const nrfx_uarte_event_t *event, void *ctx)
 		}
 		break;
 	case NRFX_UARTE_EVT_RX_BUF_REQUEST:
-		(void)bm_lpuarte_rx_buffer_set(lpu, &uarte_rx_buf[buf_idx * 128], 128);
-		buf_idx++;
-		buf_idx = (buf_idx < 2) ? buf_idx : 0;
+		(void)bm_lpuarte_rx_buffer_set(lpu, uarte_rx_buf[buf_idx],
+					       SAMPLE_LPUARTE_RX_BUF_SIZE);
+		buf_idx = buf_idx ? 0 : 1;
 		break;
 	case NRFX_UARTE_EVT_ERROR:
 		LOG_ERR("UARTE error event, %#x", event->data.error.error_mask);

--- a/samples/peripherals/uarte/src/main.c
+++ b/samples/peripherals/uarte/src/main.c
@@ -15,11 +15,13 @@
 
 LOG_MODULE_REGISTER(sample, CONFIG_SAMPLE_UARTE_LOG_LEVEL);
 
+#define SAMPLE_UARTE_RX_BUF_SIZE 1
+
 /** Application UARTE instance */
 static nrfx_uarte_t uarte_inst = NRFX_UARTE_INSTANCE(BOARD_APP_UARTE_INST);
 
 /* Receive buffer used in UARTE ISR callback */
-static uint8_t uarte_rx_buf[4];
+static uint8_t uarte_rx_buf[2][SAMPLE_UARTE_RX_BUF_SIZE];
 static int buf_idx;
 
 /* Handle data received from UARTE. */
@@ -75,10 +77,10 @@ static void uarte_event_handler(const nrfx_uarte_event_t *event, void *ctx)
 		(void)nrfx_uarte_rx_enable(&uarte_inst, 0);
 		break;
 	case NRFX_UARTE_EVT_RX_BUF_REQUEST:
-		(void)nrfx_uarte_rx_buffer_set(&uarte_inst, &uarte_rx_buf[buf_idx], 1);
+		(void)nrfx_uarte_rx_buffer_set(&uarte_inst, uarte_rx_buf[buf_idx],
+					       SAMPLE_UARTE_RX_BUF_SIZE);
 
-		buf_idx++;
-		buf_idx = (buf_idx < sizeof(uarte_rx_buf)) ? buf_idx : 0;
+		buf_idx = buf_idx ? 0 : 1;
 		break;
 	case NRFX_UARTE_EVT_ERROR:
 		LOG_ERR("UARTE error %#x", event->data.error.error_mask);


### PR DESCRIPTION
The RX buffer were declared in the wrong order for the ble_nus and ble_nus_central samples causing the uarte to be
provided a buffer with the wrong address offset when the index is 1. This commit fixes that bug and alignes all the samples using uarte with the same pattern.