### PR TITLE
sample: bluetooth: Document Peer Manager section of samples

### DIFF
--- a/samples/bluetooth/ble_bms/README.rst
+++ b/samples/bluetooth/ble_bms/README.rst
@@ -57,7 +57,45 @@ LED 0:
 LED 1:
    Lit when a device is connected.
 
-.. _ble_bms_sample_testing:
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - Display and Yes/No entry
+     - Determines local I/O capability, actual pairing method depends on negotiation with peer.
+
+This sample configures the following services and their characteristics with these specific operation modes and required security levels:
+
++----------------------------+---------------------+-----------+-------------------------------+------------------------------------------------------------------------------------------+
+| Service                    | Characteristic      | Operation | Required security level       | Effect                                                                                   |
++============================+=====================+===========+===============================+==========================================================================================+
+| Bond Management Service    | Control Point       | Write     | Encryption, no authentication | Connection must be encrypted to write bond deletion commands.                            |
++                            +---------------------+-----------+-------------------------------+------------------------------------------------------------------------------------------+
+|                            | Feature             | Read      | Encryption, no authentication | Connection must be encrypted to read which bond deletion operations the device supports. |
++----------------------------+---------------------+-----------+-------------------------------+------------------------------------------------------------------------------------------+
+| Device Information Service | All characteristics | Read      | Open, no security             | Any connected device can read device information.                                        |
++----------------------------+---------------------+-----------+-------------------------------+------------------------------------------------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
 
 Building and running
 ********************

--- a/samples/bluetooth/ble_cgms/README.rst
+++ b/samples/bluetooth/ble_cgms/README.rst
@@ -64,6 +64,58 @@ LED 0:
 LED 1:
    Lit when a device is connected.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - Display and Yes/No entry
+     - Determines local I/O capability, actual pairing method depends on negotiation with peer.
+
+This sample configures the following services and their characteristics with these specific operation modes and required security levels:
+
++---------------------------------------+-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Service                               | Characteristic              | Operation      | Required security             | Effect                                                                                                                        |
++=======================================+=============================+================+===============================+===============================================================================================================================+
+| Continuous Glucose Monitoring Service | CGM Measurement             | Notify         | Encryption, no authentication | Connection must be encrypted to subscribe to and receive periodic glucose measurement notifications.                          |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Feature                     | Read           | Encryption, no authentication | Connection must be encrypted to read which optional CGM features the sensor supports.                                         |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Status                      | Read           | Encryption, no authentication | Connection must be encrypted to read the time offset and sensor status.                                                       |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Session Start Time          | Read/Write     | Encryption, no authentication | Connection must be encrypted to read or set the timestamp that marks when the monitoring session started.                     |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Session Run Time            | Read           | Encryption, no authentication | Connection must be encrypted to read the expected run time of the CGM session.                                                |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Record Access Control Point | Write/Indicate | Encryption, no authentication | Connection must be encrypted to retrieve, filter, or delete stored glucose measurement records.                               |
++                                       +-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+|                                       | Specific Ops Control Point  | Write/Indicate | Encryption, no authentication | Connection must be encrypted to start or stop a monitoring session and configure settings such as the communication interval. |
++---------------------------------------+-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Device Information Service            | All characteristics         | Read           | Encryption, no authentication | Connection must be encrypted to read device information such as the manufacturer name and firmware version.                   |
++---------------------------------------+-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Battery Service                       | Battery Level               | Read/Notify    | Open, no security             | Any connected device can read the battery level and subscribe to battery level notifications.                                 |
++---------------------------------------+-----------------------------+----------------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
+
 Building and running
 ********************
 

--- a/samples/bluetooth/ble_hids_keyboard/README.rst
+++ b/samples/bluetooth/ble_hids_keyboard/README.rst
@@ -73,6 +73,62 @@ LED 1:
 LED 2:
    Lit when Caps Lock is active on the computer.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - Display and Yes/No entry
