### PR TITLE
boards: nordic: remove override of RRAM size

### DIFF
--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_common.dtsi
@@ -43,11 +43,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(500)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s115_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l05_cpuapp_s145_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_common.dtsi
@@ -43,11 +43,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1012)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s115_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l10_cpuapp_s145_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_common.dtsi
@@ -47,11 +47,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1524)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s115_softdevice_mcuboot.dts
@@ -29,8 +29,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54l15dk/bm_nrf54l15dk_nrf54l15_cpuapp_s145_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_common.dtsi
@@ -46,11 +46,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(2036)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s115_softdevice_mcuboot.dts
@@ -29,8 +29,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lm20dk/bm_nrf54lm20dk_nrf54lm20a_cpuapp_s145_softdevice_mcuboot.dts
@@ -29,8 +29,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_common.dtsi
@@ -43,11 +43,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(508)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice_mcuboot.dts
@@ -26,8 +26,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_common.dtsi
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_common.dtsi
@@ -46,11 +46,6 @@
 	};
 };
 
-/* Override NCS default to use entire RRAM for application CPU. */
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1012)>;
-};
-
 &gpregret1 {
 	status = "okay";
 

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s115_softdevice_mcuboot.dts
@@ -29,8 +29,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice.dts
@@ -18,8 +18,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.dts
+++ b/boards/nordic/bm_nrf54lv10dk/bm_nrf54lv10dk_nrf54lv10a_cpuapp_s145_softdevice_mcuboot.dts
@@ -29,8 +29,6 @@
 };
 
 &cpuapp_rram {
-	status = "okay";
-
 	partitions {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/doc/nrf-bm/app_dev/dfu/ug_dfu.rst
+++ b/doc/nrf-bm/app_dev/dfu/ug_dfu.rst
@@ -168,8 +168,6 @@ This board target will always enable DFU support when it is used to build the ap
       ...
 
       &cpuapp_rram {
-              status = "okay";
-
               partitions {
                       #address-cells = <1>;
                       #size-cells = <1>;

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -43,6 +43,10 @@ Boards
      This improves debugging in VS Code.
    * The number of required board qualifiers (reduced by one), as of changes in upstream Zephyr.
 
+* Removed:
+
+   * The override for ``cpuapp_rram`` size for all boards as RRAM is no longer reserved for the RISC-V core by default.
+
 Build system
 ============
 


### PR DESCRIPTION
Removed the override for cpuapp_rram size for all boards as RRAM is no longer reserved for the Risc V core by default