### PR TITLE
Revert "samples: nus: improve handling of end-of-line terminations"

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -208,14 +208,6 @@ Bluetooth LE samples
 
    * Fixed a bug with the UARTE RX buffer address provided with index 1.
 
-   * Added:
-
-      * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL` Kconfig option to select the end-of-line termination (CR, LF, or CR+LF) used with the UART connected device.
-     The default option is LF (Line Feed).
-     If your device is using CR, you must set the Kconfig option accordingly.
-      * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL_STRIP` Kconfig option to strip the termination before sending over Bluetooth LE.
-     This option is disabled by default.
-
 * :ref:`ble_nus_central_sample` sample:
 
    * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -211,22 +211,14 @@ Bluetooth LE samples
    * Added:
 
       * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL` Kconfig option to select the end-of-line termination (CR, LF, or CR+LF) used with the UART connected device.
-        The default option is LF (Line Feed).
-        If your device is using CR, you must set the Kconfig option accordingly.
+     The default option is LF (Line Feed).
+     If your device is using CR, you must set the Kconfig option accordingly.
       * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL_STRIP` Kconfig option to strip the termination before sending over Bluetooth LE.
-        This option is disabled by default.
+     This option is disabled by default.
 
 * :ref:`ble_nus_central_sample` sample:
 
    * Updated to use Button 1 to disconnect from the target peripheral to align with other central samples.
