### PR TITLE
samples: lpuarte: add a wiring section to align with other samples

### DIFF
--- a/doc/nrf-bm/app_dev/dfu/memory_partitioning.rst
+++ b/doc/nrf-bm/app_dev/dfu/memory_partitioning.rst
@@ -80,15 +80,15 @@ Requirement for MCUboot
 MCUboot requires that each firmware image includes metadata both before and after the firmware hex file.
 This metadata is crucial for the validation of the firmware image:
 
-- **Image header**: Placed at the beginning of the firmware image.
-- **TLV area**: Positioned after the firmware image to store metadata used for image validation.
+* **Image header**: Placed at the beginning of the firmware image.
+* **TLV area**: Positioned after the firmware image to store metadata used for image validation.
 
 .. note:: The size reserved for the image header and TLV area must be consistent across all MCUboot images in a project.
 
 Vector table alignment
 **********************
 
-For images that are run as a `main application` that has its own interrupt vector table there is an `Vector table requirement`_ on how to place the interrupt vector table in memory.
+For images that are run as a *main application* that has its own interrupt vector table there is an `Vector table requirement`_ on how to place the interrupt vector table in memory.
 The table must be placed starting at the 2 kB boundary.
 An example of such images are application and firmware loader.
 The SoftDevice is not affected by this requirement.
@@ -101,9 +101,9 @@ SoftDevice placement
 
 The placement of the SoftDevice in memory is predetermined and must align with specific requirements:
 
-- **System Metadata**: Reserves 0.5 kB at the top of the memory.
-- **MCUboot_SD - TLV Area**: Also reserves 0.5 kB.
-- **SD_StartAddr**: See the SoftDevice release notes for details on size and start address.
+* **System Metadata**: Reserves 0.5 kB at the top of the memory.
+* **MCUboot_SD - TLV Area**: Also reserves 0.5 kB.
+* **SD_StartAddr**: See the SoftDevice release notes for details on size and start address.
 
 The size of the SoftDevice is adjusted taking into account the above alignment and space reservations.
 

--- a/samples/bluetooth/ble_nus/README.rst
+++ b/samples/bluetooth/ble_nus/README.rst
@@ -106,18 +106,18 @@ The sample can be tested in two ways, depending on the selected UART configurati
 
          .. include:: /includes/lpuarte_board_connections.txt
 
-         #. For Two-device setup:
+         * For Two-device setup:
 
-            - Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
-            - Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
-            - Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
-            - Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
-            - Connect **GND** between both devices.
+           * Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
+           * Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
+           * Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
+           * Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
+           * Connect **GND** between both devices.
 
-         #. For Single-device loopback setup:
+         * For Single-device loopback setup:
 
-            - **LPUARTE TX** → **LPUARTE RX**
-            - **LPUARTE REQ** → **LPUARTE RDY**
+           * **LPUARTE TX** → **LPUARTE RX**
+           * **LPUARTE REQ** → **LPUARTE RDY**
 
       #. Power on the device(s).
       #. Connect the phone(s) to the device(s) using the `nRF Toolbox`_ mobile application with the :guilabel:`Universal Asynchronous Receiver/Transmitter (UART)` service.

--- a/samples/bluetooth/ble_nus_central/README.rst
+++ b/samples/bluetooth/ble_nus_central/README.rst
@@ -114,18 +114,18 @@ You can test the sample in two ways, depending on the selected UART configuratio
 
          .. include:: /includes/lpuarte_board_connections.txt
 
-         #. For Two-device setup:
+         * For Two-device setup:
 
-            - Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
-            - Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
-            - Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
-            - Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
-            - Connect **GND** between both devices.
+           * Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
+           * Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
+           * Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
+           * Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
+           * Connect **GND** between both devices.
 
-         #. For Single-device loopback setup:
+         * For Single-device loopback setup:
 
-            - **LPUARTE TX** → **LPUARTE RX**
-            - **LPUARTE REQ** → **LPUARTE RDY**
+           * **LPUARTE TX** → **LPUARTE RX**
+           * **LPUARTE REQ** → **LPUARTE RDY**
 
       #. Power on the devices.
       #. Send a message from the device not connected in loopback mode using a terminal emulator.

--- a/samples/peripherals/lpuarte/README.rst
+++ b/samples/peripherals/lpuarte/README.rst
@@ -32,24 +32,7 @@ The sample supports the following development kits:
 
       .. include:: /includes/supported_boards_all_mcuboot_variants_s145.txt
 
-The sample also requires the following pins to be connected, as defined in the boards :file:`board-config.h` header:
-
-  .. include:: /includes/lpuarte_board_connections.txt
-
-  #. For two-device setup:
-
-    - Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
-    - Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
-    - Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
-    - Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
-    - Connect **GND** between both devices.
-
-  #. For single-device loopback setup:
-
-    - **LPUARTE TX** → **LPUARTE RX**
-    - **LPUARTE REQ** → **LPUARTE RDY**
-
-Additionally, the sample requires a logic analyzer to observe the LPUARTE activity and a current measurement instrument to measure the current.
+The sample requires a logic analyzer to observe the LPUARTE activity and a current measurement instrument to measure the current.
 
 Overview
 ********
@@ -57,6 +40,26 @@ Overview
 The sample initializes the application LPUARTE instance, specified in the :file:`board-config.h` file in the board.
 It then implements a simple loopback using a single LPUARTE instance.
 By default, the console and logging are disabled to demonstrate low power consumption when UART is active.
+
+Wiring
+******
+
+The sample requires the following pins to be connected, as defined in the boards :file:`board-config.h` header:
+
+* Single-device loopback setup:
+
+  * **LPUARTE TX** → **LPUARTE RX**
+  * **LPUARTE REQ** → **LPUARTE RDY**
+
+* Two-device setup:
+
+  * Device 1 **LPUARTE TX** → Device 2 **LPUARTE RX**
+  * Device 1 **LPUARTE RX** → Device 2 **LPUARTE TX**
+  * Device 1 **LPUARTE REQ** → Device 2 **LPUARTE RDY**
+  * Device 1 **LPUARTE RDY** → Device 2 **LPUARTE REQ**
+  * Connect **GND** between both devices.
+
+.. include:: /includes/lpuarte_board_connections.txt
 
 User interface
 **************
@@ -76,6 +79,7 @@ Testing
 
 You can test this sample by performing the following steps:
 
+1. Wire the LPUARTE as described in `Wiring`_.
 #. Compile and program the application.
 #. Connect the logic analyzer to the LPUARTE pins, to confirm UARTE activity.
    The request/response pins are HIGH in the idle state.


### PR DESCRIPTION
Add a wiring section and move the pin connection instructions from the requirements section to the new section. This aligns the sample README with the SPI peripheral sample README.