### PR TITLE
boards: nrf54ls05dk: Remove comment in dts

### DIFF
--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s115_softdevice.dts
@@ -55,9 +55,6 @@
 			label = "softdevice";
 			reg = <0x00065800 DT_SIZE_K(101)>;
 		};
-		/* Area from 0x7ec00 to end of nvm (1 kB) is unused
-		 * due to placement of SD to fit with DFU
-		 */
 	};
 };
 

--- a/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
+++ b/boards/nordic/bm_nrf54ls05dk/bm_nrf54ls05dk_nrf54ls05b_cpuapp_s145_softdevice.dts
@@ -55,9 +55,6 @@
 			label = "softdevice";
 			reg = <0x0005c800 DT_SIZE_K(137)>;
 		};
-		/* Area from 0x7ec00 to end of nvm (1 kB) is unused
-		 * due to placement of SD to fit with DFU
-		 */
 	};
 };
 


### PR DESCRIPTION
Remove comment about unused partitions in dts. It is not added for other board targets and is visible in board memory layout in the documentation.