### PR TITLE
samples: doc: update board target string formatting

### DIFF
--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s115.txt
@@ -8,19 +8,19 @@
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LS05 DK`_
            - PCA10214
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LV10 DK`_
            - PCA10188
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice/mcuboot``

--- a/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_mcuboot_variants_s145.txt
@@ -8,19 +8,19 @@
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LS05 DK`_
            - PCA10214
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LV10 DK`_
            - PCA10188
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice/mcuboot``

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s115.txt
@@ -8,19 +8,19 @@
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice``
          * - `nRF54LS05 DK`_
            - PCA10214
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice
+           - ``bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice``
          * - `nRF54LV10 DK`_
            - PCA10188
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice
+           - ``bm_nrf54lv10dk/nrf54lv10a/cpuapp/s115_softdevice``

--- a/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
+++ b/doc/nrf-bm/includes/supported_boards_all_non-mcuboot_variants_s145.txt
@@ -8,19 +8,19 @@
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice``
          * - `nRF54LS05 DK`_
            - PCA10214
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice
+           - ``bm_nrf54ls05dk/nrf54ls05b/cpuapp/s145_softdevice``
          * - `nRF54LV10 DK`_
            - PCA10188
-           - bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice
+           - ``bm_nrf54lv10dk/nrf54lv10a/cpuapp/s145_softdevice``

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -40,16 +40,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice``
 
       **S145**:
 
@@ -61,16 +61,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice``
 
    .. group-tab:: MCUboot board variants
 
@@ -86,16 +86,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot``
 
       **S145**:
 
@@ -107,16 +107,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot``
 
 The sample additionally requires an NFC polling device (for example, a smartphone or a tablet with NFC support).
 

--- a/samples/nfc/record_text_t2t/README.rst
+++ b/samples/nfc/record_text_t2t/README.rst
@@ -31,16 +31,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice``
 
       **S145**:
 
@@ -52,16 +52,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice``
 
    .. group-tab:: MCUboot board variants
 
@@ -77,16 +77,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot``
 
       **S145**:
 
@@ -98,16 +98,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot``
 
 The sample also requires a smartphone or tablet.
 

--- a/samples/nfc/record_text_t4t/README.rst
+++ b/samples/nfc/record_text_t4t/README.rst
@@ -31,16 +31,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice``
 
       **S145**:
 
@@ -52,16 +52,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice``
 
    .. group-tab:: MCUboot board variants
 
@@ -77,16 +77,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot``
 
       **S145**:
 
@@ -98,16 +98,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot``
 
 The sample also requires a smartphone or tablet.
 

--- a/samples/peripherals/pwm/README.rst
+++ b/samples/peripherals/pwm/README.rst
@@ -30,16 +30,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice``
 
       **S145**:
 
@@ -51,16 +51,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice``
 
    .. group-tab:: MCUboot board variants
 
@@ -76,19 +76,19 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s115_softdevice/mcuboot``
          * - `nRF54LS05 DK`_
            - PCA10214
-           - bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot
+           - ``bm_nrf54ls05dk/nrf54ls05b/cpuapp/s115_softdevice/mcuboot``
 
       **S145**:
 
@@ -100,16 +100,16 @@ The sample supports the following development kits:
            - Board target
          * - `nRF54L15 DK`_
            - PCA10156
-           - bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l15/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L10)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l10/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54L15 DK`_ (emulating nRF54L05)
            - PCA10156
-           - bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54l15dk/nrf54l05/cpuapp/s145_softdevice/mcuboot``
          * - `nRF54LM20 DK`_
            - PCA10184
-           - bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot
+           - ``bm_nrf54lm20dk/nrf54lm20a/cpuapp/s145_softdevice/mcuboot``
 
 Overview
 ********


### PR DESCRIPTION
Update formatting of board target strings to use \`\`board/target\`\`.

Search regex: - bm_nrf54l(.\*)dk/(.\*)$
Replace regex: - \`\`bm_nrf54l$1dk/$2\`\`
Exclude sample.yaml and testcase.yaml files.