### PR TITLE
bluetooth: services: align characteristic add order

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -136,10 +136,18 @@ Bluetooth LE Services
 
    * Changed :c:member:`ble_scan_filter_data.addr_filter.addr` and :c:member:`ble_scan_filter_data.name_filter.name` to ``const`` in the :c:struct:`ble_scan_filter_data` structure.
 
+* :ref:`lib_ble_service_bms`:
+
+   * Updated the :c:func:`ble_bms_init` function to add the Bond Management Control Point characteristic before the Bond Management Feature characteristic, matching the order in the BMS specification.
+     This changes the GATT attribute handles assigned to these characteristics.
+
 * :ref:`lib_ble_service_dis`:
 
    * Added support for configuring the Device Information Service characteristics at run time through the new :c:struct:`ble_dis_values` structure, passed using the ``values`` field of :c:struct:`ble_dis_config`.
      When ``values`` is ``NULL``, the service is built from the Kconfig defaults as before.
+
+   * Updated the :c:func:`ble_dis_init` function to add the IEEE Regulatory Certification Data List characteristic before the PnP ID characteristic, matching the order in the DIS specification.
+     This changes the GATT attribute handles assigned to these characteristics.
 
 * :ref:`lib_ble_service_mcumgr`:
 

--- a/subsys/bluetooth/services/ble_bms/bms.c
+++ b/subsys/bluetooth/services/ble_bms/bms.c
@@ -459,12 +459,12 @@ uint32_t ble_bms_init(struct ble_bms *bms, struct ble_bms_config *bms_config)
 		return nrf_err;
 	}
 
-	nrf_err = feature_char_add(bms, bms_config);
+	nrf_err = ctrlpt_char_add(bms, bms_config);
 	if (nrf_err) {
 		return nrf_err;
 	}
 
-	nrf_err = ctrlpt_char_add(bms, bms_config);
+	nrf_err = feature_char_add(bms, bms_config);
 	if (nrf_err) {
 		return nrf_err;
 	}

--- a/subsys/bluetooth/services/ble_dis/dis.c
+++ b/subsys/bluetooth/services/ble_dis/dis.c
@@ -177,10 +177,10 @@ uint32_t ble_dis_init(const struct ble_dis_config *dis_config)
 
 		gatt_char(BLE_UUID_SYSTEM_ID_CHAR,
 			  sys_id_val, sys_id_len),
-		gatt_char(BLE_UUID_PNP_ID_CHAR,
-			  pnp_id_val, pnp_id_len),
 		gatt_char(BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR,
 			  reg_cert_val, reg_cert_len),
+		gatt_char(BLE_UUID_PNP_ID_CHAR,
+			  pnp_id_val, pnp_id_len),
 	};
 
 	/* Add service */

--- a/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
+++ b/tests/unit/subsys/bluetooth/services/ble_bms/src/unity_test.c
@@ -88,6 +88,11 @@ uint32_t stub_sd_ble_gatts_characteristic_add_feature_char_error_no_mem(
 	 */
 	const uint8_t encoded_feature_expected[BLE_BMS_FEATURE_LEN] = { 0x10, 0x08, 0x02 };
 
+	if (cmock_calls < 1) {
+		/* Earlier calls verified by other tests, return successfully. */
+		return NRF_SUCCESS;
+	}
+
 	TEST_ASSERT_EQUAL(SERVICE_HANDLE, service_handle);
 	TEST_ASSERT_TRUE(p_char_md->char_props.read);
 
@@ -110,11 +115,6 @@ uint32_t stub_sd_ble_gatts_characteristic_add_ctrlpt_char_error_no_mem(
 	const ble_gatts_attr_t *p_attr_char_value, ble_gatts_char_handles_t *p_handles,
 	int cmock_calls)
 {
-	if (cmock_calls < 1) {
-		/* Earlier calls verified by other tests, return successfully. */
-		return NRF_SUCCESS;
-	}
-
 	TEST_ASSERT_EQUAL(SERVICE_HANDLE, service_handle);
 	TEST_ASSERT_TRUE(p_char_md->char_props.write);
 	TEST_ASSERT_FALSE(p_char_md->char_ext_props.reliable_wr);
@@ -138,11 +138,6 @@ uint32_t stub_sd_ble_gatts_characteristic_add(
 	const ble_gatts_attr_t *p_attr_char_value, ble_gatts_char_handles_t *p_handles,
 	int cmock_calls)
 {
-	if (cmock_calls < 1) {
-		/* Earlier calls verified by other tests, return successfully. */
-		return NRF_SUCCESS;
-	}
-
 	p_handles->value_handle = CTRLPT_VALUE_HANDLE;
 
 	return NRF_SUCCESS;


### PR DESCRIPTION
test_bm_samples: PR-131

Add characteristics in the same order as their Bluetooth SIG specification tables, so the GATT attribute table matches the documented order inside the specifications.