### PR TITLE
doc: fix warnings in SoftDevice docset building

### DIFF
--- a/doc/s145_nrf54lm20/s145_nrf54lm20.doxyfile.in
+++ b/doc/s145_nrf54lm20/s145_nrf54lm20.doxyfile.in
@@ -1124,7 +1124,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = YES
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common

--- a/doc/s145_nrf54ls05/s145_nrf54ls05.doxyfile.in
+++ b/doc/s145_nrf54ls05/s145_nrf54ls05.doxyfile.in
@@ -1124,7 +1124,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = YES
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common

--- a/doc/s145_nrf54lv10/s145_nrf54lv10.doxyfile.in
+++ b/doc/s145_nrf54lv10/s145_nrf54lv10.doxyfile.in
@@ -1124,7 +1124,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = YES
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
Fix incorrectly set USE_MDFILE_AS_MAINPAGE configuration in a few s145_nrf54lxxx.doxyfile.in files.
Removes "warning: Specified markdown mainpage 'YES' does not exist" from doc build.