### PR TITLE
scripts: parse RRAM/SRAM/KMU sizes from DTS

### DIFF
--- a/doc/_scripts/gen_memory_layouts.py
+++ b/doc/_scripts/gen_memory_layouts.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import argparse
 import re
 from dataclasses import dataclass, field
+from enum import Enum
+from functools import cache
 from pathlib import Path
 
 NRF_BM_BASE = Path(__file__).resolve().parents[2]
@@ -134,6 +136,118 @@ def _parse_retained_mem(text: str) -> Partition | None:
 
 
 # ---------------------------------------------------------------------------
+# Universal per-SoC memory-field lookup (parsed straight from DTS)
+# ---------------------------------------------------------------------------
+
+
+class MemField(Enum):
+    """Fields queryable via get_soc_mem_field().
+
+    Each member corresponds to one value read from a SoC's DTS,
+    covering RRAM, SRAM, and the KMU reserved area.
+    """
+
+    RRAM_TOTAL = "rram_total"
+    RRAM_BASE_ADDR = "rram_base_addr"
+    SRAM_TOTAL = "sram_total"
+    SRAM_BASE_ADDR = "sram_base_addr"
+    KMU_SIZE = "kmu_size"
+    KMU_BASE_ADDR = "kmu_base_addr"
+
+
+_REG_RE = re.compile(r"reg\s*=\s*<\s*(0x[0-9a-fA-F]+)\s+(.*?)\s*>")
+_NODE_START_TEMPLATE = r"(?:&{label}\b|\b{label}:\s*\w+@[0-9a-fA-F]+)\s*\{{"
+
+
+def _matching_brace(text: str, open_idx: int) -> int:
+    """Find the closing brace matching an opening one.
+
+    Walks forward from open_idx counting nested braces,
+    and returns the index of the '}' that closes it.
+    """
+    depth = 1
+    i = open_idx + 1
+    while depth and i < len(text):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    return i - 1
+
+
+def _find_node_body(text: str, label: str) -> str | None:
+    """Return the body of the last node matching label.
+
+    Handles both override syntax, ``&label { ... };``,
+    and definition syntax, ``label: type@ADDR { ... };``.
+    Order in the file does not matter,
+    since the last occurrence wins.
+    """
+    pattern = re.compile(_NODE_START_TEMPLATE.format(label=label))
+    bodies = [text[m.end() : _matching_brace(text, m.end() - 1)] for m in pattern.finditer(text)]
+    return bodies[-1] if bodies else None
+
+
+def _node_reg(text: str, label: str) -> tuple[int, int]:
+    """Return the (base_addr, size) from label's own reg.
+
+    Ignores any reg that belongs to a nested child node,
+    such as a fixed-partitions child.
+    """
+    body = _find_node_body(text, label)
+    if body is None:
+        raise ValueError(f"Node '{label}' not found in DTS")
+    top_level = body.split("{", 1)[0]  # text before any nested child node
+    m = _REG_RE.search(top_level)
+    if not m:
+        raise ValueError(f"Node '{label}' has no top-level reg")
+    return int(m.group(1), 16), _eval_size_expr(m.group(2))
+
+
+@cache
+def _find_common_dtsi(soc: str, dts_path: Path) -> Path:
+    """Return the path to a SoC's common.dtsi file within dts_path."""
+    matches = sorted(dts_path.glob(f"*_{soc}_cpuapp_common.dtsi"))
+    if not matches:
+        raise FileNotFoundError(f"No *_{soc}_cpuapp_common.dtsi found under {dts_path}")
+    return matches[0]
+
+
+@cache
+def _parse_soc_mem_fields(soc: str, dts_path: Path) -> dict[MemField, int]:
+    """Parse every MemField value for one SoC.
+
+    Reads the SoC's common.dtsi once,
+    and returns all fields as a dict, keyed by MemField.
+    """
+    text = _find_common_dtsi(soc, dts_path).read_text()
+
+    kmu_addr, kmu_size = _node_reg(text, "nrf_kmu_reserved_push_area")
+    rram_addr, rram_size = _node_reg(text, "cpuapp_rram")
+    sram_addr, sram_size = _node_reg(text, "cpuapp_sram")
+
+    return {
+        MemField.KMU_BASE_ADDR: kmu_addr,
+        MemField.KMU_SIZE: kmu_size,
+        MemField.SRAM_BASE_ADDR: kmu_addr,
+        MemField.SRAM_TOTAL: (sram_addr + sram_size) - kmu_addr,
+        MemField.RRAM_BASE_ADDR: rram_addr,
+        MemField.RRAM_TOTAL: rram_size,
+    }
+
+
+def get_soc_mem_field(soc: str, field: MemField, dts_path: Path) -> int:
+    """Look up one memory field for soc, parsed straight from its DTS.
+
+    Example:
+        rram_total = get_soc_mem_field("nrf54l05", MemField.RRAM_TOTAL, dts_path)
+        sram_base  = get_soc_mem_field("nrf54l05", MemField.SRAM_BASE_ADDR, dts_path)
+    """
+    return _parse_soc_mem_fields(soc, dts_path.parent)[field]
+
+
+# ---------------------------------------------------------------------------
 # DTS → BoardConfig
 # ---------------------------------------------------------------------------
 
