### PR TITLE
treewide: Kconfig and CMake cleanup

### DIFF
--- a/applications/firmware_loader/uart_mcumgr/CMakeLists.txt
+++ b/applications/firmware_loader/uart_mcumgr/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(uart_mcumgr)
 
-zephyr_include_directories(include)
-zephyr_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/include)
+zephyr_include_directories(
+  include
+  ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/include
+)
 target_sources(app PRIVATE src/main.c)

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -7,7 +7,9 @@
 # FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
 add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
 
-add_subdirectory_ifdef(CONFIG_CONSOLE console)
-add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL clock_control)
-add_subdirectory_ifdef(CONFIG_FLASH flash)
+# zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BM_SW_LPUARTE bm_lpuarte)
+add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL clock_control)
+add_subdirectory_ifdef(CONFIG_CONSOLE console)
+add_subdirectory_ifdef(CONFIG_FLASH flash)
+# zephyr-keep-sorted-stop

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -6,9 +6,9 @@
 menu "Device Drivers"
 
 # zephyr-keep-sorted-start
+rsource "bm_lpuarte/Kconfig"
 rsource "console/Kconfig"
 rsource "flash/Kconfig"
-rsource "bm_lpuarte/Kconfig"
 # zephyr-keep-sorted-stop
 
 endmenu

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,11 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# zephyr-keep-sorted-start
 add_subdirectory(bluetooth)
-add_subdirectory_ifdef(CONFIG_BM_SCHEDULER bm_scheduler)
+# zephyr-keep-sorted-stop
+
+# zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BM_BUTTONS bm_buttons)
 add_subdirectory_ifdef(CONFIG_BM_GPIOTE bm_gpiote)
+add_subdirectory_ifdef(CONFIG_BM_SCHEDULER bm_scheduler)
 add_subdirectory_ifdef(CONFIG_BM_TIMER bm_timer)
-add_subdirectory_ifdef(CONFIG_SENSORSIM sensorsim)
 add_subdirectory_ifdef(CONFIG_NCS_BARE_METAL_BOOT_BANNER boot_banner)
+add_subdirectory_ifdef(CONFIG_SENSORSIM sensorsim)
 add_subdirectory_ifdef(CONFIG_ZEPHYR_QUEUE zephyr_queue)
+# zephyr-keep-sorted-stop

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -5,13 +5,15 @@
 #
 menu "Libraries"
 
+# zephyr-keep-sorted-start
 rsource "bluetooth/Kconfig"
-rsource "bm_scheduler/Kconfig"
 rsource "bm_buttons/Kconfig"
 rsource "bm_gpiote/Kconfig"
+rsource "bm_scheduler/Kconfig"
 rsource "bm_timer/Kconfig"
-rsource "sensorsim/Kconfig"
 rsource "boot_banner/Kconfig"
+rsource "sensorsim/Kconfig"
 rsource "zephyr_queue/Kconfig"
+# zephyr-keep-sorted-stop
 
 endmenu

--- a/lib/bluetooth/CMakeLists.txt
+++ b/lib/bluetooth/CMakeLists.txt
@@ -8,12 +8,14 @@ if(CONFIG_BLE_ADV OR CONFIG_BLE_ADV_DATA)
   add_subdirectory(ble_adv)
 endif()
 
+# zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BLE_CONN_PARAMS ble_conn_params)
 add_subdirectory_ifdef(CONFIG_BLE_CONN_STATE ble_conn_state)
 add_subdirectory_ifdef(CONFIG_BLE_DB_DISCOVERY ble_db_discovery)
 add_subdirectory_ifdef(CONFIG_BLE_GATT_QUEUE ble_gq)
+add_subdirectory_ifdef(CONFIG_BLE_QWR ble_qwr)
 add_subdirectory_ifdef(CONFIG_BLE_RACP ble_racp)
 add_subdirectory_ifdef(CONFIG_BLE_RADIO_NOTIFICATION ble_radio_notification)
 add_subdirectory_ifdef(CONFIG_BLE_SCAN ble_scan)
-add_subdirectory_ifdef(CONFIG_BLE_QWR ble_qwr)
 add_subdirectory_ifdef(CONFIG_PEER_MANAGER peer_manager)
+# zephyr-keep-sorted-stop

--- a/lib/bluetooth/Kconfig
+++ b/lib/bluetooth/Kconfig
@@ -5,16 +5,18 @@
 #
 menu "Bluetooth libraries"
 
