### PR TITLE
boards: nordic: add specific jlink device

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/board.cmake
+++ b/boards/nordic/bm_nrf54l15dk/board.cmake
@@ -7,7 +7,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/sysbuild.cmake)
 
 if(CONFIG_SOC_NRF54L05_CPUAPP OR CONFIG_SOC_NRF54L10_CPUAPP OR CONFIG_SOC_NRF54L15_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/bm_nrf54lm20dk/board.cmake
+++ b/boards/nordic/bm_nrf54lm20dk/board.cmake
@@ -7,7 +7,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/sysbuild.cmake)
 
 if(CONFIG_SOC_NRF54LM20A_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(jlink "--device=nRF54LM20A_M33" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/bm_nrf54ls05dk/board.cmake
+++ b/boards/nordic/bm_nrf54ls05dk/board.cmake
@@ -7,7 +7,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/sysbuild.cmake)
 
 if(CONFIG_SOC_NRF54LS05B_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(jlink "--device=NRF54LS05B_M33" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/bm_nrf54lv10dk/board.cmake
+++ b/boards/nordic/bm_nrf54lv10dk/board.cmake
@@ -7,7 +7,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/sysbuild.cmake)
 
 if(CONFIG_SOC_NRF54LV10A_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(jlink "--device=NRF54LV10A_M33" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -33,11 +33,14 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Boards
 ======
 
-* Updated all boards to use ``zephyr,mapped-partition`` instead of ``zephyr,fixed-partitions`` and ``zephyr,fixed-subpartitions``.
-  When referencing partition nodes, the code now uses ``PARTITION_*`` macros instead of ``DT_*`` and ``FIXED_PARTITION_*`` macros.
-  The use of the :kconfig:option:`CONFIG_FLASH_LOAD_OFFSET` Kconfig option is also replaced by ``PARTITION_*`` macros.
+* Updated:
 
-* Reduced the number of required board qualifiers by one, as of changes in upstream Zephyr.
+   * All boards to use ``zephyr,mapped-partition`` instead of ``zephyr,fixed-partitions`` and ``zephyr,fixed-subpartitions``.
+     When referencing partition nodes, the code now uses ``PARTITION_*`` macros instead of ``DT_*`` and ``FIXED_PARTITION_*`` macros.
+     The use of the :kconfig:option:`CONFIG_FLASH_LOAD_OFFSET` Kconfig option is also replaced by ``PARTITION_*`` macros.
+   * All boards to use specific J-Link devices from the nRF54L series.
+     This improves debugging in VS Code.
+   * The number of required board qualifiers (reduced by one), as of changes in upstream Zephyr.
 
 Build system
 ============


### PR DESCRIPTION
Jlink device are now available so we no longer need to use the generic cortex-m33 device.