@@ -145,24 +259,6 @@ _SOC = {
     "nrf54l15",
     "nrf54l10",
     "nrf54l05",
-}
-
-_SOC_RRAM_TOTAL = {
-    "nrf54lm20a": 2000 * 1024,
-    "nrf54lv10a": 1012 * 1024,
-    "nrf54ls05b": 508 * 1024,
-    "nrf54l15": 1524 * 1024,
-    "nrf54l10": 1012 * 1024,
-    "nrf54l05": 500 * 1024,
-}
-
-_SOC_SRAM_TOTAL = {
-    "nrf54lm20a": 512 * 1024,
-    "nrf54lv10a": 192 * 1024,
-    "nrf54ls05b": 96 * 1024,
-    "nrf54l15": 256 * 1024,
-    "nrf54l10": 192 * 1024,
-    "nrf54l05": 96 * 1024,
 }
 
 _SOFTDEVICE = {
@@ -234,7 +330,8 @@ def parse_dts(dts_path: Path, common_text: str = "") -> BoardConfig:
     rram_parts.sort(key=lambda p: p.offset)
 
     # Fill gaps between partitions
-    rram_total = _SOC_RRAM_TOTAL[soc]
+    rram_total = get_soc_mem_field(soc, MemField.RRAM_TOTAL, dts_path)
+    rram_base_addr = get_soc_mem_field(soc, MemField.RRAM_BASE_ADDR, dts_path)
     filled: list[Partition] = []
     cursor = 0
     for p in rram_parts:
@@ -246,12 +343,14 @@ def parse_dts(dts_path: Path, common_text: str = "") -> BoardConfig:
         filled.append(Partition(name="(unused)", offset=cursor, size=rram_total - cursor))
     rram_parts = filled
 
-    rram = MemoryMap(label="RRAM", total=rram_total, base_addr=0x0, partitions=rram_parts)
+    rram = MemoryMap(
+        label="RRAM", total=rram_total, base_addr=rram_base_addr, partitions=rram_parts
+    )
 
     # ---- SRAM partitions ----
-    sram_total = _SOC_SRAM_TOTAL[soc]
-    sram_base = 0x20000000
-    kmu_size = 0x80
+    sram_total = get_soc_mem_field(soc, MemField.SRAM_TOTAL, dts_path)
+    sram_base = get_soc_mem_field(soc, MemField.SRAM_BASE_ADDR, dts_path)
+    kmu_size = get_soc_mem_field(soc, MemField.KMU_SIZE, dts_path)
 
     sram_body = _find_last_node_block(r"&cpuapp_sram\s*\{(.*?)^\};", full)
     sram_parts_raw = _parse_partitions(sram_body) if sram_body else []
@@ -442,25 +541,25 @@ def render_svg(cfg: BoardConfig) -> str:
 # ---------------------------------------------------------------------------
 
 
-def discover_boards(boards_dir: Path) -> dict[str, Path]:
-    """Return mapping of board_name → board_dir for all bm_* boards."""
+def discover_boards(dts_path: Path) -> dict[str, Path]:
+    """Return mapping of board_name → dts_path for all bm_* boards."""
     result = {}
-    for d in sorted(boards_dir.iterdir()):
+    for d in sorted(dts_path.iterdir()):
         if d.is_dir() and d.name.startswith("bm_"):
             result[d.name] = d
     return result
 
 
-def find_common_dtsi(board_dir: Path, soc: str) -> str:
+def find_common_dtsi(dts_path: Path, soc: str) -> str:
     """Read the common .dtsi for a given SoC variant."""
     pattern = f"*_{soc}_cpuapp_common.dtsi"
-    matches = list(board_dir.glob(pattern))
+    matches = list(dts_path.glob(pattern))
     return matches[0].read_text() if matches else ""
 
 
-def process_board(board_dir: Path, output_dir: Path) -> list[BoardConfig]:
+def process_board(dts_path: Path, output_dir: Path) -> list[BoardConfig]:
     """Process all DTS files for a board and generate SVGs."""
-    dts_files = sorted(board_dir.glob("*.dts"))
+    dts_files = sorted(dts_path.glob("*.dts"))
     configs: list[BoardConfig] = []
 
     for dts in dts_files:
@@ -468,7 +567,7 @@ def process_board(board_dir: Path, output_dir: Path) -> list[BoardConfig]:
             soc = _detect_soc(dts.stem)
         except ValueError:
             continue
-        common = find_common_dtsi(board_dir, soc)
+        common = find_common_dtsi(dts_path, soc)
         try:
             cfg = parse_dts(dts, common)
         except Exception as exc:
@@ -507,9 +606,9 @@ def main() -> None:
         print(f"No bm_* boards found in {args.board_dir}")
         return
 
-    for name, board_dir in boards.items():
+    for name, dts_path in boards.items():
         print(f"Board: {name}")
-        process_board(board_dir, args.output_dir)
+        process_board(dts_path, args.output_dir)
 
     print(f"\nDone. SVGs written to {args.output_dir}")
 

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.svg
@@ -25,7 +25,7 @@
 <text x="86" y="55.183727034120736" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
 <text x="295" y="47.09186351706037" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (255.5 KB)</text>
 <rect x="570" y="421.83561643835617" width="200" height="28.164383561643834" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9178082191781" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.svg
@@ -37,7 +37,7 @@
 <text x="86" y="55.064304461942285" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
 <text x="295" y="47.03215223097116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (255.5 KB)</text>
 <rect x="570" y="421.8485742379548" width="200" height="28.151425762045232" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9242871189774" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.svg
@@ -25,7 +25,7 @@
 <text x="86" y="55.18372703412071" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CC00</text>
 <text x="295" y="47.09186351706034" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="26.99999999999997" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (255.5 KB)</text>
 <rect x="570" y="421.83561643835617" width="200" height="28.164383561643834" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9178082191781" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.svg
@@ -37,7 +37,7 @@
 <text x="86" y="55.064304461942285" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017CE00</text>
 <text x="295" y="47.03215223097116" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x0017D000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (256 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (255.5 KB)</text>
 <rect x="570" y="421.8485742379548" width="200" height="28.151425762045232" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9242871189774" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.svg
@@ -3,25 +3,29 @@
      width="920" height="476"
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
-  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="130.49729729729728" width="200" height="319.5027027027027" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="294.24864864864867" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2036 KB)</text>
+<rect x="90" y="157.12770137524558" width="200" height="292.8722986247544" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="307.5638506876228" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="293.24864864864867" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1926 KB</text>
-<rect x="90" y="101.89189189189187" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="120.19459459459458" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="127.49729729729728" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E1800</text>
-<text x="295" y="119.19459459459458" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="73.28648648648647" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="91.58918918918917" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="98.89189189189187" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2800</text>
-<text x="295" y="90.58918918918917" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="29.99999999999998" width="200" height="43.28648648648649" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="55.64324324324322" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="70.28648648648647" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E3800</text>
-<text x="295" y="54.64324324324322" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
-<text x="86" y="26.99999999999998" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
+<text x="295" y="306.5638506876228" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1926 KB</text>
+<rect x="90" y="128.57760314341846" width="200" height="28.55009823182711" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="146.85265225933202" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="154.12770137524558" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E1800</text>
+<text x="295" y="145.85265225933202" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="100.02750491159135" width="200" height="28.55009823182711" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="118.30255402750491" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="125.57760314341846" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E2800</text>
+<text x="295" y="117.30255402750491" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.13752455795677" width="200" height="41.88998035363458" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="83.08251473477407" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="97.02750491159135" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001E3800</text>
+<text x="295" y="82.08251473477407" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">101 KB</text>
+<rect x="90" y="29.999999999999996" width="200" height="28.137524557956777" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.06876227897838" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.13752455795677" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
+<text x="295" y="47.06876227897838" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.999999999999996" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (511.3 KB)</text>
 <rect x="570" y="421.9178584525119" width="200" height="28.08214154748808" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9589292262559" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.svg
@@ -3,7 +3,7 @@
      width="920" height="476"
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
-  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
+  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2036 KB)</text>
 <rect x="90" y="419.0157170923379" width="200" height="30.98428290766208" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="190.0" y="438.50785854616896" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