-
-   * Added:
-
-      * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL` Kconfig option to select the end-of-line termination (CR, LF, or CR+LF) used with the UART connected device.
-        The default option is LF (Line Feed).
-        If your device is using CR, you must set the Kconfig option accordingly.
-      * The :kconfig:option:`CONFIG_SAMPLE_UART_EOL_STRIP` Kconfig option to strip the termination before sending over Bluetooth LE.
-        This option is disabled by default.
 
    * Fixed:
 

--- a/samples/bluetooth/ble_nus/Kconfig
+++ b/samples/bluetooth/ble_nus/Kconfig
@@ -23,34 +23,6 @@ config SAMPLE_NUS_UART_IRQ_PRIO
 config SAMPLE_NUS_UART_PARITY
 	bool "Bluetooth LE UART use parity"
 
-choice SAMPLE_UART_EOL
-	prompt "End-of-line termination"
-	default SAMPLE_UART_EOL_LF
-	help
-	  End-of-line termination used with the UART connected device (for example a PC terminal).
-	  Input from the connected device is forwarded over Bluetooth LE one line at a time,
-	  using this sequence as the delimiter.
-	  Data received over Bluetooth LE has this termination appended before it is written back
-	  to the connected device when it is missing.
-
-config SAMPLE_UART_EOL_CR
-	bool "Carriage return (CR)"
-
-config SAMPLE_UART_EOL_LF
-	bool "Line feed (LF)"
-
-config SAMPLE_UART_EOL_CR_LF
-	bool "Carriage return and line feed (CR+LF)"
-
-endchoice # SAMPLE_UART_EOL
-
-config SAMPLE_UART_EOL_STRIP
-	bool "Strip the end-of-line before sending over Bluetooth LE"
-	help
-	  When enabled, the end-of-line termination is removed before it is sent to the peer,
-	  so the message arrives without a trailing line break.
-	  When disabled, the termination is sent as part of the message.
-
 config SAMPLE_NUS_LPUARTE
 	bool "NUS Low Power UARTE"
 

--- a/samples/bluetooth/ble_nus/README.rst
+++ b/samples/bluetooth/ble_nus/README.rst
@@ -55,20 +55,6 @@ LED 1:
 
   In LPUARTE mode, the LEDs may appear on even when no device is connected for some development kits because it shares pins with the LPUARTE; RX or TX activity can toggle the LED, which is expected behavior.
 
-.. _ble_nus_configuration:
-
-Configuration
-*************
-
-The sample allows configuring how end-of-line (EOL) terminations are handled for the UART connected device (for example, a PC terminal).
-You can modify the following options (available in the Kconfig file at :file:`samples/bluetooth/ble_nus`):
-
-* :kconfig:option:`CONFIG_SAMPLE_UART_EOL_CR`, :kconfig:option:`CONFIG_SAMPLE_UART_EOL_LF`, and :kconfig:option:`CONFIG_SAMPLE_UART_EOL_CR_LF` - Select the end-of-line termination (``CR``, ``LF`` (the default), or ``CR+LF``) used with the UART connected device.
-  Input from the connected device is forwarded over Bluetooth LE one line at a time using this sequence as the delimiter, and the same termination is appended to data received over Bluetooth LE before it is written back to the connected device when missing.
-
-* :kconfig:option:`CONFIG_SAMPLE_UART_EOL_STRIP` - Strip the end-of-line termination from a line before it is sent over Bluetooth LE, so the message arrives without a trailing line break.
-  Disabled by default.
-
 Building and running
 ********************
 
@@ -99,20 +85,16 @@ The sample can be tested in two ways, depending on the selected UART configurati
          If you use a development kit, UART 0 and 1 are forwarded as COM ports (Windows) or ttyACM devices (Linux) after you connect the development kit over USB.
          One instance is used for logging (if enabled with :kconfig:option:`CONFIG_LOG`), while the other is used for the NUS service.
       #. Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_) for both UARTs.
-         In the following steps, these are referred to as the **logging terminal** and the **NUS terminal**.
       #. Reset the kit.
-      #. Observe that the NUS terminal prints ``UART started.`` followed by ``Line terminator set to:`` with the terminator configured through the ``CONFIG_SAMPLE_UART_EOL_*`` Kconfig option (see `Configuration`_).
-         Set the NUS terminal to use the same line terminator.
-      #. Observe that the logging terminal prints ``BLE NUS sample initialized``.
-      #. Observe that the logging terminal prints ``Advertising as nRF_BM_NUS``.
+      #. Observe that the text ``BLE NUS sample initialized`` is printed on the COM listener running on the computer.
+      #. Observe that the ``Advertising as nRF_BM_NUS`` message is printed.
          You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
          For information on how to do this, see `Configuring Kconfig`_.
       #. Connect to your device using the `nRF Toolbox`_ mobile application with the :guilabel:`Universal Asynchronous Receiver/Transmitter (UART)` service.
          If the device is not advertising, reset the board with the :guilabel:`Reset Board` option in |VSC| or by pressing the reset button on the development kit.
-      #. Write a text in the NUS terminal and press Enter.
-         Observe that the text is displayed in the terminal on the mobile phone.
+      #. Write a text in the second COM listener running on the computer and press Enter.
       #. Write a text in the terminal on the mobile phone and press :guilabel:`Send`.
-         Observe that the text is displayed in the NUS terminal.
+         Observe that the text is displayed in the second COM listener running on the computer.
 
    .. group-tab:: LPUARTE configuration
 

--- a/samples/bluetooth/ble_nus/src/main.c
+++ b/samples/bluetooth/ble_nus/src/main.c
@@ -65,22 +65,6 @@ static volatile uint16_t ble_nus_max_data_len = BLE_NUS_MAX_DATA_LEN_CALC(BLE_GA
 static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_UART_RX_BUF_SIZE];
 static int buf_idx;
 
-/* End-of-line termination for NUS messages (CONFIG_SAMPLE_UART_EOL_*).
- * Used as the line delimiter for UART data sent over BLE,
- * and appended to BLE data before it is written back to the UART.
- */
-#if defined(CONFIG_SAMPLE_UART_EOL_CR)
-#define UART_EOL "\r"
-#define EOL_LABEL "CR ('\\r')"
-#elif defined(CONFIG_SAMPLE_UART_EOL_LF)
-#define UART_EOL "\n"
-#define EOL_LABEL "LF ('\\n')"
-#else
-#define UART_EOL "\r\n"
-#define EOL_LABEL "CR+LF ('\\r\\n')"
-#endif
-#define UART_EOL_LEN (sizeof(UART_EOL) - 1)
-
 /**
  * @brief Handle data received from UART.
  *
@@ -112,7 +96,6 @@ static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
 	uint8_t c;
-	bool eol;
 	/* receive buffer used in UART ISR callback. */
 	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
 	static uint16_t rx_buf_idx;
@@ -125,16 +108,7 @@ static void uarte_rx_handler(char *data, size_t data_len)
 			rx_buf[rx_buf_idx++] = c;
 		}
 
-		/* Send once the buffer ends with the configured EOL or the buffer is full. */
-		eol = rx_buf_idx >= UART_EOL_LEN &&
-			memcmp(&rx_buf[rx_buf_idx - UART_EOL_LEN], UART_EOL, UART_EOL_LEN) == 0;
-
-		if (eol || (rx_buf_idx >= ble_nus_max_data_len)) {
-			/* Optionally drop the line ending so the peer gets just the message. */
-			if (eol && IS_ENABLED(CONFIG_SAMPLE_UART_EOL_STRIP)) {
-				rx_buf_idx -= UART_EOL_LEN;
-			}
-
+		if ((c == '\n' || c == '\r') || (rx_buf_idx >= ble_nus_max_data_len)) {
 			if (rx_buf_idx == 0) {
 				/* RX buffer is empty, nothing to send. */
 				continue;
@@ -341,8 +315,7 @@ uint16_t ble_qwr_evt_handler(struct ble_qwr *qwr, const struct ble_qwr_evt *qwr_
  */
 static void ble_nus_evt_handler(struct ble_nus *nus, const struct ble_nus_evt *evt)
 {
-	/* EasyDMA can only transmit from RAM, so use a local (RAM) copy of the EOL. */
-	char eol[] = UART_EOL;
+	const char newline = '\n';
 	int err;
 
 	if (evt->evt_type == BLE_NUS_EVT_ERROR) {
@@ -370,14 +343,12 @@ static void ble_nus_evt_handler(struct ble_nus *nus, const struct ble_nus_evt *e
 	}
 #endif
 
-	/* Append the configured EOL when the peer did not send a line ending. */
-	if (evt->rx_data.data[evt->rx_data.length - 1] != '\n' &&
-	    evt->rx_data.data[evt->rx_data.length - 1] != '\r') {
+
+	if (evt->rx_data.data[evt->rx_data.length - 1] == '\r') {
 #if defined(CONFIG_SAMPLE_NUS_LPUARTE)
-		(void)bm_lpuarte_tx(&lpu, eol, UART_EOL_LEN, 3000);
+		(void)bm_lpuarte_tx(&lpu, &newline, 1, 3000);
 #else
-		(void)nrfx_uarte_tx(&nus_uarte_inst, eol,
-				    UART_EOL_LEN, NRFX_UARTE_TX_BLOCKING);
+		(void)nrfx_uarte_tx(&nus_uarte_inst, &newline, 1, NRFX_UARTE_TX_BLOCKING);
 #endif
 	}
 }
@@ -550,8 +521,8 @@ int main(void)
 		LOG_ERR("UART RX failed, err %d", err);
 	}
 #else
-	const uint8_t out[] = "UART started.\r\n"
-			      "Line terminator set to: " EOL_LABEL "\r\n";
+	const uint8_t out[] = "UART started.\r\n";
+
 	err = nrfx_uarte_tx(&nus_uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
 	if (err) {
 		LOG_ERR("UARTE TX failed, err %d", err);

--- a/samples/bluetooth/ble_nus_central/Kconfig
+++ b/samples/bluetooth/ble_nus_central/Kconfig
@@ -27,34 +27,6 @@ config SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE
 	help
 	  UART RX is double buffered, so the actual buffer will be twice as large.
 
-choice SAMPLE_UART_EOL
-	prompt "End-of-line termination"
-	default SAMPLE_UART_EOL_LF
-	help
-	  End-of-line termination used with the UART connected device (for example a PC terminal).
-	  Input from the connected device is forwarded over Bluetooth LE one line at a time,
-	  using this sequence as the delimiter.
-	  Data received over Bluetooth LE has this termination appended before it is written back
-	  to the connected device when it is missing.
-
-config SAMPLE_UART_EOL_CR
-	bool "Carriage return (CR)"
-
-config SAMPLE_UART_EOL_LF
-	bool "Line feed (LF)"
-
-config SAMPLE_UART_EOL_CR_LF
-	bool "Carriage return and line feed (CR+LF)"
-
-endchoice # SAMPLE_UART_EOL
-
-config SAMPLE_UART_EOL_STRIP
-	bool "Strip the end-of-line before sending over Bluetooth LE"
-	help
-	  When enabled, the end-of-line termination is removed before it is sent to the peer,
-	  so the message arrives without a trailing line break.
-	  When disabled, the termination is sent as part of the message.
-
 config SAMPLE_NUS_CENTRAL_LPUARTE
 	bool "NUS Client Low Power UARTE"
 

--- a/samples/bluetooth/ble_nus_central/README.rst
+++ b/samples/bluetooth/ble_nus_central/README.rst
@@ -59,18 +59,6 @@ LED 1:
    In LPUARTE mode, **LED 1** may appear lit even when no device is connected for some development kits, because it shares a pin with the RX signal.
    RX activity can toggle the LED, which is expected behavior.
 
-Configuration
-*************
-
-The sample allows configuring how end-of-line (EOL) terminations are handled for the UART connected device (for example, a PC terminal).
-You can modify the following options (available in the Kconfig file at :file:`samples/bluetooth/ble_nus_central`):
-
-* :kconfig:option:`CONFIG_SAMPLE_UART_EOL_CR`, :kconfig:option:`CONFIG_SAMPLE_UART_EOL_LF`, and :kconfig:option:`CONFIG_SAMPLE_UART_EOL_CR_LF` - Select the end-of-line termination (``CR``, ``LF`` (the default), or ``CR+LF``) used with the UART connected device.
-  Input from the connected device is forwarded over Bluetooth LE one line at a time using this sequence as the delimiter, and the same termination is appended to data received over Bluetooth LE before it is written back to the connected device when missing.
-
-* :kconfig:option:`CONFIG_SAMPLE_UART_EOL_STRIP` - Strip the end-of-line termination from a line before it is sent over Bluetooth LE, so the message arrives without a trailing line break.
-  Disabled by default.
-
 .. _ble_nus_central_sample_testing:
 
 Building and running
@@ -104,7 +92,6 @@ You can test the sample in two ways, depending on the selected UART configuratio
          If you use development kits, UART 0 and 1 are forwarded as COM ports (Windows) or ttyACM devices (Linux) after you connect the development kits over USB.
          One instance is used for logging (if enabled with :kconfig:option:`CONFIG_LOG`), while the other is used for the NUS Client service.
       #. Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_) for both UARTs on both development kits.
-         In the following steps, these are referred to as the **central logging terminal** and **central NUS terminal** (device running :ref:`ble_nus_central_sample`), and the **peripheral logging terminal** and **peripheral NUS terminal** (device running :ref:`ble_nus_sample`).
       #. Reset the kits.
       #. Observe that the device running the :ref:`ble_nus_central_sample` sample is configured to connect to ``nRF_BM_NUS``.
          You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_TARGET_PERIPHERAL_NAME` Kconfig option.
