### PR TITLE
bluetooth: peer_manager: LE secure connections fixes

### DIFF
--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -123,6 +123,7 @@ Libraries
       * The :c:func:`pm_init` function to clear the default security parameters set with the :c:func:`pm_sec_params_set` function.
       * The :c:func:`pm_register` function to return ``NRF_ERROR_NULL`` when the event handler parameter is ``NULL``.
         The check was documented but was missing.
+      * The LESC key agreement handling to clear the static RAM copy of the ECDH shared secret after the secret have been handed over to the SoftDevice using the :c:func:`sd_ble_gap_lesc_dhkey_reply` function.
 
    * Fixed:
 

--- a/doc/nrf-bm/release_notes/release_notes_changelog.rst
+++ b/doc/nrf-bm/release_notes/release_notes_changelog.rst
@@ -124,6 +124,8 @@ Libraries
       * The :c:func:`pm_register` function to return ``NRF_ERROR_NULL`` when the event handler parameter is ``NULL``.
         The check was documented but was missing.
       * The LESC key agreement handling to clear the static RAM copy of the ECDH shared secret after the secret have been handed over to the SoftDevice using the :c:func:`sd_ble_gap_lesc_dhkey_reply` function.
+      * The :kconfig:option:`CONFIG_PM_LESC_GENERATE_NEW_KEYS` Kconfig option to be enabled by default.
+        This option forces the use of new ECDH key pair for each pairing procedure.
 
    * Fixed:
 

--- a/lib/bluetooth/peer_manager/Kconfig
+++ b/lib/bluetooth/peer_manager/Kconfig
@@ -63,8 +63,9 @@ if PM_LESC
 
 config PM_LESC_GENERATE_NEW_KEYS
 	bool "Generate new LESC key pair after every pairing attempt"
+	default y
 	help
-	  New LESC keys are generated on the auth status event.
+	  New LESC keys are generated on every "authentication procedure completed" event.
 
 config PM_LESC_PRIVATE_KEY_EXPORT
 	bool "Export private key for debugging purposes"

