### PR TITLE
softdevice_handler: fix issue in logging SoftDevice version

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -28,7 +28,8 @@ No changes since the latest nRF Connect SDK Bare Metal release.
 SoftDevice Handler
 ==================
 
-No changes since the latest nRF Connect SDK Bare Metal release.
+* Fixed an issue where using the :kconfig:option:`CONFIG_NRF_SDH_LOG_SD_INFO` Kconfig option for MCUboot board targets would log invalid SoftDevice version data.
+  The logging now takes the SoftDevice partition offset into account for those board targets.
 
 Boards
 ======

--- a/subsys/softdevice_handler/nrf_sdh.c
+++ b/subsys/softdevice_handler/nrf_sdh.c
@@ -132,7 +132,10 @@ static int nrf_sdh_enable(void)
 	};
 
 	if (IS_ENABLED(CONFIG_NRF_SDH_LOG_SD_INFO)) {
-		const uint32_t base = PARTITION_OFFSET(softdevice_partition);
+		uint32_t base = PARTITION_OFFSET(softdevice_partition);
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+		base += CONFIG_ROM_START_OFFSET;
+#endif
 		const struct nrf_sdh_info_version sd_ver = nrf_sdh_info_version_get(base);
 		const struct nrf_sdh_info_unique_str sd_unique = nrf_sdh_info_unique_str_get(base);
 


### PR DESCRIPTION
Fixed a bug where using the CONFIG_NRF_SDH_LOG_SD_INFO Kconfig option in MCUboot board targets would log invalid SoftDevice version data. The logging now takes into account for the SoftDevice partition offset in the MCUboot board targets.