+     - Determines local I/O capability, actual pairing method depends on negotiation with peer.
+
+This sample configures the following services and their characteristics with these specific operation modes and required security levels:
+
++----------------------------+-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Service                    | Characteristic              | Operation         | Required security level       | Effect                                                                                                                       |
++============================+=============================+===================+===============================+==============================================================================================================================+
+| HID Service                | Protocol Mode               | Read/Write        | Encryption, no authentication | Connection must be encrypted to switch the keyboard between Boot Protocol Mode and Report Protocol Mode.                     |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Input Report                | Read/Write/Notify | Encryption, no authentication | Connection must be encrypted to send key press and release events to the host.                                               |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Output Report               | Read/Write        | Encryption, no authentication | Connection must be encrypted for the host to read or set the LED state (Caps Lock, Num Lock, Scroll Lock).                   |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Feature Report              | Read/Write        | Encryption, no authentication | Connection must be encrypted to exchange vendor-specific configuration data.                                                 |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Report Map                  | Read              | Encryption, no authentication | Connection must be encrypted to read the report format the host needs to parse keyboard reports.                             |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Boot Keyboard Input Report  | Read/Write/Notify | Encryption, no authentication | Connection must be encrypted to send key presses with this characteristic when in the boot protocol mode.                    |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Boot Keyboard Output Report | Read/Write        | Encryption, no authentication | Connection must be encrypted for boot protocol hosts to read or set the LED state (Caps Lock, Num Lock, Scroll Lock).        |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | HID Information             | Read              | Encryption, no authentication | Connection must be encrypted to read the HID version and device capability flags.                                            |
++                            +-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | HID Control Point           | Write             | Encryption, no authentication | Connection must be encrypted to suspend or resume HID report notifications, for example when the host enters low power mode. |
++----------------------------+-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Device Information Service | All characteristics         | Read              | Open, no security             | Any connected device can read device information such as the manufacturer name and firmware version.                         |
++----------------------------+-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Battery Service            | Battery Level               | Read/Notify       | Open, no security             | Any connected device can read the battery level and subscribe to battery level notifications.                                |
++----------------------------+-----------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
+
 Building and running
 ********************
 

--- a/samples/bluetooth/ble_hids_mouse/README.rst
+++ b/samples/bluetooth/ble_hids_mouse/README.rst
@@ -72,6 +72,56 @@ LED 0:
 LED 1:
    Lit when a device is connected.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - Display and Yes/No entry
+     - Determines local I/O capability, actual pairing method depends on negotiation with peer.
+
+This sample configures the following services and their characteristics with these specific operation modes and required security levels:
+
++----------------------------+-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Service                    | Characteristic                                      | Operation         | Required security level       | Effect                                                                                                                       |
++============================+=====================================================+===================+===============================+==============================================================================================================================+
+| HID Service                | Protocol Mode                                       | Read/Write        | Encryption, no authentication | Connection must be encrypted to switch the mouse between Boot Protocol Mode and Report Protocol Mode.                        |
++                            +-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Input Reports (Buttons, Movement, Advanced Buttons) | Read/Write/Notify | Encryption, no authentication | Connection must be encrypted to send button presses, cursor movement, and advanced button presses, to the host.              |
++                            +-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Report Map                                          | Read              | Encryption, no authentication | Connection must be encrypted to read the report format the host needs to parse mouse reports.                                |
++                            +-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | Boot Mouse Input Report                             | Read/Write/Notify | Encryption, no authentication | Connection must be encrypted to send button and movement data with this characteristic when in the boot protocol mode.       |
++                            +-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | HID Information                                     | Read              | Encryption, no authentication | Connection must be encrypted to read the HID version and device capability flags.                                            |
++                            +-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+|                            | HID Control Point                                   | Write             | Encryption, no authentication | Connection must be encrypted to suspend or resume HID report notifications, for example when the host enters low power mode. |
++----------------------------+-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Device Information Service | All characteristics                                 | Read              | Open, no security             | Any connected device can read device information such as the manufacturer name and firmware version.                         |
++----------------------------+-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+| Battery Service            | Battery Level                                       | Read/Notify       | Open, no security             | Any connected device can read the battery level and subscribe to battery level notifications.                                |
++----------------------------+-----------------------------------------------------+-------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
+
 Building and running
 ********************
 