--- a/lib/bluetooth/peer_manager/modules/nrf_ble_lesc.c
+++ b/lib/bluetooth/peer_manager/modules/nrf_ble_lesc.c
@@ -237,6 +237,7 @@ void nrf_ble_lesc_peer_oob_data_handler_set(nrf_ble_lesc_peer_oob_data_handler h
  */
 static uint32_t compute_and_give_dhkey(struct lesc_peer_pub_key *peer_public_key)
 {
+	uint32_t nrf_err;
 	psa_status_t status = PSA_ERROR_BAD_STATE;
 	uint8_t *shared_secret = lesc_dh_key.key;
 	size_t shared_secret_size;
@@ -278,7 +279,12 @@ static uint32_t compute_and_give_dhkey(struct lesc_peer_pub_key *peer_public_key
 	LOG_INF("Calling sd_ble_gap_lesc_dhkey_reply(sec_status: %#x) on conn_handle: %d",
 		sec_status, peer_public_key->conn_handle);
 
-	return sd_ble_gap_lesc_dhkey_reply(peer_public_key->conn_handle, sec_status, p_dh_key);
+	nrf_err = sd_ble_gap_lesc_dhkey_reply(peer_public_key->conn_handle, sec_status, p_dh_key);
+
+	/* Discard the key immediately after handing it over to the SoftDevice. */
+	memset(lesc_dh_key.key, 0, sizeof(lesc_dh_key.key));
+
+	return nrf_err;
 }
 
 uint32_t nrf_ble_lesc_request_handler(void)

--- a/tests/unit/lib/bluetooth/peer_manager/prj.conf
+++ b/tests/unit/lib/bluetooth/peer_manager/prj.conf
@@ -1,8 +1,5 @@
 CONFIG_UNITY=y
 
-# Enable generation of new LESC key pair after every pairing attempt
-# CONFIG_PM_LESC_GENERATE_NEW_KEYS=y
-
 # Repeated Attempts Protection feature
 CONFIG_PM_RA_PROTECTION=y
 

--- a/tests/unit/lib/bluetooth/peer_manager/src/unity_test.c
+++ b/tests/unit/lib/bluetooth/peer_manager/src/unity_test.c
@@ -237,7 +237,6 @@ static const mbedtls_svc_key_id_t key_pair_id = 0x2A;
 #define PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(_key_pair_id)                           \
 	psa_key_attributes_t key_attributes_mock = PSA_KEY_ATTRIBUTES_INIT;                        \
 												   \
-	__cmock_psa_crypto_init_ExpectAndReturn(PSA_SUCCESS);                                      \
 	__cmock_psa_destroy_key_ExpectAnyArgsAndReturn(PSA_ERROR_INVALID_HANDLE);                  \
 												   \
 	__cmock_psa_set_key_usage_flags_ExpectWithArray(                                           \
@@ -369,6 +368,7 @@ void peer_manager_initialize_success(void)
 	__cmock_bm_zms_mount_Stub(stub_bm_zms_mount_success);
 	__cmock_bm_zms_read_Stub(stub_bm_zms_read_pm_init);
 
+	__cmock_psa_crypto_init_ExpectAndReturn(PSA_SUCCESS);
 	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
 
 	__cmock_bm_timer_init_Stub(stub_bm_timer_init_ast);
@@ -598,6 +598,7 @@ void test_pm_init_success(void)
 	__cmock_bm_zms_mount_Stub(stub_bm_zms_mount_success);
 	__cmock_bm_zms_read_Stub(stub_bm_zms_read_pm_init);
 
+	__cmock_psa_crypto_init_ExpectAndReturn(PSA_SUCCESS);
 	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
 
 	__cmock_bm_timer_init_Stub(stub_bm_timer_init_ast);
@@ -1151,8 +1152,11 @@ void test_pm_conn_secure_peripheral_pair_success(void)
 	TEST_ASSERT_TRUE(conn_sec_status.lesc);
 
 	/* On a BLE_GAP_EVT_AUTH_STATUS, expect peer manager to finish up the pairing request.
-	 * Not much is done in response to this event when simply pairing (no bonding).
+	 *
+	 * Expect a new ECDH key to be generated because CONFIG_PM_LESC_GENERATE_NEW_KEYS is set.
 	 */
+	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
+
 	evt.header.evt_id = BLE_GAP_EVT_AUTH_STATUS;
 	evt.evt.gap_evt.params.auth_status = (ble_gap_evt_auth_status_t) {
 		.auth_status = BLE_GAP_SEC_STATUS_SUCCESS,
@@ -1346,6 +1350,8 @@ void test_pm_conn_secure_peripheral_pair_and_bond_success(void)
 	 * Expect the bonding data storage to be iterated to check if the paired peer already have
 	 * bonding data. No duplicate bonding data is to be found.
 	 * Next, expect new bonding data to be stored.
+	 *
+	 * Expect a new ECDH key to be generated because CONFIG_PM_LESC_GENERATE_NEW_KEYS is set.
 	 */
 	entry.data_id = PM_PEER_DATA_ID_BONDING;
 	entry.peer_id = 0;
@@ -1362,6 +1368,8 @@ void test_pm_conn_secure_peripheral_pair_and_bond_success(void)
 	__cmock_bm_zms_write_ExpectAndReturn(zms_fs, entry.id, PTR_IGNORE,
 					     sizeof(struct pm_peer_data_bonding), 0);
 	__cmock_bm_zms_write_IgnoreArg_data();
+
+	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
 
 	evt.header.evt_id = BLE_GAP_EVT_AUTH_STATUS;
 	evt.evt.gap_evt.params.auth_status = (ble_gap_evt_auth_status_t) {
@@ -1744,8 +1752,11 @@ void test_pm_conn_secure_peripheral_pair_again_with_bonding_data_present_success
 	TEST_ASSERT_TRUE(conn_sec_status.lesc);
 
 	/* On a BLE_GAP_EVT_AUTH_STATUS, expect peer manager to finish up the pairing request.
-	 * Not much is done in response to this event when simply pairing (no bonding).
+	 *
+	 * Expect a new ECDH key to be generated because CONFIG_PM_LESC_GENERATE_NEW_KEYS is set.
 	 */
+	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
+
 	evt.header.evt_id = BLE_GAP_EVT_AUTH_STATUS;
 	evt.evt.gap_evt.params.auth_status = (ble_gap_evt_auth_status_t) {
 		.auth_status = BLE_GAP_SEC_STATUS_SUCCESS,
@@ -1933,8 +1944,11 @@ void test_pm_conn_secure_central_pair_success(void)
 	TEST_ASSERT_TRUE(conn_sec_status.lesc);
 
 	/* On a BLE_GAP_EVT_AUTH_STATUS, expect peer manager to finish up the pairing request.
-	 * Not much is done in response to this event when simply pairing (no bonding).
+	 *
+	 * Expect a new ECDH key to be generated because CONFIG_PM_LESC_GENERATE_NEW_KEYS is set.
 	 */
+	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
+
 	evt.header.evt_id = BLE_GAP_EVT_AUTH_STATUS;
 	evt.evt.gap_evt.params.auth_status = (ble_gap_evt_auth_status_t) {
 		.auth_status = BLE_GAP_SEC_STATUS_SUCCESS,
@@ -2125,8 +2139,11 @@ void test_pm_conn_secure_central_pair_and_bond_success(void)
 	TEST_ASSERT_TRUE(conn_sec_status.lesc);
 
 	/* On a BLE_GAP_EVT_AUTH_STATUS, expect peer manager to finish up the pairing request.
-	 * Not much is done in response to this event when simply pairing (no bonding).
+	 *
+	 * Expect a new ECDH key to be generated because CONFIG_PM_LESC_GENERATE_NEW_KEYS is set.
 	 */
+	PSA_GENERATE_ECDH_KEYS_AND_EXPORT_PUBLIC_KEY_MOCKS(key_pair_id);
+
 	evt.header.evt_id = BLE_GAP_EVT_AUTH_STATUS;
 	evt.evt.gap_evt.params.auth_status = (ble_gap_evt_auth_status_t) {
 		.auth_status = BLE_GAP_SEC_STATUS_SUCCESS,


### PR DESCRIPTION
* Clear memory used for storing the LESC secret/key after it have been handed over to SoftDevice.
* Make regenerating private/public key-pair for each LESC pairing the default.