### PR TITLE
samples: ble_nus: detect UART line terminator with compare-match

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -218,6 +218,8 @@ Bluetooth LE samples
 
    * Fixed a bug with the UARTE RX buffer address provided with index 1.
 
+   * Updated UART reception to detect the line terminator in hardware using the UARTE compare-match filter, reporting each line as its own transfer instead of each received byte.
+
 * :ref:`ble_nus_central_sample` sample:
 
    * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -232,6 +232,13 @@ NFC samples
 
 No changes since the latest nRF Connect SDK Bare Metal release.
 
+Peripheral samples
+------------------
+
+* :ref:`uarte_sample` sample:
+
+   * Updated UART reception to detect the line terminator in hardware using the UARTE compare-match filter, reporting each line as its own transfer instead of each received byte.
+
 DFU samples
 -----------
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -222,7 +222,10 @@ Bluetooth LE samples
 
 * :ref:`ble_nus_central_sample` sample:
 
-   * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.
+   * Updated:
+
+      * To use Button 1 to disconnect from the target peripheral to align with other central samples.
+      * UART reception to detect the line terminator in hardware using the UARTE compare-match filter, reporting each line as its own transfer instead of each received byte.
 
    * Fixed:
 

--- a/samples/bluetooth/ble_nus/Kconfig
+++ b/samples/bluetooth/ble_nus/Kconfig
@@ -39,6 +39,12 @@ config SAMPLE_NUS_UART_RX_BUF_SIZE
 	int "NUS UART receive buffer size"
 	default 128
 	help
+	  Do not set this too low. No data is lost if it is too small, but the
+	  buffer fills up and gets flushed sooner, so the radio has to send more,
+	  smaller BLE NUS notifications instead of fewer, larger ones. That means
+	  more radio activity for the same amount of data, which costs more power.
+	  For the best power efficiency, keep this at the high end of the ATT MTU
+	  or message sizes you expect to send.
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
 module=SAMPLE_BLE_NUS

--- a/samples/bluetooth/ble_nus/Kconfig
+++ b/samples/bluetooth/ble_nus/Kconfig
@@ -37,8 +37,7 @@ config SAMPLE_NUS_UART_HWFC
 
 config SAMPLE_NUS_UART_RX_BUF_SIZE
 	int "NUS UART receive buffer size"
-	default 128 if SAMPLE_NUS_LPUARTE
-	default 1
+	default 128
 	help
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -17,6 +17,7 @@
 #include <bm/bluetooth/services/ble_nus.h>
 #include <nrf_soc.h>
 #include <nrfx_uarte.h>
+#include <hal/nrf_uarte.h>
 #if defined(CONFIG_SAMPLE_NUS_LPUARTE)
 #include <bm/drivers/bm_lpuarte.h>
 #endif
@@ -61,7 +62,9 @@ static nrfx_uarte_t nus_uarte_inst = NRFX_UARTE_INSTANCE(NUS_UARTE_INST);
  */
 static volatile uint16_t ble_nus_max_data_len = BLE_NUS_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 
-/* Receive buffers used in UART ISR callback. */
+/* Double-buffered RX: one buffer is always queued as "next",
+ * so when the current one is filled or aborted, DMA continues into the other.
+ */
 static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_UART_RX_BUF_SIZE];
 static int buf_idx;
 
@@ -162,12 +165,9 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 			uarte_rx_handler(event->data.rx.p_buffer, event->data.rx.length);
 #endif
 		}
-
-#if !defined(CONFIG_SAMPLE_NUS_LPUARTE)
-		(void)nrfx_uarte_rx_enable(&nus_uarte_inst, 0);
-#endif
 		break;
 	case NRFX_UARTE_EVT_RX_BUF_REQUEST:
+		/* Queue the free buffer immediately so RX keeps running with zero downtime. */
 #if defined(CONFIG_SAMPLE_NUS_LPUARTE)
 		(void)bm_lpuarte_rx_buffer_set(&lpu, uarte_rx_buf[buf_idx],
 					       CONFIG_SAMPLE_NUS_UART_RX_BUF_SIZE);