--- a/samples/bluetooth/ble_hrs/README.rst
+++ b/samples/bluetooth/ble_hrs/README.rst
@@ -69,6 +69,48 @@ LED 0:
 LED 1:
    Lit when a device is connected.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - Display only
+     - Determines local I/O capability, actual pairing method depends on negotiation with peer.
+
+This sample configures the following services and their characteristics with these specific operation modes and security levels:
+
++----------------------------+------------------------+-------------+-------------------------+------------------------------------------------------------------------------------------------------+
+| Service                    | Characteristic         | Operation   | Required security level | Effect                                                                                               |
++============================+========================+=============+=========================+======================================================================================================+
+| Heart Rate Service         | Heart Rate Measurement | Notify      | Open, no security       | Any connected device can subscribe and receive periodic heart rate measurement notifications.        |
++                            +------------------------+-------------+-------------------------+------------------------------------------------------------------------------------------------------+
+|                            | Body Sensor Location   | Read        | Open, no security       | Any connected device can read where on the body the sensor is worn.                                  |
++----------------------------+------------------------+-------------+-------------------------+------------------------------------------------------------------------------------------------------+
+| Device Information Service | All characteristics    | Read        | Open, no security       | Any connected device can read device information such as the manufacturer name and firmware version. |
++----------------------------+------------------------+-------------+-------------------------+------------------------------------------------------------------------------------------------------+
+| Battery Service            | Battery Level          | Read/Notify | Open, no security       | Any connected device can read the battery level and subscribe to battery level notifications.        |
++----------------------------+------------------------+-------------+-------------------------+------------------------------------------------------------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
+
 Building and running
 ********************
 

--- a/samples/bluetooth/ble_hrs_central/README.rst
+++ b/samples/bluetooth/ble_hrs_central/README.rst
@@ -52,6 +52,32 @@ LED 0:
 LED 1:
    Lit when a device is connected.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding, and to maintain an allow list of previously bonded peripherals for reconnection.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - None
+     - Pairing uses the Just Works method.
+
 .. _ble_hrs_central_sample_testing:
 
 Building and running

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -151,6 +151,42 @@ LED 1:
 LED 2:
    Lit when an NFC field is present.
 
+Security
+********
+
+The sample integrates :ref:`lib_peer_manager` (backed by :ref:`lib_bm_zms` for persistent storage) to support pairing and bonding.
+
+The following security parameters are configured:
+
+.. list-table:: Peer Manager security parameters
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Effect
+   * - Bonding
+     - True
+     - Supports storing of pairing information (bonding data).
+   * - MITM protection
+     - False
+     - Man-in-the-middle protection not required.
+   * - LE Secure Connections
+     - True
+     - Supports LESC pairing.
+   * - I/O capabilities
+     - None
+     - Authentication relies on the out-of-band data exchanged over NFC instead of a display or keyboard, as described in `Overview`_.
+
+This sample configures the following services and their characteristics with these specific operation modes and required security levels:
+
++----------------------------+---------------------+-----------+-------------------------+---------------------------------------------------+
+| Service                    | Characteristic      | Operation | Required security level | Effect                                            |
++============================+=====================+===========+=========================+===================================================+
+| Device Information Service | All characteristics | Read      | Open, no security       | Any connected device can read device information. |
++----------------------------+---------------------+-----------+-------------------------+---------------------------------------------------+
+
+See `Testing`_ for the pairing and bonding steps.
+
 Building and running
 ********************
 


### PR DESCRIPTION
Add a short "Security" chapter to the `README.rst` of each relevant Bluetooth sample that integrates Peer Manager,
describing the configured pairing/bonding parameters and the security requirements of the sample's BLE services.
Samples with peer manager documentation:
- `ble_bms`
- `ble_cgms`
- `ble_hids_keyboard`
- `ble_hids_mouse`
- `ble_hrs`
- `ble_hrs_central`
- `peripheral_nfc_pairing`