+# zephyr-keep-sorted-start
 rsource "ble_adv/Kconfig"
 rsource "ble_conn_params/Kconfig"
 rsource "ble_conn_state/Kconfig"
 rsource "ble_db_discovery/Kconfig"
 rsource "ble_gq/Kconfig"
+rsource "ble_qwr/Kconfig"
 rsource "ble_racp/Kconfig"
 rsource "ble_radio_notification/Kconfig"
 rsource "ble_scan/Kconfig"
-rsource "ble_qwr/Kconfig"
 rsource "peer_manager/Kconfig"
+# zephyr-keep-sorted-stop
 
 menu "Common"
 

--- a/lib/bluetooth/ble_conn_params/CMakeLists.txt
+++ b/lib/bluetooth/ble_conn_params/CMakeLists.txt
@@ -5,7 +5,10 @@
 #
 zephyr_library()
 zephyr_library_sources(event.c)
-zephyr_library_sources_ifdef(CONFIG_BLE_CONN_PARAMS_AUTO_GAP_CONN_PARAM_UPDATE conn_param.c)
+
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_BLE_CONN_PARAMS_AUTO_ATT_MTU att_mtu.c)
 zephyr_library_sources_ifdef(CONFIG_BLE_CONN_PARAMS_AUTO_DATA_LENGTH data_length.c)
+zephyr_library_sources_ifdef(CONFIG_BLE_CONN_PARAMS_AUTO_GAP_CONN_PARAM_UPDATE conn_param.c)
 zephyr_library_sources_ifdef(CONFIG_BLE_CONN_PARAMS_AUTO_PHY_UPDATE phy_mode.c)
+# zephyr-keep-sorted-stop

--- a/lib/bluetooth/peer_manager/CMakeLists.txt
+++ b/lib/bluetooth/peer_manager/CMakeLists.txt
@@ -6,8 +6,10 @@
 
 zephyr_library()
 zephyr_library_include_directories(include)
-zephyr_library_sources(peer_manager.c)
-zephyr_library_sources(nrf_strerror.c)
+zephyr_library_sources(
+  nrf_strerror.c
+  peer_manager.c
+)
 
 add_subdirectory(modules)
 

--- a/lib/bluetooth/peer_manager/modules/CMakeLists.txt
+++ b/lib/bluetooth/peer_manager/modules/CMakeLists.txt
@@ -4,16 +4,21 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_library_sources_ifdef(CONFIG_PM_RA_PROTECTION auth_status_tracker.c)
-zephyr_library_sources(conn_state.c)
-zephyr_library_sources(gatt_cache_manager.c)
-zephyr_library_sources(gatts_cache_manager.c)
-zephyr_library_sources(id_manager.c)
+zephyr_library_sources(
+  conn_state.c
+  gatt_cache_manager.c
+  gatts_cache_manager.c
+  id_manager.c
+  peer_data_storage.c
+  peer_database.c
+  peer_id.c
+  peer_manager_handler.c
+  pm_buffer.c
+  security_dispatcher.c
+  security_manager.c
+)
+
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_PM_LESC nrf_ble_lesc.c)
-zephyr_library_sources(peer_data_storage.c)
-zephyr_library_sources(peer_database.c)
-zephyr_library_sources(peer_id.c)
-zephyr_library_sources(peer_manager_handler.c)
-zephyr_library_sources(pm_buffer.c)
-zephyr_library_sources(security_dispatcher.c)
-zephyr_library_sources(security_manager.c)
+zephyr_library_sources_ifdef(CONFIG_PM_RA_PROTECTION auth_status_tracker.c)
+# zephyr-keep-sorted-stop

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -12,6 +12,9 @@ add_subdirectory(logging)
 add_subdirectory(nfc)
 add_subdirectory(shell)
 add_subdirectory(storage)
+# zephyr-keep-sorted-stop
+
+# zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_NCS_BM_MCUMGR mgmt/mcumgr)
 add_subdirectory_ifdef(CONFIG_NRF_SDH softdevice_handler)
 add_subdirectory_ifdef(CONFIG_SOFTDEVICE softdevice)

--- a/subsys/bluetooth/services/CMakeLists.txt
+++ b/subsys/bluetooth/services/CMakeLists.txt
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+
+# zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BLE_BAS ble_bas)
 add_subdirectory_ifdef(CONFIG_BLE_BAS_CLIENT ble_bas_client)
 add_subdirectory_ifdef(CONFIG_BLE_BMS ble_bms)