@@ -37,7 +37,7 @@
 <text x="86" y="55.04813359528488" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
 <text x="295" y="47.02406679764245" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.000000000000007" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (511.3 KB)</text>
 <rect x="570" y="421.92454679078884" width="200" height="28.075453209211172" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.96227339539445" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.svg
@@ -3,25 +3,29 @@
      width="920" height="476"
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
-  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
-<rect x="90" y="135.94594594594594" width="200" height="314.05405405405406" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="296.97297297297297" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
+  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2036 KB)</text>
+<rect x="90" y="162.07858546168956" width="200" height="287.92141453831044" fill="#6ad1e3" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="310.03929273084475" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Application (slot0)</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
-<text x="295" y="295.97297297297297" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1890 KB</text>
-<rect x="90" y="107.34054054054053" width="200" height="28.605405405405406" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="125.64324324324323" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
-<text x="86" y="132.94594594594594" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D8800</text>
-<text x="295" y="124.64324324324323" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="78.73513513513512" width="200" height="28.605405405405406" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="97.03783783783783" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
-<text x="86" y="104.34054054054053" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9800</text>
-<text x="295" y="96.03783783783783" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
-<rect x="90" y="29.999999999999986" width="200" height="48.73513513513514" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="58.367567567567555" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
-<text x="86" y="75.73513513513512" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001DA800</text>
-<text x="295" y="57.367567567567555" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
-<text x="86" y="26.999999999999986" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
+<text x="295" y="309.03929273084475" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1890 KB</text>
+<rect x="90" y="133.52848722986244" width="200" height="28.550098231827118" fill="#de823b" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="151.803536345776" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: Peer Manager</text>
+<text x="86" y="159.07858546168956" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D8800</text>
+<text x="295" y="150.803536345776" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="104.97838899803531" width="200" height="28.550098231827118" fill="#f4cb43" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="123.25343811394887" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Storage: User data</text>
+<text x="86" y="130.52848722986244" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001D9800</text>
+<text x="295" y="122.25343811394887" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">4 KB</text>
+<rect x="90" y="58.13752455795672" width="200" height="46.84086444007859" fill="#0077c8" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="85.55795677799603" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">SoftDevice</text>
+<text x="86" y="101.97838899803531" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001DA800</text>
+<text x="295" y="84.55795677799603" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">137 KB</text>
+<rect x="90" y="29.99999999999994" width="200" height="28.137524557956784" fill="#d9e1e2" rx="3" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="48.06876227897833" text-anchor="middle" font-size="10" font-weight="600" fill="#667085">Unused</text>
+<text x="86" y="55.13752455795672" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCC00</text>
+<text x="295" y="47.06876227897833" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
+<text x="86" y="26.99999999999994" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (511.3 KB)</text>
 <rect x="570" y="421.9178584525119" width="200" height="28.08214154748809" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.9589292262559" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.svg