@@ -112,12 +99,10 @@ You can test the sample in two ways, depending on the selected UART configuratio
       #. Observe that the device running the :ref:`ble_nus_sample` sample is advertising under the default name ``nRF_BM_NUS``.
          You can configure this name using the :kconfig:option:`CONFIG_SAMPLE_BLE_DEVICE_NAME` Kconfig option.
          For information on how to do this, see `Configuring Kconfig`_.
-      #. Observe that the central NUS terminal prints ``UART started.`` followed by ``Line terminator set to:`` with the terminator configured through the ``CONFIG_SAMPLE_UART_EOL_*`` Kconfig option (see `Configuration`_).
-         Set the central NUS terminal to use the same line terminator.
-      #. Observe that the central logging terminal prints ``BLE NUS central sample initialized``.
-      #. Observe that the peripheral logging terminal prints ``BLE NUS sample initialized``.
-      #. Write a text in the central NUS terminal and press Enter.
-      #. Observe that the text is displayed in the peripheral NUS terminal.
+      #. Observe that the text ``BLE NUS central sample initialized`` is printed on the COM listener connected to the device running the :ref:`ble_nus_central_sample` sample.
+      #. Observe that the text ``BLE NUS sample initialized`` is printed on the COM listener connected to the device running the :ref:`ble_nus_sample` sample.
+      #. Write a text in the COM listener running on the computer and press Enter.
+      #. Observe that the text is displayed in the second COM listener running on the computer.
 
    .. group-tab:: LPUARTE configuration
 