@@ -10,8 +12,9 @@ add_subdirectory_ifdef(CONFIG_BLE_CGMS ble_cgms)
 add_subdirectory_ifdef(CONFIG_BLE_DIS ble_dis)
 add_subdirectory_ifdef(CONFIG_BLE_HIDS ble_hids)
 add_subdirectory_ifdef(CONFIG_BLE_HRS ble_hrs)
+add_subdirectory_ifdef(CONFIG_BLE_HRS_CLIENT ble_hrs_client)
 add_subdirectory_ifdef(CONFIG_BLE_LBS ble_lbs)
+add_subdirectory_ifdef(CONFIG_BLE_MCUMGR ble_mcumgr)
 add_subdirectory_ifdef(CONFIG_BLE_NUS ble_nus)
 add_subdirectory_ifdef(CONFIG_BLE_NUS_CLIENT ble_nus_client)
-add_subdirectory_ifdef(CONFIG_BLE_MCUMGR ble_mcumgr)
-add_subdirectory_ifdef(CONFIG_BLE_HRS_CLIENT ble_hrs_client)
+# zephyr-keep-sorted-stop

--- a/subsys/bluetooth/services/Kconfig
+++ b/subsys/bluetooth/services/Kconfig
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+
+# zephyr-keep-sorted-start
 rsource "ble_bas/Kconfig"
 rsource "ble_bas_client/Kconfig"
 rsource "ble_bms/Kconfig"
@@ -12,6 +14,7 @@ rsource "ble_hids/Kconfig"
 rsource "ble_hrs/Kconfig"
 rsource "ble_hrs_client/Kconfig"
 rsource "ble_lbs/Kconfig"
+rsource "ble_mcumgr/Kconfig"
 rsource "ble_nus/Kconfig"
 rsource "ble_nus_client/Kconfig"
-rsource "ble_mcumgr/Kconfig"
+# zephyr-keep-sorted-stop

--- a/subsys/bluetooth/services/ble_mcumgr/CMakeLists.txt
+++ b/subsys/bluetooth/services/ble_mcumgr/CMakeLists.txt
@@ -5,8 +5,10 @@
 #
 
 zephyr_sources(mcumgr.c)
-zephyr_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/util/include)
-zephyr_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/grp/img_mgmt/include)
-zephyr_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/include)
+zephyr_include_directories(
+  ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/grp/img_mgmt/include
+  ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/include
+  ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/util/include
+)
 zephyr_linker_sources(SECTIONS ${ZEPHYR_NRF_BM_MODULE_DIR}/subsys/mgmt/mcumgr/transport/mcumgr_handler.ld)
 zephyr_link_libraries(MCUBOOT_BOOTUTIL)

--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -8,10 +8,12 @@
 # The mgmt_mcumgr is interface library for MCUmgr services.
 zephyr_interface_library_named(mgmt_mcumgr)
 
+# zephyr-keep-sorted-start
+add_subdirectory(grp)
 add_subdirectory(mgmt)
 add_subdirectory(smp)
-add_subdirectory(util)
-add_subdirectory(grp)
 add_subdirectory(transport)
+add_subdirectory(util)
+# zephyr-keep-sorted-stop
 
 zephyr_library_link_libraries(mgmt_mcumgr)

--- a/subsys/mgmt/mcumgr/grp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/CMakeLists.txt
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_IMG            img_mgmt)
-add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_OS             os_mgmt)
-add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_SETTINGS       settings_mgmt)
+# zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_IMG img_mgmt)
+add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_OS os_mgmt)
+add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_SETTINGS settings_mgmt)
+# zephyr-keep-sorted-stop

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
@@ -9,11 +9,11 @@
 # when Image Management is enabled.
 zephyr_library_named(mgmt_mcumgr_grp_img)
 zephyr_library_sources(
-  src/zephyr_img_mgmt.c
-  src/bm_img_mgmt.c
   ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_util.c
+  src/bm_img_mgmt.c
   src/img_mgmt_state.c
   src/img_mgmt.c
+  src/zephyr_img_mgmt.c
 )
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -15,9 +15,9 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_REASSEMBLY
 )
 
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_BM_UART
-  src/smp_uart.c
-  src/bm_uart_mcumgr.c
   ${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/src/serial_util.c
+  src/bm_uart_mcumgr.c
+  src/smp_uart.c
 )
 
 zephyr_include_directories(${ZEPHYR_BASE}/subsys/mgmt/mcumgr/transport/include include)

