### PR TITLE
doc: nrf-bm: correct sizes in memory layout page

### DIFF
--- a/doc/nrf-bm/boards/memory_layout.rst
+++ b/doc/nrf-bm/boards/memory_layout.rst
@@ -184,7 +184,7 @@ Select **DK** → **SoC** → **SoftDevice** to view RRAM and SRAM layout diagra
 
          .. group-tab:: nRF54LM20A
 
-            Total RRAM: 2048 KB | Total SRAM: 512 KB
+            Total RRAM: 2036 KB | Total SRAM: 512 KB
 
             .. tabs::
 
@@ -252,7 +252,7 @@ Select **DK** → **SoC** → **SoftDevice** to view RRAM and SRAM layout diagra
 
          .. group-tab:: nRF54LV10A
 
-            Total RRAM: 1012 KB | Total SRAM: 191 KB
+            Total RRAM: 1012 KB | Total SRAM: 192 KB
 
             .. tabs::
 


### PR DESCRIPTION
The nRF54LM20A has 2036 KB of RRAM, not 2048 KB.
The nRF54LV10A has 192 KB of SRAM, not 191 KB. (Due to the VPR saved context and Protected RAM, not all can be used by application.)