--- a/samples/bluetooth/ble_nus_central/src/main.c
+++ b/samples/bluetooth/ble_nus_central/src/main.c
@@ -76,22 +76,6 @@ static uint16_t ble_nus_max_data_len = BLE_NUS_CLIENT_MAX_DATA_LEN_CALC(BLE_GATT
 static uint8_t uarte_rx_buf[2][CONFIG_SAMPLE_NUS_CENTRAL_UART_RX_BUF_SIZE];
 static int buf_idx;
 
-/* End-of-line termination for NUS messages (CONFIG_SAMPLE_UART_EOL_*).
- * Used as the line delimiter for UART data sent over BLE,
- * and appended to BLE data before it is written back to the UART.
- */
-#if defined(CONFIG_SAMPLE_UART_EOL_CR)
-#define UART_EOL "\r"
-#define EOL_LABEL "CR ('\\r')"
-#elif defined(CONFIG_SAMPLE_UART_EOL_LF)
-#define UART_EOL "\n"
-#define EOL_LABEL "LF ('\\n')"
-#else
-#define UART_EOL "\r\n"
-#define EOL_LABEL "CR+LF ('\\r\\n')"
-#endif
-#define UART_EOL_LEN (sizeof(UART_EOL) - 1)
-
 #if defined(CONFIG_SAMPLE_USE_TARGET_PERIPHERAL_ADDR)
 /* Target peripheral address (little-endian). */
 static const uint8_t target_periph_addr[BLE_GAP_ADDR_LEN] = {
@@ -129,7 +113,6 @@ static void uarte_rx_handler(char *data, size_t data_len)
 {
 	uint32_t nrf_err;
 	uint8_t c;
-	bool eol;
 	/* Receive buffer used in UART ISR callback. */
 	static char rx_buf[BLE_NUS_MAX_DATA_LEN];
 	static uint16_t rx_buf_idx;
@@ -142,16 +125,7 @@ static void uarte_rx_handler(char *data, size_t data_len)
 			rx_buf[rx_buf_idx++] = c;
 		}
 
-		/* Send once the buffer ends with the configured EOL or the buffer is full. */
-		eol = rx_buf_idx >= UART_EOL_LEN &&
-			memcmp(&rx_buf[rx_buf_idx - UART_EOL_LEN], UART_EOL, UART_EOL_LEN) == 0;
-
-		if (eol || (rx_buf_idx >= ble_nus_max_data_len)) {
-			/* Optionally drop the line ending so the peer gets just the message. */
-			if (eol && IS_ENABLED(CONFIG_SAMPLE_UART_EOL_STRIP)) {
-				rx_buf_idx -= UART_EOL_LEN;
-			}
-
+		if ((c == '\n' || c == '\r') || (rx_buf_idx >= ble_nus_max_data_len)) {
 			if (rx_buf_idx == 0) {
 				/* RX buffer is empty, nothing to send. */
 				continue;
@@ -326,8 +300,6 @@ static void scan_evt_handler(const struct ble_scan_evt *scan_evt)
 static void nus_client_evt_handler(struct ble_nus_client *nus_c,
 				   const struct ble_nus_client_evt *nus_evt)
 {
-	/* EasyDMA can only transmit from RAM, so use a local (RAM) copy of the EOL. */
-	char eol[] = UART_EOL;
 	int err;
 	uint32_t nrf_err;
 
@@ -362,17 +334,6 @@ static void nus_client_evt_handler(struct ble_nus_client *nus_c,
 			LOG_ERR("nrfx_uarte_tx failed, err %d", err);
 		}
 #endif
-
-		/* Append the configured EOL when the peer did not send a line ending. */
-		if (nus_evt->tx_data.data[nus_evt->tx_data.length - 1] != '\n' &&
-		    nus_evt->tx_data.data[nus_evt->tx_data.length - 1] != '\r') {
-#if defined(CONFIG_SAMPLE_NUS_CENTRAL_LPUARTE)
-			(void)bm_lpuarte_tx(&lpu, eol, UART_EOL_LEN, 3000);
-#else
-			(void)nrfx_uarte_tx(&nus_uarte_inst, eol,
-					    UART_EOL_LEN, NRFX_UARTE_TX_BLOCKING);
-#endif
-		}
 		break;
 	case BLE_NUS_CLIENT_EVT_DISCONNECTED:
 		LOG_INF("NUS disconnected");
@@ -463,15 +424,6 @@ static int uarte_init(void)
 		LOG_ERR("Failed to initialize UART, err %d", err);
 		return err;
 	}
-
-	const uint8_t out[] = "UART started.\r\n"
-			      "Line terminator set to: " EOL_LABEL "\r\n";
-	err = nrfx_uarte_tx(&nus_uarte_inst, out, sizeof(out), NRFX_UARTE_TX_BLOCKING);
-	if (err) {
-		LOG_ERR("UARTE TX failed, err %d", err);
-		return err;
-	}
-
 	err = nrfx_uarte_rx_enable(&nus_uarte_inst, 0);
 	if (err) {
 		LOG_ERR("UART RX failed, err %d", err);


### PR DESCRIPTION
Reason for reverting:
* Injected `CRLF` in the UART output for each ATT packet received over Bluetooth LE and forwarded on UART, changing the original input stream.
* Required EOF configuration for common terminals that was not required before.