@@ -3,7 +3,7 @@
      width="920" height="476"
      font-family="Inter, -apple-system, sans-serif">
   <rect width="100%" height="100%" fill="#ffffff" rx="8"/>
-  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2000 KB)</text>
+  <text x="190.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">RRAM (2036 KB)</text>
 <rect x="90" y="419.0157170923379" width="200" height="30.98428290766208" fill="#0032a0" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="190.0" y="438.50785854616896" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">MCUboot</text>
 <text x="86" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x00000000</text>
@@ -37,7 +37,7 @@
 <text x="86" y="55.048133595284874" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FCE00</text>
 <text x="295" y="47.02406679764243" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x001FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (512 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (511.3 KB)</text>
 <rect x="570" y="421.92454679078884" width="200" height="28.075453209211172" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.96227339539445" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.svg
@@ -25,7 +25,7 @@
 <text x="86" y="55.2766798418972" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
 <text x="295" y="47.13833992094858" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="26.999999999999964" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (191.3 KB)</text>
 <rect x="570" y="421.7804639006861" width="200" height="28.21953609931395" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.89023195034304" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.svg
@@ -37,7 +37,7 @@
 <text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
 <text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (191.3 KB)</text>
 <rect x="570" y="421.7976346911958" width="200" height="28.202365308804204" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.89881734559793" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.svg
@@ -25,7 +25,7 @@
 <text x="86" y="55.27667984189725" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCC00</text>
 <text x="295" y="47.13833992094863" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">1 KB</text>
 <text x="86" y="27.000000000000014" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (191.3 KB)</text>
 <rect x="570" y="421.7804639006861" width="200" height="28.21953609931395" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.89023195034304" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.svg
+++ b/doc/nrf-bm/boards/images/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.svg
@@ -37,7 +37,7 @@
 <text x="86" y="55.09683794466406" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FCE00</text>
 <text x="295" y="47.048418972332044" text-anchor="start" font-size="10" font-weight="bold" fill="#6b7280">512 B</text>
 <text x="86" y="27.00000000000003" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x000FD000</text>
-  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (192 KB)</text>
+  <text x="670.0" y="18" text-anchor="middle" font-size="13" font-weight="bold" fill="#333f48">SRAM (191.3 KB)</text>
 <rect x="570" y="421.7976346911958" width="200" height="28.202365308804204" fill="#768692" rx="3" stroke="#e5e7eb" stroke-width="1"/>
 <text x="670.0" y="439.89881734559793" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">KMU reserved</text>
 <text x="566" y="447.0" text-anchor="end" font-size="10" font-weight="bold" font-family="monospace" fill="#6b7280">0x20000000</text>

--- a/doc/nrf-bm/boards/memory_layout.rst
+++ b/doc/nrf-bm/boards/memory_layout.rst
@@ -82,6 +82,11 @@ Memory layout diagrams
 
 Select **DK** → **SoC** → **SoftDevice** to view RRAM and SRAM layout diagrams.
 
+.. note::
+   The total SRAM size shown in these diagrams may differ from the total given in the Datasheet.
+   Reserved regions, "VPR saved context" and "Protected RAM", are part of the SRAM memory map but are not shown as partitions in the diagrams.
+   For the complete layout, see the Memory map section in the device-specific Datasheet.
+
 .. tabs::
 
    .. group-tab:: nRF54L15-DK

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -266,4 +266,4 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 Documentation
 =============
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* Updated the memory layout diagram generation script to parse RRAM and SRAM sizes directly from devicetree instead of hardcoded per-SoC values.


### PR DESCRIPTION
Replace the hardcoded per-SoC RRAM/SRAM size tables and hardcoded SRAM base address/KMU reserved area size with values parsed directly from each board's `bm_<name_dk>_<name_soc>_cpuapp_common.dtsi` via `new get_soc_mem_field()` helper, so new SoCs and layout changes no longer need hand editing this script.