### PR TITLE
doc: license: update copyright year in documentation and license

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -18,7 +18,7 @@ NRF_BASE = NRF_BM_BASE / ".." / "nrf"
 # General configuration --------------------------------------------------------
 
 project = "Kconfig reference"
-copyright = "2025, Nordic Semiconductor"
+copyright = "2025-2026, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 # NOTE: use blank space as version to preserve space
 version = "&nbsp;"

--- a/doc/nrf-bm/conf.py
+++ b/doc/nrf-bm/conf.py
@@ -18,7 +18,7 @@ ZEPHYR_BASE = NRF_BM_BASE / ".." / "zephyr"
 # General configuration --------------------------------------------------------
 
 project = "nRF Connect SDK Bare Metal"
-copyright = "2025, Nordic Semiconductor"
+copyright = "2025-2026, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 version = release = os.environ.get("DOCSET_VERSION")
 


### PR DESCRIPTION
Update year in the copyright footer of the nrf-bm and the Kconfig tabs of the documentation.