@@ -355,6 +355,34 @@ static void ble_nus_evt_handler(struct ble_nus *nus, const struct ble_nus_evt *e
 
 ISR_DIRECT_DECLARE(uarte_direct_isr)
 {
+#if !defined(CONFIG_SAMPLE_NUS_LPUARTE)
+	/* The compare-match filter raises MATCH0 on '\r' and MATCH1 on '\n',
+	 * either one ends a line, so both are handled the same way here.
+	 * Clear it and abort the current RX. A second buffer is already queued,
+	 * so reception continues into it without a gap.
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)nus_uarte_inst.p_reg;
+	bool match = false;
+
+	if (reg->EVENTS_DMA.RX.MATCH[0]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[0]));
+		match = true;
+	}
+
+	if (reg->EVENTS_DMA.RX.MATCH[1]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[1]));
+		match = true;
+	}
+
+	if (match) {
+		(void)nrfx_uarte_rx_abort(&nus_uarte_inst, false, false);
+	}
+#endif
+
 	nrfx_uarte_irq_handler(&nus_uarte_inst);
 	return 0;
 }
@@ -415,6 +443,19 @@ static int uarte_init(void)
 		LOG_ERR("Failed to initialize UART, err %d", err);
 		return err;
 	}
+
+	/* Configure the compare-match filter so reception stops on '\r' or '\n':
+	 * CANDIDATE[0] = '\r', CANDIDATE[1] = '\n', both enabled and both raising
+	 * an interrupt (uarte_direct_isr aborts RX on either match).
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)nus_uarte_inst.p_reg;
+
+	reg->DMA.RX.MATCH.CANDIDATE[0] = '\r';
+	reg->DMA.RX.MATCH.CANDIDATE[1] = '\n';
+	reg->DMA.RX.MATCH.CONFIG       = UARTE_DMA_RX_MATCH_CONFIG_ENABLE0_Msk |
+					 UARTE_DMA_RX_MATCH_CONFIG_ENABLE1_Msk;
+	reg->INTENSET                  = UARTE_INTENSET_DMARXMATCH0_Msk |
+					 UARTE_INTENSET_DMARXMATCH1_Msk;
 #endif /* CONFIG_SAMPLE_NUS_LPUARTE */
 
 	return 0;
@@ -529,7 +570,10 @@ int main(void)
 		goto idle;
 	}
 
-	err = nrfx_uarte_rx_enable(&nus_uarte_inst, 0);
+	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
+	 * an abort on match ends the current one and continues into the other.
+	 */
+	err = nrfx_uarte_rx_enable(&nus_uarte_inst, NRFX_UARTE_RX_ENABLE_CONT);
 	if (err) {
 		LOG_ERR("UART RX failed, err %d", err);
 	}

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -98,50 +98,29 @@ static void lpuarte_rx_handler(char *data, size_t data_len)
 static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
-	uint8_t c;
-	/* receive buffer used in UART ISR callback. */
-	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
-	static uint16_t rx_buf_idx;
+	uint16_t sent = 0;
 	uint16_t len;
 
-	for (int i = 0; i < data_len; i++) {
-		c = data[i];
+	/* Forward the chunk as received, split only if it exceeds the current
+	 * NUS notification size limit. No bytes are added or dropped.
+	 */
+	while (sent < data_len) {
+		len = MIN(data_len - sent, ble_nus_max_data_len);
+		LOG_INF("Sending data over BLE NUS, len %d", len);
 
-		if (rx_buf_idx < sizeof(rx_buf)) {
-			rx_buf[rx_buf_idx++] = c;
-		}
-
-		if ((c == '\n' || c == '\r') || (rx_buf_idx >= ble_nus_max_data_len)) {
-			if (rx_buf_idx == 0) {
-				/* RX buffer is empty, nothing to send. */
-				continue;
+		/* Retry when the SoftDevice notification queue is full.
+		 * sd_ble_gatts_hvx() returns NRF_ERROR_RESOURCES when UART data arrives
+		 * faster than the radio can transmit notifications.
+		 */
+		do {
+			nrf_err = ble_nus_data_send(&ble_nus, &data[sent], &len, conn_handle);
+			if ((nrf_err) && (nrf_err != NRF_ERROR_RESOURCES)) {
+				LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
+				return;
 			}
+		} while (nrf_err == NRF_ERROR_RESOURCES);
 
-			len = rx_buf_idx;
-			LOG_INF("Sending data over BLE NUS, len %d", len);
-
-			/* Retry when the SoftDevice notification queue is full.
-			 * sd_ble_gatts_hvx() returns NRF_ERROR_RESOURCES when UART data arrives
-			 * faster than the radio can transmit notifications.
-			 */
-			do {
-				nrf_err = ble_nus_data_send(&ble_nus, rx_buf, &len, conn_handle);
-				if ((nrf_err) && (nrf_err != NRF_ERROR_RESOURCES)) {
-					LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
-					return;
-				}
-			} while (nrf_err == NRF_ERROR_RESOURCES);
-
-			if (len == rx_buf_idx) {
-				rx_buf_idx = 0;
-			} else {
-				/* Not all data in RX buffer was transmitted.
-				 * Move what is left to start of buffer.
-				 */
-				memmove(&rx_buf[len], &rx_buf[0], rx_buf_idx - len);
-				rx_buf_idx -= len;
-			}
-		}
+		sent += len;
 	}
 }
 #endif

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -315,7 +315,6 @@ uint16_t ble_qwr_evt_handler(struct ble_qwr *qwr, const struct ble_qwr_evt *qwr_
  */
 static void ble_nus_evt_handler(struct ble_nus *nus, const struct ble_nus_evt *evt)
 {
-	const char newline = '\n';
 	int err;
 
 	if (evt->evt_type == BLE_NUS_EVT_ERROR) {
@@ -342,15 +341,6 @@ static void ble_nus_evt_handler(struct ble_nus *nus, const struct ble_nus_evt *e
 		LOG_ERR("nrfx_uarte_tx failed, err %d", err);
 	}
 #endif
-
-
-	if (evt->rx_data.data[evt->rx_data.length - 1] == '\r') {
-#if defined(CONFIG_SAMPLE_NUS_LPUARTE)
-		(void)bm_lpuarte_tx(&lpu, &newline, 1, 3000);
-#else
-		(void)nrfx_uarte_tx(&nus_uarte_inst, &newline, 1, NRFX_UARTE_TX_BLOCKING);
-#endif
-	}
 }
 
 ISR_DIRECT_DECLARE(uarte_direct_isr)

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -156,8 +156,8 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 {
 	switch (event->type) {
 	case NRFX_UARTE_EVT_RX_DONE:
-		LOG_DBG("Received data from UART: %.*s (%d)",
-			event->data.rx.length, event->data.rx.p_buffer, event->data.rx.length);
+		LOG_DBG("Received data from UART (len %d): %.*s", event->data.rx.length,
+			event->data.rx.length, event->data.rx.p_buffer);
 		if (event->data.rx.length > 0) {
 #if defined(CONFIG_SAMPLE_NUS_LPUARTE)
 			lpuarte_rx_handler(event->data.rx.p_buffer, event->data.rx.length);
@@ -437,6 +437,11 @@ static int uarte_init(void)
 		LOG_ERR("Failed to initialize UART, err %d", err);
 		return err;
 	}
+
+	err = bm_lpuarte_rx_enable(&lpu);
+	if (err) {
+		LOG_ERR("UART RX failed, err %d", err);
+	}
 #else
 	err = nrfx_uarte_init(&nus_uarte_inst, &uarte_config, uarte_evt_handler);
 	if (err) {
@@ -456,6 +461,22 @@ static int uarte_init(void)
 					 UARTE_DMA_RX_MATCH_CONFIG_ENABLE1_Msk;
 	reg->INTENSET                  = UARTE_INTENSET_DMARXMATCH0_Msk |
 					 UARTE_INTENSET_DMARXMATCH1_Msk;
+
+	const uint8_t out[] = "UART started.\r\n";
+
+	err = nrfx_uarte_tx(&nus_uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
+	if (err) {
+		LOG_ERR("UARTE TX failed, err %d", err);
+		return err;
+	}
+
+	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
+	 * an abort on match ends the current one and continues into the other.
+	 */
+	err = nrfx_uarte_rx_enable(&nus_uarte_inst, NRFX_UARTE_RX_ENABLE_CONT);
+	if (err) {
+		LOG_ERR("UART RX failed, err %d", err);
+	}
 #endif /* CONFIG_SAMPLE_NUS_LPUARTE */
 
 	return 0;
@@ -555,29 +576,6 @@ int main(void)
 		LOG_ERR("Failed to initialize advertising, nrf_error %#x", nrf_err);
 		goto idle;
 	}
-
-#if defined(CONFIG_SAMPLE_NUS_LPUARTE)
-	err = bm_lpuarte_rx_enable(&lpu);
-	if (err) {
-		LOG_ERR("UART RX failed, err %d", err);
-	}
-#else
-	const uint8_t out[] = "UART started.\r\n";
-
-	err = nrfx_uarte_tx(&nus_uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
-	if (err) {
-		LOG_ERR("UARTE TX failed, err %d", err);
-		goto idle;
-	}
-
-	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
-	 * an abort on match ends the current one and continues into the other.
-	 */
-	err = nrfx_uarte_rx_enable(&nus_uarte_inst, NRFX_UARTE_RX_ENABLE_CONT);
-	if (err) {
-		LOG_ERR("UART RX failed, err %d", err);
-	}
-#endif
 
 #if !defined(CONFIG_SAMPLE_NUS_LPUARTE)
 	nrf_gpio_pin_write(BOARD_PIN_LED_0, BOARD_LED_ACTIVE_STATE);

--- a/samples/bluetooth/ble_nus_central/Kconfig
+++ b/samples/bluetooth/ble_nus_central/Kconfig
@@ -22,8 +22,7 @@ config SAMPLE_NUS_UART_IRQ_PRIO
 
 config SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE
 	int "NUS UART receive buffer size"
-	default 128 if SAMPLE_NUS_CENTRAL_LPUARTE
-	default 1
+	default 128
 	help
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 

--- a/samples/bluetooth/ble_nus_central/Kconfig
+++ b/samples/bluetooth/ble_nus_central/Kconfig
@@ -24,6 +24,12 @@ config SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE
 	int "NUS UART receive buffer size"
 	default 128
 	help
+	  Do not set this too low. No data is lost if it is too small, but the
+	  buffer fills up and gets flushed sooner, so the radio has to send more,
+	  smaller BLE NUS notifications instead of fewer, larger ones. That means
+	  more radio activity for the same amount of data, which costs more power.
+	  For the best power efficiency, keep this at the high end of the ATT MTU
+	  or message sizes you expect to send.
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
 config SAMPLE_NUS_CENTRAL_LPUARTE

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include <ble.h>
 #include <bm/bm_buttons.h>
 #include <bm/bm_irq.h>
@@ -28,6 +29,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/util.h>
 
 #include <board-config.h>
 
@@ -115,39 +117,26 @@ static void lpuarte_rx_handler(char *data, size_t data_len)
 static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
-	uint8_t c;
-	/* Receive buffer used in UART ISR callback. */
-	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
-	static uint16_t rx_buf_idx;
+	uint16_t sent = 0;
 	uint16_t len;
 
-	for (int i = 0; i < data_len; i++) {
-		c = data[i];
+	/* Forward the chunk as received, split only if it exceeds the current
+	 * NUS notification size limit. No bytes are added or dropped.
+	 */
+	while (sent < data_len) {
+		len = MIN(data_len - sent, ble_nus_max_data_len);
+		LOG_INF("Sending NUS data, len %d", len);
 
-		if (rx_buf_idx < sizeof(rx_buf)) {
-			rx_buf[rx_buf_idx++] = c;
-		}
-
-		if ((c == '\n' || c == '\r') || (rx_buf_idx >= ble_nus_max_data_len)) {
-			if (rx_buf_idx == 0) {
-				/* RX buffer is empty, nothing to send. */
-				continue;
+		do {
+			nrf_err = ble_nus_client_string_send(&ble_nus_client, &data[sent], len);
+			if ((nrf_err != NRF_ERROR_INVALID_STATE) &&
+			    (nrf_err != NRF_ERROR_RESOURCES) && nrf_err) {
+				LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
+				return;
 			}
+		} while (nrf_err == NRF_ERROR_RESOURCES);
 
-			len = rx_buf_idx;
-			LOG_INF("Sending NUS data, len %d", len);
-
-			do {
-				nrf_err = ble_nus_client_string_send(&ble_nus_client, rx_buf,
-									 len);
-				if ((nrf_err != NRF_ERROR_INVALID_STATE) &&
-				    (nrf_err != NRF_ERROR_RESOURCES) && nrf_err) {
-					LOG_ERR("Failed to send NUS data, nrf_error %#x", nrf_err);
-					return;
-				}
-			} while (nrf_err == NRF_ERROR_RESOURCES);
-			rx_buf_idx = 0;
-		}
+		sent += len;
 	}
 }
 #endif /* CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE */

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -156,8 +156,8 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 {
 	switch (event->type) {
 	case NRFX_UARTE_EVT_RX_DONE:
-		LOG_DBG("Received data from UART: %.*s (%d)", event->data.rx.length,
-			event->data.rx.p_buffer, event->data.rx.length);
+		LOG_DBG("Received data from UART (len %d): %.*s", event->data.rx.length,
+			event->data.rx.length, event->data.rx.p_buffer);
 		if (event->data.rx.length > 0) {
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 			lpuarte_rx_handler(event->data.rx.p_buffer, event->data.rx.length);
@@ -466,6 +466,14 @@ static int uarte_init(void)
 					 UARTE_DMA_RX_MATCH_CONFIG_ENABLE1_Msk;
 	reg->INTENSET                  = UARTE_INTENSET_DMARXMATCH0_Msk |
 					 UARTE_INTENSET_DMARXMATCH1_Msk;
+
+	const uint8_t out[] = "UART started.\r\n";
+
+	err = nrfx_uarte_tx(&nus_uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
+	if (err) {
+		LOG_ERR("UARTE TX failed, err %d", err);
+		return err;
+	}
 
 	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
 	 * an abort on match ends the current one and continues into the other.

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -10,6 +10,7 @@
 #include <bm/bm_irq.h>
 #include <hal/nrf_gpio.h>
 #include <nrfx_uarte.h>
+#include <hal/nrf_uarte.h>
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 #include <bm/drivers/bm_lpuarte.h>
 #endif
@@ -72,7 +73,9 @@ static nrfx_uarte_t nus_uarte_inst = NRFX_UARTE_INSTANCE(NUS_UARTE_INST);
  */
 static uint16_t ble_nus_max_data_len = BLE_NUS_CLIENT_MAX_DATA_LEN_CALC(BLE_GATT_ATT_MTU_DEFAULT);
 
-/* Receive buffers used in UART ISR callback. */
+/* Double-buffered RX: one buffer is always queued as "next",
+ * so when the current one is filled or aborted, DMA continues into the other.
+ */
 static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE];
 static int buf_idx;
 
@@ -153,7 +156,7 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 {
 	switch (event->type) {
 	case NRFX_UARTE_EVT_RX_DONE:
-		LOG_INF("Received data from UART: %.*s (%d)", event->data.rx.length,
+		LOG_DBG("Received data from UART: %.*s (%d)", event->data.rx.length,
 			event->data.rx.p_buffer, event->data.rx.length);
 		if (event->data.rx.length > 0) {
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
@@ -162,11 +165,9 @@ static void uarte_evt_handler(const nrfx_uarte_event_t *event, void *ctx)
 			uarte_rx_handler(event->data.rx.p_buffer, event->data.rx.length);
 #endif
 		}
-#if !defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
-		(void)nrfx_uarte_rx_enable(&nus_uarte_inst, 0);
-#endif
 		break;
 	case NRFX_UARTE_EVT_RX_BUF_REQUEST:
+		/* Queue the free buffer immediately so RX keeps running with zero downtime. */
 #if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
 		(void)bm_lpuarte_rx_buffer_set(&lpu, uarte_rx_buf[buf_idx],
 					       CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE);
@@ -363,6 +364,34 @@ static void button_handler_disconnect(uint8_t pin, uint8_t action)
 
 ISR_DIRECT_DECLARE(uarte_direct_isr)
 {
+#if !defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
+	/* The compare-match filter raises MATCH0 on '\r' and MATCH1 on '\n',
+	 * either one ends a line, so both are handled the same way here.
+	 * Clear it and abort the current RX. A second buffer is already queued,
+	 * so reception continues into it without a gap.
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)nus_uarte_inst.p_reg;
+	bool match = false;
+
+	if (reg->EVENTS_DMA.RX.MATCH[0]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[0]));
+		match = true;
+	}
+
+	if (reg->EVENTS_DMA.RX.MATCH[1]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[1]));
+		match = true;
+	}
+
+	if (match) {
+		(void)nrfx_uarte_rx_abort(&nus_uarte_inst, false, false);
+	}
+#endif
+
 	nrfx_uarte_irq_handler(&nus_uarte_inst);
 	return 0;
 }
@@ -424,7 +453,24 @@ static int uarte_init(void)
 		LOG_ERR("Failed to initialize UART, err %d", err);
 		return err;
 	}
-	err = nrfx_uarte_rx_enable(&nus_uarte_inst, 0);
+
+	/* Configure the compare-match filter so reception stops on '\r' or '\n':
+	 * CANDIDATE[0] = '\r', CANDIDATE[1] = '\n', both enabled and both raising
+	 * an interrupt (uarte_direct_isr aborts RX on either match).
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)nus_uarte_inst.p_reg;
+
+	reg->DMA.RX.MATCH.CANDIDATE[0] = '\r';
+	reg->DMA.RX.MATCH.CANDIDATE[1] = '\n';
+	reg->DMA.RX.MATCH.CONFIG       = UARTE_DMA_RX_MATCH_CONFIG_ENABLE0_Msk |
+					 UARTE_DMA_RX_MATCH_CONFIG_ENABLE1_Msk;
+	reg->INTENSET                  = UARTE_INTENSET_DMARXMATCH0_Msk |
+					 UARTE_INTENSET_DMARXMATCH1_Msk;
+
+	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
+	 * an abort on match ends the current one and continues into the other.
+	 */
+	err = nrfx_uarte_rx_enable(&nus_uarte_inst, NRFX_UARTE_RX_ENABLE_CONT);
 	if (err) {
 		LOG_ERR("UART RX failed, err %d", err);
 	}

--- a/samples/peripherals/uarte/src/main.c
+++ b/samples/peripherals/uarte/src/main.c
@@ -10,56 +10,31 @@
 
 #include <bm/bm_irq.h>
 #include <hal/nrf_gpio.h>
+#include <hal/nrf_uarte.h>
 #include <board-config.h>
 #include <nrfx_uarte.h>
 
 LOG_MODULE_REGISTER(sample, CONFIG_SAMPLE_UARTE_LOG_LEVEL);
 
-#define SAMPLE_UARTE_RX_BUF_SIZE 1
-
 /** Application UARTE instance */
 static nrfx_uarte_t uarte_inst = NRFX_UARTE_INSTANCE(BOARD_APP_UARTE_INST);
 
-/* Receive buffer used in UARTE ISR callback */
-static uint8_t uarte_rx_buf[2][SAMPLE_UARTE_RX_BUF_SIZE];
+/* Double-buffered RX: one buffer is always queued as "next",
+ * so when the current one is filled or aborted, DMA continues into the other.
+ */
+static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_UARTE_DATA_LEN_MAX];
 static int buf_idx;
 
 /* Handle data received from UARTE. */
 static void uarte_rx_handler(char *data, size_t data_len)
 {
 	int err;
-	uint8_t c;
-	static char rx_buf[CONFIG_SAMPLE_UARTE_DATA_LEN_MAX];
-	static uint16_t rx_buf_idx;
 
-	for (int i = 0; i < data_len; i++) {
-		c = data[i];
+	LOG_HEXDUMP_INF(data, data_len, "Received data from UARTE:");
 
-		if (rx_buf_idx < sizeof(rx_buf)) {
-			rx_buf[rx_buf_idx++] = c;
-		}
-
-		if ((c == '\n' || c == '\r') || (rx_buf_idx >= sizeof(rx_buf))) {
-			if (rx_buf_idx == 0) {
-				/* RX buffer is empty, nothing to send. */
-				continue;
-			}
-
-			LOG_INF("Echo data, len %d", rx_buf_idx);
-
-			/* Add newline if not already output at the end */
-			if ((rx_buf[rx_buf_idx - 1] != '\n') && (rx_buf_idx < sizeof(rx_buf))) {
-				rx_buf[rx_buf_idx++] = '\n';
-			}
-
-			err = nrfx_uarte_tx(&uarte_inst, rx_buf, rx_buf_idx,
-					    NRFX_UARTE_TX_BLOCKING);
-			if (err) {
-				LOG_ERR("nrfx_uarte_tx failed, err %d", err);
-			}
-
-			rx_buf_idx = 0;
-		}
+	err = nrfx_uarte_tx(&uarte_inst, data, data_len, NRFX_UARTE_TX_BLOCKING);
+	if (err) {
+		LOG_ERR("nrfx_uarte_tx failed, err %d", err);
 	}
 }
 
@@ -68,18 +43,14 @@ static void uarte_event_handler(const nrfx_uarte_event_t *event, void *ctx)
 {
 	switch (event->type) {
 	case NRFX_UARTE_EVT_RX_DONE:
-		LOG_INF("Received data from UARTE: %c", event->data.rx.p_buffer[0]);
 		if (event->data.rx.length > 0) {
 			uarte_rx_handler(event->data.rx.p_buffer, event->data.rx.length);
 		}
-
-		/* Provide new UARTE RX buffer. */
-		(void)nrfx_uarte_rx_enable(&uarte_inst, 0);
 		break;
 	case NRFX_UARTE_EVT_RX_BUF_REQUEST:
+		/* Queue the free buffer immediately so RX keeps running with zero downtime. */
 		(void)nrfx_uarte_rx_buffer_set(&uarte_inst, uarte_rx_buf[buf_idx],
-					       SAMPLE_UARTE_RX_BUF_SIZE);
-
+					       sizeof(uarte_rx_buf[buf_idx]));
 		buf_idx = buf_idx ? 0 : 1;
 		break;
 	case NRFX_UARTE_EVT_ERROR:
@@ -92,6 +63,32 @@ static void uarte_event_handler(const nrfx_uarte_event_t *event, void *ctx)
 
 ISR_DIRECT_DECLARE(uarte_direct_isr)
 {
+	/* The compare-match filter raises MATCH0 on '\r' and MATCH1 on '\n',
+	 * either one ends a line, so both are handled the same way here.
+	 * Clear it and abort the current RX. A second buffer is already queued,
+	 * so reception continues into it without a gap.
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)uarte_inst.p_reg;
+	bool match = false;
+
+	if (reg->EVENTS_DMA.RX.MATCH[0]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[0]));
+		match = true;
+	}
+
+	if (reg->EVENTS_DMA.RX.MATCH[1]) {
+		nrf_uarte_event_clear(
+			reg,
+			(nrf_uarte_event_t)offsetof(NRF_UARTE_Type, EVENTS_DMA.RX.MATCH[1]));
+		match = true;
+	}
+
+	if (match) {
+		(void)nrfx_uarte_rx_abort(&uarte_inst, false, false);
+	}
+
 	nrfx_uarte_irq_handler(&uarte_inst);
 	return 0;
 }
@@ -129,6 +126,19 @@ static int uarte_init(void)
 		return err;
 	}
 
+	/* Configure the compare-match filter so reception stops on '\r' or '\n':
+	 * CANDIDATE[0] = '\r', CANDIDATE[1] = '\n', both enabled and both raising
+	 * an interrupt (uarte_direct_isr aborts RX on either match).
+	 */
+	NRF_UARTE_Type *reg = (NRF_UARTE_Type *)uarte_inst.p_reg;
+
+	reg->DMA.RX.MATCH.CANDIDATE[0] = '\r';
+	reg->DMA.RX.MATCH.CANDIDATE[1] = '\n';
+	reg->DMA.RX.MATCH.CONFIG       = UARTE_DMA_RX_MATCH_CONFIG_ENABLE0_Msk |
+					 UARTE_DMA_RX_MATCH_CONFIG_ENABLE1_Msk;
+	reg->INTENSET                  = UARTE_INTENSET_DMARXMATCH0_Msk |
+					 UARTE_INTENSET_DMARXMATCH1_Msk;
+
 	return 0;
 }
 
@@ -152,8 +162,10 @@ int main(void)
 		goto idle;
 	}
 
-	/* Start reception */
-	err = nrfx_uarte_rx_enable(&uarte_inst, 0);
+	/* Continuous mode keeps RX running across buffers. With a second buffer queued,
+	 * an abort on match ends the current one and continues into the other.
+	 */
+	err = nrfx_uarte_rx_enable(&uarte_inst, NRFX_UARTE_RX_ENABLE_CONT);
 	if (err) {
 		LOG_ERR("UARTE RX failed, err %d", err);
 	}


### PR DESCRIPTION
Rework the wired-UART reception in the BLE NUS sample so the UARTE compare-match filter watches for the line terminator in hardware. The CPU is only woken when the configured EOL byte arrives, and then decides whether to buffer or send, instead of scanning every RX_DONE chunk in software. Multi-byte terminators like CR+LF are still confirmed through software, since the filter only matches a single byte at the time and needs some extra logic for multi-line terminators bytes.