--- a/subsys/nfc/Kconfig
+++ b/subsys/nfc/Kconfig
@@ -6,8 +6,10 @@
 
 menu "NFC for Bare Metal"
 
+# zephyr-keep-sorted-start
+rsource "lib/Kconfig"
 rsource "ndef/Kconfig"
 rsource "t4t/Kconfig"
-rsource "lib/Kconfig"
+# zephyr-keep-sorted-stop
 
 endmenu

--- a/subsys/nfc/lib/CMakeLists.txt
+++ b/subsys/nfc/lib/CMakeLists.txt
@@ -6,7 +6,9 @@
 if(CONFIG_NFC_T2T_NRFXLIB OR CONFIG_NFC_T4T_NRFXLIB)
   if(CONFIG_BM_NFC_PLATFORM)
     zephyr_library()
-    zephyr_library_sources(nfc_bm_platform.c)
-    zephyr_library_sources(nfc_bm_platform_internal.c)
+    zephyr_library_sources(
+      nfc_bm_platform.c
+      nfc_bm_platform_internal.c
+    )
   endif()
 endif()

--- a/subsys/softdevice_handler/CMakeLists.txt
+++ b/subsys/softdevice_handler/CMakeLists.txt
@@ -7,10 +7,10 @@ zephyr_library()
 zephyr_linker_sources(SECTIONS sdh.ld)
 zephyr_linker_sources(DATA_SECTIONS sdh_ram.ld)
 zephyr_library_sources(
-  nrf_sdh.c
+  irq_connect.c
   nrf_sdh_info.c
   nrf_sdh_soc.c
-  irq_connect.c
+  nrf_sdh.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_NRF_SDH_SOC_RAND_SEED rand_seed.c)

--- a/subsys/storage/bm_storage/CMakeLists.txt
+++ b/subsys/storage/bm_storage/CMakeLists.txt
@@ -7,6 +7,8 @@
 zephyr_library()
 zephyr_library_sources(bm_storage.c)
 
+# zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_BM_STORAGE_BACKEND_NATIVE_SIM native_sim)
 add_subdirectory_ifdef(CONFIG_BM_STORAGE_BACKEND_RRAM rram)
 add_subdirectory_ifdef(CONFIG_BM_STORAGE_BACKEND_SD sd)
-add_subdirectory_ifdef(CONFIG_BM_STORAGE_BACKEND_NATIVE_SIM native_sim)
+# zephyr-keep-sorted-stop

--- a/sysbuild/Kconfig.bm
+++ b/sysbuild/Kconfig.bm
@@ -203,12 +203,12 @@ config SOFTDEVICE_FILE
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54l/s145/s145_nrf54l05_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54L05
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54l/s145/s145_nrf54l10_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54L10
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54l/s145/s145_nrf54l15_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54L15
-	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lv/s115/s115_nrf54lv10_10.0.1_softdevice.hex" if SOFTDEVICE_S115 && SOC_NRF54LV10A
-	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lv/s145/s145_nrf54lv10_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54LV10A
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lm/s115/s115_nrf54lm20_10.0.1_softdevice.hex" if SOFTDEVICE_S115 && SOC_NRF54LM20A
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lm/s145/s145_nrf54lm20_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54LM20A
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54ls/s115/s115_nrf54ls05_10.0.1_softdevice.hex" if SOFTDEVICE_S115 && SOC_NRF54LS05B
 	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54ls/s145/s145_nrf54ls05_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54LS05B
+	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lv/s115/s115_nrf54lv10_10.0.1_softdevice.hex" if SOFTDEVICE_S115 && SOC_NRF54LV10A
+	default "$(ZEPHYR_NRF_BM_MODULE_DIR)/components/softdevice/nrf54lv/s145/s145_nrf54lv10_10.0.1_softdevice.hex" if SOFTDEVICE_S145 && SOC_NRF54LV10A
 	help
 	  Specifies the path to the softdevice hex file.
 


### PR DESCRIPTION
Sort lines in Kconfig and CMake in alphabetic order where the order of the lines does not matter.
Cleanup zephyr_include_directories and zephyr_library_sources.