### PR TITLE
doc: nrf-bm: libraries: remove Sample section and move sample mention

### DIFF
--- a/doc/nrf-bm/libraries/bluetooth/ble_radio_notification.rst
+++ b/doc/nrf-bm/libraries/bluetooth/ble_radio_notification.rst
@@ -35,15 +35,12 @@ Initialize the library by calling the :c:func:`ble_radio_notification_init` func
 Usage
 *****
 
+The usage of this library is demonstrated in the :ref:`ble_radio_ntf_sample` sample.
+
 When initializing the library with the :c:func:`ble_radio_notification_init` function, make sure to specify the event handler to receive the Radio Notification signal.
 You can specify the interval in microseconds between the Radio Notification signal and the start of the radio event.
 The signal raised at the start of the radio event has ``active_state`` set to ``true``.
 A new Radio Notification signal will be raised when the radio event completes with ``active_state`` set to ``false``.
-
-Sample
-******
-
-The usage of this library is demonstrated in the :ref:`ble_radio_ntf_sample` sample.
 
 Dependencies
 ************

--- a/doc/nrf-bm/libraries/bm_spi_mngr.rst
+++ b/doc/nrf-bm/libraries/bm_spi_mngr.rst
@@ -67,6 +67,8 @@ Do not call it while a transaction is running, as it does not cancel pending wor
 Usage
 *****
 
+The usage of this library is demonstrated in the :ref:`spi_mngr_sample` sample.
+
 Work is described in a :c:struct:`bm_spi_mngr_transaction` structure, holding an array of transfers and the number of transfers.
 Use the :c:macro:`BM_SPI_MNGR_TRANSFER` macro to set up each transfer.
 
@@ -90,11 +92,6 @@ Busy state
 ==========
 
 Use the :c:func:`bm_spi_mngr_is_idle` function to check whether all scheduled work has completed.
-
-Sample
-******
-
-The usage of this library is demonstrated in the :ref:`spi_mngr_sample` sample.
 
 Dependencies
 ************

--- a/doc/nrf-bm/libraries/bm_storage.rst
+++ b/doc/nrf-bm/libraries/bm_storage.rst
@@ -69,6 +69,8 @@ You can uninitialize a storage instance with the :c:func:`bm_storage_uninit` fun
 Usage
 *****
 
+The usage of this library is demonstrated in the :ref:`bm_storage_sample` sample.
+
 The following is a list of operations you can perform with this library.
 
 Read
@@ -131,11 +133,6 @@ Backends with an internal operation queue (for example, the SoftDevice backend) 
 To prevent recursion in backends without a queue, enable the :kconfig:option:`CONFIG_BM_SCHEDULER` Kconfig option.
 When the scheduler is available, synchronous events are automatically deferred and delivered from the main thread context on the next call to :c:func:`bm_scheduler_process`.
 Deferred events have their :c:member:`bm_storage_evt.is_async` field set to ``true``.
-
-Sample
-******
-
-The usage of this library is demonstrated in the :ref:`bm_storage_sample` sample.
 
 Dependencies
 ************

--- a/doc/nrf-bm/libraries/timer.rst
+++ b/doc/nrf-bm/libraries/timer.rst
@@ -36,6 +36,8 @@ The timer can be initialized in the following modes:
 Usage
 *****
 
+The usage of this library is demonstrated in the :ref:`timer_sample` sample.
+
 After initialization, start the timer by calling the :c:func:`bm_timer_start` function, providing the timeout and user-provided context passed to the callback.
 The timeout is provided in ticks.
 
@@ -45,11 +47,6 @@ The library provides macros to convert standard time units to ticks:
 * :c:macro:`BM_TIMER_MS_TO_TICKS` - Converts milliseconds to ticks.
 
 To stop a timer, call the :c:func:`bm_timer_stop` function.
-
-Sample
-******
-
-Usage of this library is demonstrated in the :ref:`timer_sample` sample.
 
 Dependencies
 ************


### PR DESCRIPTION
Move the mentions of samples that showcase libraries from the "Sample" section to the "Usage" section.
Remove "Sample" section in library documentation.