### PR TITLE
samples: defined the samples folder in module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -13,3 +13,5 @@ build:
   depends:
     - nrf
     - memfault-firmware-sdk
+samples:
+  - samples


### PR DESCRIPTION
Modified zephyr/module.yml to include samples section This will allow vscode and other tools to recognize the samples directory within the module.